### PR TITLE
ensure stat returns a data.frame

### DIFF
--- a/R/stat_conf_ellipse.R
+++ b/R/stat_conf_ellipse.R
@@ -93,5 +93,5 @@ StatConfEllipse <- ggproto("StatConfEllipse", Stat,
   if (bary)
   mat.cov = mat.cov/nrow(tab)
   res <- .ellipse(mat.cov, centre = center, level = level, npoints = npoint)
-  return(res)
+  return(data.frame(res))
 }


### PR DESCRIPTION
The next version of ggplot2 will move to using vctrs internally. Because of this, returning a matrix rather than a data.frame in a stat will cause an error downstream. This was never really supported but apparently worked by accident :-)

We plan to release ggplot2 by the end of October and hope a fix in ggpubr have been released at that time

thank you for your contributions to the ecosystem

kind regards
Thomas