### PR TITLE
geom_pwc(): detect rstatix missing-ref.group by condition class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,12 @@
   subsets were skipped and why (e.g., missing `ref.group` or insufficient levels).
 - Added regression tests for mixed comparable/non-comparable subsets and fully sparse
   subsets.
+- `geom_pwc()` now detects an absent `ref.group` in a grouped subset via the
+  `rstatix_missing_ref_group` condition class raised by recent `rstatix`
+  (walking the parent chain with `rlang::cnd_inherits()`), in addition to
+  matching the error message. This keeps the "skip ref-less subsets" behaviour
+  working after `rstatix` made that error message clearer (rstatix #153); older
+  `rstatix` versions are still handled via the message fallback.
 
 ## P-value formatting
 

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -393,15 +393,23 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
     stat.test <- tryCatch(
       do.call(method, method.args),
       error = function(e) {
-        sparse_error <- grepl(
-          paste0(
-            "not enough|exactly 2 levels|at least 2|same group|fewer than two levels|must be an existing level",
-            # French locale equivalents
-            "|insuffisant|niveau existant|pas assez|au moins 2"
-          ),
-          conditionMessage(e),
-          ignore.case = TRUE
-        )
+        # rstatix (>= 0.7.3.9000) tags an absent reference group with the S3
+        # condition class "rstatix_missing_ref_group"; detect it by class
+        # (locale-independent, robust to message wording), walking the parent
+        # chain because the grouped path wraps the condition in dplyr/purrr
+        # errors. Fall back to matching the message text for older rstatix and
+        # for the other "sparse data" failures (too few levels / observations).
+        sparse_error <- rlang::cnd_inherits(e, "rstatix_missing_ref_group") ||
+          grepl(
+            paste0(
+              "not enough|exactly 2 levels|at least 2|same group|fewer than two levels",
+              "|must be an existing level|not present in the data",
+              # French locale equivalents
+              "|insuffisant|niveau existant|pas assez|au moins 2"
+            ),
+            conditionMessage(e),
+            ignore.case = TRUE
+          )
         if (!sparse_error) {
           stop(e)
         }


### PR DESCRIPTION
## `geom_pwc()`: detect rstatix's missing-`ref.group` by condition class

`geom_pwc()` (and `stat_pwc()`) skip grouped subsets that lack the requested `ref.group`, keeping the valid comparisons in the same layer. It decided a subset was "skippable" by **matching rstatix's error message text** (`"...must be an existing level"`).

rstatix recently improved that error to a clearer message (`"The reference group (ref.group = '…') is not present in the data. …"`, rstatix #153). The new wording no longer matched `geom_pwc()`'s pattern, so instead of skipping a ref-less subset it re-raised the error and the whole layer failed.

### Fix
Detect the condition by **class** rather than message: recent rstatix tags this error with the S3 condition class `rstatix_missing_ref_group`. `geom_pwc()` now checks `rlang::cnd_inherits(e, "rstatix_missing_ref_group")` (walking the parent chain, since the grouped path wraps the condition in dplyr/purrr errors), and additionally adds the new message wording (`"not present in the data"`) to the fallback regex.

This is robust to message wording and locale, and works with **both**:
- current rstatix master (clearer message, no class yet) → caught by the regex fallback;
- rstatix with the new `rstatix_missing_ref_group` class → caught by class.

### Verification
- `devtools::test()` full suite: **404 PASS / 0 fail** (the `geom_pwc` "skips grouped subsets missing ref.group" tests are green again).
- Verified against both rstatix master and the rstatix branch that adds the condition class.

Companion to rstatix #153 / the rstatix PR adding the `rstatix_missing_ref_group` condition class.
