### PR TITLE
Add a parameter to show the number of observations

### DIFF
--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -209,6 +209,13 @@ ggboxplot_core <- function(data, x, y,
   if(!is.factor(data[[x]])) data[[x]] <- as.factor(data[[x]])
   if("jitter" %in% add) outlier.shape <- NA
 
+  library(dplyr)
+
+  # Calculer le nombre d'observations et la médiane pour chaque groupe
+  stats <- data %>%
+    group_by(!!sym(x)) %>%
+    summarise(n = n(), median = median(!!sym(y)), .groups = "drop")
+
   p <- ggplot(data, create_aes(list(x = x, y = y)))
   if(bxp.errorbar){
     if(fill %in% colnames(data)){
@@ -233,14 +240,8 @@ ggboxplot_core <- function(data, x, y,
               position = position_dodge(0.8), size = size,...)
 
   if (show.n) {
-    p <- p + stat_boxplot(
-      aes(label = paste("n = ", ..count..)),  # Nombre d'observations à afficher
-      geom = "text",                         # Affiche le label sous forme de texte
-      vjust = -0.5,                          # Ajuste la position verticale du label
-      size = 4,                              # Taille du texte
-      color = "black",                       # Couleur du texte
-      position = position_dodge(0.8)         # Ajuste la position pour gérer plusieurs groupes
-    )
+    p <- p + geom_text(data = stats, aes(x = !!sym(x), y = median, label = paste("n =", n)),
+                       vjust = -0.5, size = 4, color = "black")
   }
 
 

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -213,6 +213,7 @@ ggboxplot_core <- function(data, x, y,
 
   # Calculer le nombre d'observations et la médiane pour chaque groupe
   stats <- data %>%
+    suppressPackageStartupMessages() %>%
     group_by(!!sym(x)) %>%
     summarise(n = n(), median = median(!!sym(y)), .groups = "drop")
 

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -71,7 +71,8 @@ NULL
 #'  scales: xscale, yscale (e.g.: yscale = "log2") \item color palettes: palette
 #'  = "Dark2" or palette = c("gray", "blue", "red") \item legend title, labels
 #'  and position: legend = "right" \item plot orientation : orientation =
-#'  c("vertical", "horizontal", "reverse") \item sample size display: show.n = TRUE }
+#'  c("vertical", "horizontal", "reverse") \item sample size display: show.n =
+#'  TRUE }
 #'
 #'@section Suggestions for the argument "add": Suggested values are one of
 #'  c("dotplot", "jitter").
@@ -246,7 +247,10 @@ ggboxplot_core <- function(data, x, y,
               position = position_dodge(0.8), size = size,...)
 
   if (show.n) {
-    p <- p + geom_text(data = stats, aes(x = !!sym(x), y = median, label = paste("n =", n)),
+    stats <- stats %>%
+      mutate(max_y = tapply(data[[y]], data[[x]], max)) %>%
+      mutate(y_position = max_y + 0.5)
+    p <- p + geom_text(data = stats, aes(x = !!sym(x), y = y_position, label = paste("n =", n)),
                        vjust = -0.5, size = 4, color = "black")
   }
 

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -24,6 +24,7 @@ NULL
 #'@param bxp.errorbar logical value. If TRUE, shows error bars of box plots.
 #'@param bxp.errorbar.width numeric value specifying the width of box plot error
 #'  bars. Default is 0.4.
+#'@param show.n logical value. If TRUE, displays the number of observations (n) for each group on the plot.
 #'@param linetype line types.
 #'@param size Numeric value (e.g.: size = 1). change the size of points and
 #'  outlines.
@@ -69,7 +70,7 @@ NULL
 #'  scales: xscale, yscale (e.g.: yscale = "log2") \item color palettes: palette
 #'  = "Dark2" or palette = c("gray", "blue", "red") \item legend title, labels
 #'  and position: legend = "right" \item plot orientation : orientation =
-#'  c("vertical", "horizontal", "reverse") }
+#'  c("vertical", "horizontal", "reverse") \item sample size display: show.n = TRUE }
 #'
 #'@section Suggestions for the argument "add": Suggested values are one of
 #'  c("dotplot", "jitter").
@@ -138,6 +139,9 @@ NULL
 #' # fill or color box plot by a second group : "supp"
 #' ggboxplot(df, "dose", "len", color = "supp",
 #'  palette = c("#00AFBB", "#E7B800"))
+#'
+#' # Display number of observations per group
+#' ggboxplot(df, x = "dose", y = "len", show.n = TRUE)
 #'
 #'@export
 ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -240,4 +240,3 @@ ggboxplot_core <- function(data, x, y,
   p
 }
 
-

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -24,7 +24,8 @@ NULL
 #'@param bxp.errorbar logical value. If TRUE, shows error bars of box plots.
 #'@param bxp.errorbar.width numeric value specifying the width of box plot error
 #'  bars. Default is 0.4.
-#'@param show.n logical value. If TRUE, displays the number of observations (n) for each group on the plot.
+#'@param show.n logical value. If TRUE, adds the number of observations per
+#'  group to the plot.
 #'@param linetype line types.
 #'@param size Numeric value (e.g.: size = 1). change the size of points and
 #'  outlines.

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -152,7 +152,7 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
                       error.plot = "pointrange",
                       label = NULL, font.label = list(size = 11, color = "black"),
                       label.select = NULL, repel = FALSE, label.rectangle = FALSE,
-                      ggtheme = theme_pubr(),...)
+                      ggtheme = theme_pubr(), show.n = FALSE,...)
 {
 
   # Default options
@@ -167,7 +167,7 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
     select = select , remove = remove, order = order,
     add = add, add.params = add.params, error.plot = error.plot,
     label = label, font.label = font.label, label.select = label.select,
-    repel = repel, label.rectangle = label.rectangle, ggtheme = ggtheme, ...)
+    repel = repel, label.rectangle = label.rectangle, ggtheme = ggtheme, show.n = show.n,...)
   if(!missing(data)) .opts$data <- data
   if(!missing(x)) .opts$x <- x
   if(!missing(y)) .opts$y <- y
@@ -202,6 +202,7 @@ ggboxplot_core <- function(data, x, y,
                       add = "none", add.params = list(),
                       error.plot = "pointrange",
                       ggtheme = theme_pubr(),
+                      show.n = FALSE,
                       ...)
 {
 
@@ -230,6 +231,20 @@ ggboxplot_core <- function(data, x, y,
               size = size, width = width, notch = notch,
               outlier.shape = outlier.shape,
               position = position_dodge(0.8), size = size,...)
+
+  if (show.n) {
+    p <- p + stat_boxplot(
+      aes(label = paste("n = ", ..count..)),  # Nombre d'observations à afficher
+      geom = "text",                         # Affiche le label sous forme de texte
+      vjust = -0.5,                          # Ajuste la position verticale du label
+      size = 4,                              # Taille du texte
+      color = "black",                       # Couleur du texte
+      position = position_dodge(0.8)         # Ajuste la position pour gérer plusieurs groupes
+    )
+  }
+
+
+
 
   # Add
   add.params <- .check_add.params(add, add.params, error.plot, data, color, fill, ...) %>%

--- a/R/ggstripchart.R
+++ b/R/ggstripchart.R
@@ -10,6 +10,8 @@ NULL
 #' @param position position adjustment, either as a string, or the result of a
 #'   call to a position adjustment function. Used to adjust position for
 #'   multiple groups.
+#' @param show.n logical value. If TRUE, adds the number of observations per
+#'   group to the plot.
 #' @param ... other arguments to be passed to
 #'   \code{\link[ggplot2]{geom_jitter}}, \code{\link{ggpar}} and
 #'   \code{\link{facet}}.
@@ -19,7 +21,8 @@ NULL
 #'   scales: xscale, yscale (e.g.: yscale = "log2") \item color palettes:
 #'   palette = "Dark2" or palette = c("gray", "blue", "red") \item legend title,
 #'   labels and position: legend = "right" \item plot orientation : orientation
-#'   = c("vertical", "horizontal", "reverse") }
+#'   = c("vertical", "horizontal", "reverse") \item sample size display: show.n
+#'   = TRUE }
 #'@seealso \code{\link{ggpar}}, \code{\link{ggviolin}}, \code{\link{ggdotplot}}
 #'  and \code{\link{ggboxplot}}.
 #' @examples
@@ -86,6 +89,9 @@ NULL
 #' ggstripchart(df, "dose", "len", shape = "supp",
 #'  color = "supp", palette = c("#00AFBB", "#E7B800"),
 #'  add = "boxplot", add.params = list(color = "black") )
+#'
+#' # Display number of observations per group
+#' ggstripchart(df, x = "dose", y = "len", show.n = TRUE)
 #'
 #' @export
 ggstripchart <- function(data, x, y, combine = FALSE, merge = FALSE,


### PR DESCRIPTION
To resolve issue #598, I have added the show.n parameter to the ggboxplot, ggviolin, and ggstripchart functions, allowing the display of labels showing the number of observations in each group on the plots.
It works as a boolean, defaulting to false. When set to True, the code retrieves the number of observations in each group and positions the label appropriately, ensuring it's visible and not overlapping with the point cloud, for example.
The documentation has also been updated, following the general structure.
If you have any questions or need further clarifications, feel free to reach out.