### PR TITLE
forward arguments from stat_compare_means to geom_signif

### DIFF
--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -126,7 +126,7 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
     ggsignif::geom_signif(comparisons = comparisons, y_position = label.y,
                           test = method, test.args = test.args,
                           step_increase = step_increase, size = size, color = color,
-                          map_signif_level = map_signif_level, tip_length = tip.length)
+                          map_signif_level = map_signif_level, tip_length = tip.length, ...)
   }
 
   else{


### PR DESCRIPTION
just a very small modificatin that allows to pass arguments (such as textsize) to geom_signif