### PR TITLE
Fix issue 621 and add a unit-test for it.

### DIFF
--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -118,7 +118,7 @@ stat_pvalue_manual <- function(
   bracket.nudge.y = 0, bracket.shorten = 0,
   color = "black", linetype = 1, tip.length = 0.03,
   remove.bracket = FALSE, step.increase = 0, step.group.by = NULL,
-  hide.ns = FALSE, vjust = 0, coord.flip = FALSE, position = "identity", ...
+  hide.ns = FALSE, vjust = 0, coord.flip = FALSE, position = "identity", inherit.aes = F, ...
 )
 {
   if(is.null(label)){
@@ -229,7 +229,7 @@ stat_pvalue_manual <- function(
       label.size = label.size, size = bracket.size,
       bracket.nudge.y = bracket.nudge.y, bracket.shorten = bracket.shorten,
       color = color, linetype = linetype, step.increase = step.increase,
-      step.group.by = step.group.by, coord.flip = coord.flip, position = position, ...
+      step.group.by = step.group.by, coord.flip = coord.flip, position = position, inherit.aes=inherit.aes, ...
     )
   }
   else{
@@ -246,7 +246,7 @@ stat_pvalue_manual <- function(
     else{
       mapping <- aes(x = xmin, y = y.position, vjust = vjust, label = label)
     }
-    option <- list(data = data, size = label.size, position = position, ...)
+    option <- list(data = data, size = label.size, position = position, inherit.aes = inherit.aes, ...)
     if(color %in% colnames(data)) mapping$colour <- rlang::ensym(color)
     else option$color <- color
     option[["mapping"]] <- mapping

--- a/tests/testthat/test-stat_pvalue_manual.R
+++ b/tests/testthat/test-stat_pvalue_manual.R
@@ -1,0 +1,27 @@
+context("test-stat_pvalue_manual")
+data("ToothGrowth")
+df <- ToothGrowth
+
+test_with_fill <- function(inherit.aes = NULL) {
+    stat.test <- df %>%
+        group_by(dose) %>%
+        rstatix::t_test(len ~ supp) %>%
+        rstatix::add_xy_position(x = "dose")
+
+    if (is.null(inherit.aes)) {
+        layer <- stat_pvalue_manual(stat.test)
+    } else {
+        layer <- stat_pvalue_manual(stat.test, inherit.aes = inherit.aes)
+    }
+
+    p <- ggplot(df, aes(x = dose, y = len, color = supp, fill = supp)) +
+        geom_boxplot() +
+        layer
+    ggplot2::ggplot_build(p)
+}
+
+test_that("fill aes works well by default", {
+    expect_error(test_with_fill(inherit.aes = TRUE))
+    expect_no_error(test_with_fill(inherit.aes = FALSE))
+    expect_no_error(test_with_fill())
+})


### PR DESCRIPTION
When users define mappings at the top level of a `ggplot` object, the mappings will be passed to `stat_pvalue_manual` and thereby passed to `geom_text` and `geom_bracket`. This will cause an error and I believe this is a common case.

Since there are seldom users who would like to inherit the mappings from the top in a `stat_pvalue_manual` call, I passed a `inherit.aes=inherit.aes` to all `geom_*`s in `stat_pvalue_manual` explicitly, and set its default value to `FALSE`.

Besides, I added a unittest for this and it passed.

For more details, also refer to issue #621 .

