### PR TITLE
Updating ggtexttable doc to justify text for individual cells/rows/columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
   
 ## Minor changes
 
+- `ggtexttable()`: doc updated with another example; text justification for individual cells/rows/columns (#335).
 - `ggpie()`: setting the default of `clip = "off"` in `coord_polar()` so that `ggpie()` does not crop labels (#429)
 - `as_ggplot()`: using null_device to avoid blank page #306 and #158
 - `ggarrange()`: using null_device to avoid blank page #306 and #158

--- a/R/ggtexttable.R
+++ b/R/ggtexttable.R
@@ -67,6 +67,17 @@ NULL
 #' # Remove row names using rows = NULL
 #' ggtexttable(df, rows = NULL)
 #'
+#' # Text justification for individual cells/rows/columns (#335)
+#' # First column is left justified i.e., hjust = 0 , x = 0.1
+#' # Remaining columns are right justified i.e., hjust = 1 , x = 0.9
+#' table_theme <- ttheme(
+#'   tbody.style = tbody_style(
+#'    hjust = as.vector(matrix(c(0, 1, 1, 1, 1), ncol = 5, nrow = nrow(df), byrow = TRUE)),
+#'    x = as.vector(matrix(c(.1, .9, .9,.9, .9), ncol = 5, nrow = nrow(df), byrow = TRUE))
+#'  )
+#' )
+#' ggtexttable(df, rows = NULL, theme = table_theme)
+#'
 #' # Blank theme
 #' ggtexttable(df, rows = NULL, theme = ttheme("blank"))
 #'

--- a/man/ggtexttable.Rd
+++ b/man/ggtexttable.Rd
@@ -304,6 +304,17 @@ df <- head(iris)
 # Remove row names using rows = NULL
 ggtexttable(df, rows = NULL)
 
+# Text justification for individual cells/rows/columns (#335)
+# First column is left justified i.e., hjust = 0 , x = 0.1
+# Remaining columns are right justified i.e., hjust = 1 , x = 0.9
+table_theme <- ttheme(
+  tbody.style = tbody_style(
+   hjust = as.vector(matrix(c(0, 1, 1, 1, 1), ncol = 5, nrow = nrow(df), byrow = TRUE)),
+   x = as.vector(matrix(c(.1, .9, .9,.9, .9), ncol = 5, nrow = nrow(df), byrow = TRUE))
+ )
+)
+ggtexttable(df, rows = NULL, theme = table_theme)
+
 # Blank theme
 ggtexttable(df, rows = NULL, theme = ttheme("blank"))
 


### PR DESCRIPTION
## Main changes

- `ggtexttable()`:  updating example section
- fix for #335