### PR TITLE
gghistogram: Support weighted histograms

### DIFF
--- a/R/gghistogram.R
+++ b/R/gghistogram.R
@@ -21,6 +21,7 @@ NULL
 #' @param position Position adjustment, either as a string, or the result of a
 #'   call to a position adjustment function. Allowed values include "identity",
 #'   "stack", "dodge".
+#' @param weight variable used assign weights to each x value.
 #' @param ... other arguments to be passed to
 #'   \code{\link[ggplot2]{geom_histogram}} and \code{\link{ggpar}}.
 #' @details The plot can be easily customized using the function ggpar(). Read
@@ -67,6 +68,12 @@ NULL
 #'    fill = "sex", palette = c("#00AFBB", "#E7B800"),
 #'    add_density = TRUE)
 #'
+#' # Plot weighted histogram
+#' weighted.data <- data.frame(
+#'    x = sort(runif(1000)),
+#'    weight = seq(1, 1000)
+#' )
+#' gghistogram(weighted.data, x = "x", weight = "weight")
 #'
 #' @export
 gghistogram <- function(data, x, y = "..count..", combine = FALSE, merge = FALSE,
@@ -80,7 +87,7 @@ gghistogram <- function(data, x, y = "..count..", combine = FALSE, merge = FALSE
                         rug = FALSE, add_density = FALSE,
                         label = NULL, font.label = list(size = 11, color = "black"),
                         label.select = NULL, repel = FALSE, label.rectangle = FALSE,
-                        position = position_identity(),
+                        position = position_identity(), weight = NULL,
                         ggtheme = theme_pubr(),
                         ...)
 {
@@ -96,7 +103,7 @@ gghistogram <- function(data, x, y = "..count..", combine = FALSE, merge = FALSE
     add = add, add.params = add.params, rug = rug, add_density = add_density,
     label = label, font.label = font.label, label.select = label.select,
     repel = repel, label.rectangle = label.rectangle,
-    position = position, ggtheme = ggtheme, ...)
+    position = position, weight = weight, ggtheme = ggtheme, ...)
   if(!missing(data)) .opts$data <- data
   if(!missing(x)) .opts$x <- x
   if(!missing(y)) .opts$y <- y
@@ -159,7 +166,11 @@ gghistogram_core <- function(data, x, y = "..count..",
   if(is.null(add.params$linetype)) add.params$linetype <- linetype
   # if(add_density) y <- "..density.."
 
-  p <- ggplot(data, aes_string(x, y))
+  if (is.null(weight)) {
+    p <- ggplot(data, aes_string(x, y))
+  } else {
+    p <- ggplot(data, aes_string(x, y, weight = as.name(weight)))
+  }
 
   p <- p +
       geom_exec(geom_histogram, data = data,

--- a/man/gghistogram.Rd
+++ b/man/gghistogram.Rd
@@ -13,7 +13,7 @@ gghistogram(data, x, y = "..count..", combine = FALSE, merge = FALSE,
   add_density = FALSE, label = NULL, font.label = list(size = 11,
   color = "black"), label.select = NULL, repel = FALSE,
   label.rectangle = FALSE, position = position_identity(),
-  ggtheme = theme_pubr(), ...)
+  weight = NULL, ggtheme = theme_pubr(), ...)
 }
 \arguments{
 \item{data}{a data frame}
@@ -112,6 +112,8 @@ text, making it easier to read.}
 call to a position adjustment function. Allowed values include "identity",
 "stack", "dodge".}
 
+\item{weight}{variable used assign weights to each x value.}
+
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
@@ -166,6 +168,12 @@ gghistogram(wdata, x = "weight",
    fill = "sex", palette = c("#00AFBB", "#E7B800"),
    add_density = TRUE)
 
+# Plot weighted histogram
+weighted.data <- data.frame(
+   x = sort(runif(1000)),
+   weight = seq(1, 1000)
+)
+gghistogram(weighted.data, x = "x", weight = "weight")
 
 }
 \seealso{


### PR DESCRIPTION
Added a "weight" parameter to gghistogram() so that it's parsed as in geom_histogram(aes(weight)).

Previously if we wrote

```r
gghistogram(data, x = "x", weight = "w")
```

the `weight` parameter would be ignored. Now it would be like

```r
ggplot(data, aes(x = x, weight = w))+
  geom_histogram()
```

The solution wasn't so elegant and I'd love some input on this!