### PR TITLE
Revert exact = FALSE workaround, use flexible test assertions #649

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     testthat
 URL: https://rpkgs.datanovia.com/ggpubr/
 BugReports: https://github.com/kassambara/ggpubr/issues
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate:
     'utilities_color.R'
     'utilities_base.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes
 
+- Reverted the `exact = FALSE` workaround from version 0.6.2 that forced non-default behavior on `wilcox.test()`. Instead, updated tests in `test-compare_means.R` and `test-stat_compare_means.R` to accept both legacy and R-devel p-values when exact conditional two-sample inference with ties is used (R-devel r88748). Tests now use flexible assertions to ensure compatibility across R versions without changing R's default `wilcox.test()` behavior (#649, #647).
+
 # ggpubr 0.6.2
 
 ## Bug fixes

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -284,8 +284,6 @@ compare_means <- function(formula, data, method = "wilcox.test",
     test.opts <- list(x = .select_vec(data, x), ...)
   else test.opts <- list(formula = formula, data = data, ...)
 
-  if(method == "wilcox.test" && is.null(test.opts$exact)) test.opts$exact <- FALSE
-
   res <- data.frame(p = suppressWarnings(do.call(test, test.opts)$p.value))
   group1 <- group2 <- NULL
 
@@ -330,7 +328,6 @@ compare_means <- function(formula, data, method = "wilcox.test",
                     g = .select_vec(data, group),
                     paired = paired,
                     ...)
-  if(method == "pairwise.wilcox.test" && is.null(test.opts$exact)) test.opts$exact <- FALSE
   if(method == "pairwise.t.test"){
     if(missing(pool.sd)){
       if(!paired) pool.sd <- FALSE

--- a/tests/testthat/test-compare_means.R
+++ b/tests/testthat/test-compare_means.R
@@ -19,11 +19,14 @@ test_that("compare_means works for Two-samples unpaired test", {
   results <- compare_means(len ~ supp, ToothGrowth)
   results <- results %>%
     dplyr::select(.y., group1, group2, p.format, p.signif, method)
-  expected <- tibble::tribble(
-      ~.y., ~group1, ~group2, ~p.format, ~p.signif,    ~method,
-     "len",    "OJ",    "VC",   "0.064",      "ns", "Wilcoxon"
-     )
-  expect_equal(results, expected)
+  # Accept either 0.064 (exact=FALSE) or 0.063 (R-devel exact conditional inference)
+  expect_true(results$p.format %in% c("0.064", "0.063"),
+              info = paste("Observed p.format =", results$p.format))
+  expect_equal(results$.y., "len")
+  expect_equal(results$group1, "OJ")
+  expect_equal(results$group2, "VC")
+  expect_equal(results$p.signif, "ns")
+  expect_equal(results$method, "Wilcoxon")
 })
 
 
@@ -31,11 +34,14 @@ test_that("compare_means works for Two-samples paired test", {
   results <- compare_means(len ~ supp, ToothGrowth, paired = TRUE)
   results <- results %>%
     dplyr::select(.y., group1, group2, p.format, p.signif, method)
-  expected <- tibble::tribble(
-      ~.y., ~group1, ~group2, ~p.format, ~p.signif,    ~method,
-     "len",    "OJ",    "VC",  "0.0043",      "**", "Wilcoxon"
-     )
-  expect_equal(results, expected)
+  # Accept either 0.0043 (exact=FALSE) or 0.0038 (R-devel exact conditional inference)
+  expect_true(results$p.format %in% c("0.0043", "0.0038"),
+              info = paste("Observed p.format =", results$p.format))
+  expect_equal(results$.y., "len")
+  expect_equal(results$group1, "OJ")
+  expect_equal(results$group2, "VC")
+  expect_equal(results$p.signif, "**")
+  expect_equal(results$method, "Wilcoxon")
 })
 
 
@@ -43,25 +49,35 @@ test_that("compare_means works for pairwise comparisons", {
   results <- compare_means(len ~ dose, ToothGrowth)
   results <- results %>%
     dplyr::select(.y., group1, group2, p.format, p.signif, method)
-  expected <- tibble::tribble(
-      ~.y., ~group1, ~group2, ~p.format, ~p.signif,    ~method,
-     "len",   "0.5",     "1", "7.0e-06",    "****", "Wilcoxon",
-     "len",   "0.5",     "2", "8.4e-08",    "****", "Wilcoxon",
-     "len",     "1",     "2", "0.00018",     "***", "Wilcoxon"
-     )
-  expect_equal(results, expected)
+  # Accept both exact=FALSE and R-devel exact conditional inference p-values
+  legacy_p <- c("7.0e-06", "8.4e-08", "0.00018")
+  rdevel_p <- c("7.7e-07", "4.4e-11", "7.6e-05")
+  observed_p <- results$p.format
+  expect_true(all(observed_p %in% c(legacy_p, rdevel_p)),
+              info = paste("Observed p.format =", paste(observed_p, collapse=", ")))
+  expect_equal(results$.y., rep("len", 3))
+  expect_equal(results$group1, c("0.5", "0.5", "1"))
+  expect_equal(results$group2, c("1", "2", "2"))
+  expect_true(all(results$p.signif %in% c("***", "****")),
+              info = paste("Observed p.signif =", paste(results$p.signif, collapse=", ")))
+  expect_equal(results$method, rep("Wilcoxon", 3))
 })
 
 test_that("compare_means works for comparison against reference groups", {
   results <- compare_means(len ~ dose, ToothGrowth, ref.group = "0.5")
   results <- results %>%
     dplyr::select(.y., group1, group2, p.format, p.signif, method)
-  expected <- tibble::tribble(
-      ~.y., ~group1, ~group2, ~p.format, ~p.signif,    ~method,
-     "len",   "0.5",     "1", "7.0e-06",    "****", "Wilcoxon",
-     "len",   "0.5",     "2", "8.4e-08",    "****", "Wilcoxon"
-     )
-  expect_equal(results, expected)
+  # Accept both exact=FALSE and R-devel exact conditional inference p-values
+  legacy_p <- c("7.0e-06", "8.4e-08")
+  rdevel_p <- c("7.7e-07", "4.4e-11")
+  observed_p <- results$p.format
+  expect_true(all(observed_p %in% c(legacy_p, rdevel_p)),
+              info = paste("Observed p.format =", paste(observed_p, collapse=", ")))
+  expect_equal(results$.y., rep("len", 2))
+  expect_equal(results$group1, c("0.5", "0.5"))
+  expect_equal(results$group2, c("1", "2"))
+  expect_equal(results$p.signif, rep("****", 2))
+  expect_equal(results$method, rep("Wilcoxon", 2))
 })
 
 
@@ -147,11 +163,13 @@ test_that("compare_means works when grouping variable levels contain group2", {
   results <- compare_means(val ~ gp, data = dat, group.by = 'by', paired = F)
   results <- results %>%
     dplyr::select(.y., group1, group2, p.format, p.signif, method)
-  expected <- tibble::tribble(
-      ~.y.,  ~group1,  ~group2, ~p.format, ~p.signif,    ~method,
-     "val", "group2", "group4",    "0.22",      "ns", "Wilcoxon",
-     "val", "group2", "group4",    "0.22",      "ns", "Wilcoxon"
-     )
-  expect_equal(results, expected)
+  # Accept either 0.23 (exact=FALSE) or 0.22 (R-devel exact conditional inference)
+  expect_true(all(results$p.format %in% c("0.23", "0.22")),
+              info = paste("Observed p.format =", paste(results$p.format, collapse=", ")))
+  expect_equal(results$.y., rep("val", 2))
+  expect_equal(results$group1, c("group2", "group2"))
+  expect_equal(results$group2, c("group4", "group4"))
+  expect_equal(results$p.signif, rep("ns", 2))
+  expect_equal(results$method, rep("Wilcoxon", 2))
 })
 

--- a/tests/testthat/test-stat_compare_means.R
+++ b/tests/testthat/test-stat_compare_means.R
@@ -90,15 +90,14 @@ test_that("stat_compare_means works when label specified as aes(label=..p.signif
 # Paired samples-----------------------------------
 test_that("stat_compare_means works for paired samples comparison", {
   stat.test <- .get_stat_test(df, paired = TRUE)
-  label_coords_expected <- data.frame(
-    stringsAsFactors = FALSE,
-    x = 1,
-    y = c(33.9),
-    label = c("Wilcoxon, p = 0.0043")
-  )
   label_coords_observed <- stat.test[, c("x", "y", "label")]
   label_coords_observed$x <- as.numeric(label_coords_observed$x)
-  expect_equal(label_coords_expected, label_coords_observed)
+
+  # Accept either 0.0043 (exact=FALSE) or 0.0038 (R-devel exact conditional inference)
+  expect_true(label_coords_observed$label %in% c("Wilcoxon, p = 0.0043", "Wilcoxon, p = 0.0038"),
+              info = paste("Observed label =", label_coords_observed$label))
+  expect_equal(label_coords_observed$x, 1)
+  expect_equal(label_coords_observed$y, 33.9)
 })
 
 


### PR DESCRIPTION
## Summary
This PR reverts the `exact = FALSE` workaround from version 0.6.2 and instead uses flexible test assertions that accept both legacy and R-devel p-values.

## Problem with v0.6.2 Approach
The previous fix (#647) forced `exact = FALSE` on all `wilcox.test()` and `pairwise.wilcox.test()` calls, which:
- Changed R's default statistical behavior
- May not be what users expect or want
- Could affect statistical results in downstream packages

## New Approach
Instead of changing R's behavior, we now:
- Keep R's default `wilcox.test()` behavior (exact tests when possible)
- Update tests to accept both legacy p-values and R-devel exact conditional inference p-values
- Use flexible assertions with informative error messages

## Changes
- Removed `exact = FALSE` from `wilcox.test()` and `pairwise.wilcox.test()` in `R/compare_means.R`
- Updated `tests/testthat/test-compare_means.R` with flexible p-value assertions
- Updated `tests/testthat/test-stat_compare_means.R` with flexible p-value assertions
- Bumped version to 0.6.2.999
- Updated NEWS.md

## Benefits
- Respects R's default statistical behavior
- Tests pass on both legacy R and R-devel
- No breaking changes for package users
- Maintains statistical integrity

## Related Issues
- Closes #649
- Related to #647

## Testing
- [x] Tests pass on local R installation
- [ ] Need to verify on R-devel