### PR TITLE
Fix issue 386: Brackets positioning messed up when using emmeans_test()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     glue,
     polynom,
     rlang (>= 0.4.6),
-    rstatix (>= 0.7.1),
+    rstatix (>= 0.7.1.999),
     tibble,
     magrittr
 Suggests:
@@ -137,4 +137,5 @@ Collate:
     'utils-tidyr.R'
 Remotes:  
     tidyverse/tidyr,
-    slowkow/ggrepel
+    slowkow/ggrepel,
+    kassambara/rstatix

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 
 ## Bug fixes
   
+- Requiring `rstatix v >=0.7.1.999` for preserving factor class in `emmeans_test()` (#386)
 - `ggmaplot()`: Suppressing ggmaplot warning: *Unlabeled data points (too many overlaps). Consider increasing max.overlaps* (#520)
 - `compare_means()`: works now when the grouping variable levels contain the key words group2 or group1 (#450)
 - `ggparagraph()` : fixing bug about minimum paragraph length (#408)


### PR DESCRIPTION

## Main changes

- Works done in the related `rstatix` package at https://github.com/kassambara/rstatix/issues/169 
- `ggpubr` now requires rstatix v >=0.7.1.999 which preserves factor class in `emmeans_test()`
- Fix issue #386 