### PR TITLE
stat_cor option to show/hide p-value

### DIFF
--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -51,7 +51,7 @@ NULL
 #'
 #' @export
 stat_cor <- function(mapping = NULL, data = NULL,
-                     method = "pearson", label.sep = ", ",
+                     method = "pearson", show.P = F, label.sep = ", ",
                      label.x.npc = "left", label.y.npc = "top",
                      label.x = NULL, label.y = NULL,
                      geom = "text", position = "identity",  na.rm = FALSE, show.legend = NA,
@@ -60,7 +60,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
     stat = StatCor, data = data, mapping = mapping, geom = geom,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(label.x.npc  = label.x.npc , label.y.npc  = label.y.npc,
-                  label.x = label.x, label.y = label.y, label.sep = label.sep,
+                  label.x = label.x, label.y = label.y, show.p = show.p, label.sep = label.sep,
                   method = method, na.rm = na.rm, ...)
   )
 }
@@ -94,14 +94,27 @@ StatCor<- ggproto("StatCor", Stat,
 # Correlation test
 #::::::::::::::::::::::::::::::::::::::::
 # Returns a data frame: estimatel|p.value|method|label
-.cor_test <- function(x, y, method = "pearson", label.sep = ", "){
+.cor_test <- function(x, y, method = "pearson", show.p = F, label.sep = ", "){
   .cor <- stats::cor.test(x, y, method = method, exact = FALSE)
   z <- data.frame(estimate = .cor$estimate, p.value = .cor$p.value, method = method)
   pval <- .cor$p.value
-  pvaltxt <- ifelse(pval < 2.2e-16, "p < 2.2e-16",
-                    paste("p =", signif(pval, 2)))
-  cortxt <- paste0("r = ", signif(.cor$estimate, 2),
-                   label.sep,  pvaltxt)
+if(show.p == T){
+  
+   pvaltxt <- ifelse(pval < 2.2e-16, "p < 2.2e-16",
+                    
+                      paste("p =", signif(pval, 2)))
+  
+    cortxt <- paste0("r = ", signif(.cor$estimate, 2),
+                   
+                    label.sep,  pvaltxt)
+  }
+  else {
+    pvaltxt <- ifelse(pval < 2.2e-16, "p < 2.2e-16",
+                      
+                      paste("p =", signif(pval, 2)))
+    
+    cortxt <- paste0("r = ", signif(.cor$estimate, 2))
+  }
   z$label <- cortxt
   z
 }

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -51,7 +51,7 @@ NULL
 #'
 #' @export
 stat_cor <- function(mapping = NULL, data = NULL,
-                     method = "pearson", show.P = F, label.sep = ", ",
+                     method = "pearson", label.sep = ", ",
                      label.x.npc = "left", label.y.npc = "top",
                      label.x = NULL, label.y = NULL,
                      geom = "text", position = "identity",  na.rm = FALSE, show.legend = NA,
@@ -60,7 +60,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
     stat = StatCor, data = data, mapping = mapping, geom = geom,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(label.x.npc  = label.x.npc , label.y.npc  = label.y.npc,
-                  label.x = label.x, label.y = label.y, show.p = show.p, label.sep = label.sep,
+                  label.x = label.x, label.y = label.y, label.sep = label.sep,
                   method = method, na.rm = na.rm, ...)
   )
 }
@@ -94,27 +94,17 @@ StatCor<- ggproto("StatCor", Stat,
 # Correlation test
 #::::::::::::::::::::::::::::::::::::::::
 # Returns a data frame: estimatel|p.value|method|label
-.cor_test <- function(x, y, method = "pearson", show.p = F, label.sep = ", "){
+.cor_test <- function(x, y, method = "pearson", label.sep = ", "){
   .cor <- stats::cor.test(x, y, method = method, exact = FALSE)
   z <- data.frame(estimate = .cor$estimate, p.value = .cor$p.value, method = method)
   pval <- .cor$p.value
-if(show.p == T){
-  
-   pvaltxt <- ifelse(pval < 2.2e-16, "p < 2.2e-16",
-                    
-                      paste("p =", signif(pval, 2)))
-  
-    cortxt <- paste0("r = ", signif(.cor$estimate, 2),
-                   
-                    label.sep,  pvaltxt)
-  }
-  else {
+
     pvaltxt <- ifelse(pval < 2.2e-16, "p < 2.2e-16",
                       
                       paste("p =", signif(pval, 2)))
     
     cortxt <- paste0("r = ", signif(.cor$estimate, 2))
-  }
+  
   z$label <- cortxt
   z
 }

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -6,6 +6,8 @@ NULL
 #' @param method a character string indicating which correlation coefficient (or
 #'   covariance) is to be computed. One of "pearson" (default), "kendall", or
 #'   "spearman".
+#' @param show.p a logical value (T/F) indicating whether the p-value is 
+#' displayed. Default to T, where the p.value is displayed.
 #' @param label.sep a character string to separate the terms. Default is ", ", to
 #'   separate the correlation coefficient and the p.value.
 #' @param label.x.npc,label.y.npc can be \code{numeric} or \code{character}
@@ -51,7 +53,7 @@ NULL
 #'
 #' @export
 stat_cor <- function(mapping = NULL, data = NULL,
-                     method = "pearson", show.p = F, label.sep = ", ",
+                     method = "pearson", show.p = T, label.sep = ", ",
                      label.x.npc = "left", label.y.npc = "top",
                      label.x = NULL, label.y = NULL,
                      geom = "text", position = "identity",  na.rm = FALSE, show.legend = NA,

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -7,7 +7,7 @@ NULL
 #'   covariance) is to be computed. One of "pearson" (default), "kendall", or
 #'   "spearman".
 #' @param show.p a logical value (T/F) indicating whether the p-value is 
-#' displayed. Default to T, where the p.value is displayed.
+#'   displayed. Default to T, where the p.value is displayed.
 #' @param label.sep a character string to separate the terms. Default is ", ", to
 #'   separate the correlation coefficient and the p.value.
 #' @param label.x.npc,label.y.npc can be \code{numeric} or \code{character}


### PR DESCRIPTION
This minor edit allows users a bit more flexibility in what is displayed when using stat_cor. A parameter has been added called 'show.p', of which the logical is used in .cor_test. 