### PR TITLE
ggballoonplot(): honor xlab/ylab (Fixes #639)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,8 @@
   single positive finite number.
 - Updated `create_p_label()` to preserve `NA` values in `p.format` (returning
   `NA_character_` instead of stringifying to `"p = NA"`).
+- `ggballoonplot()` now honors user-supplied `xlab`/`ylab` instead of always
+  blanking the axis titles; axis titles are still blank by default (@issue 639).
 
 ## Tests and docs
 

--- a/R/ggballoonplot.R
+++ b/R/ggballoonplot.R
@@ -190,11 +190,16 @@ ggballoonplot <- function(
   p <- p +
     scale_size(range = size.range) +
     guides(size = guide_legend(reverse = TRUE)) +
-    ggtheme +
-    theme(
-      axis.title.x = ggplot2::element_blank(),
-      axis.title.y = ggplot2::element_blank()
-    )
+    ggtheme
+  # Blank the axis titles by default, but keep them when the user supplies
+  # xlab/ylab (passed via ... to ggpar) so those labels are honored (#639).
+  dots <- list(...)
+  if (is.null(dots$xlab)) {
+    p <- p + theme(axis.title.x = ggplot2::element_blank())
+  }
+  if (is.null(dots$ylab)) {
+    p <- p + theme(axis.title.y = ggplot2::element_blank())
+  }
 
   if (show.label) {
     font.label <- .check_lab_font(font.label)

--- a/tests/testthat/test-ggballoonplot.R
+++ b/tests/testthat/test-ggballoonplot.R
@@ -1,0 +1,27 @@
+test_that("ggballoonplot honors xlab/ylab and blanks them by default (#639)", {
+  dat <- as.data.frame(matrix(1:6, nrow = 2,
+    dimnames = list(c("r1", "r2"), c("c1", "c2", "c3"))))
+
+  # Default: axis titles are blanked (unchanged behavior)
+  th_default <- ggplot2::ggplot_build(ggballoonplot(dat))$plot$theme
+  expect_s3_class(th_default$axis.title.x, "element_blank")
+  expect_s3_class(th_default$axis.title.y, "element_blank")
+
+  # When supplied, xlab/ylab are honored (not blanked, and label text set)
+  p <- ggballoonplot(dat, xlab = "My X", ylab = "My Y")
+  built <- ggplot2::ggplot_build(p)
+  expect_false(inherits(built$plot$theme$axis.title.x, "element_blank"))
+  expect_false(inherits(built$plot$theme$axis.title.y, "element_blank"))
+  expect_equal(built$plot$labels$x, "My X")
+  expect_equal(built$plot$labels$y, "My Y")
+
+  # Only one label supplied: it shows, the other stays blank
+  p_x <- ggballoonplot(dat, xlab = "Only X")
+  th_x <- ggplot2::ggplot_build(p_x)$plot$theme
+  expect_false(inherits(th_x$axis.title.x, "element_blank"))
+  expect_s3_class(th_x$axis.title.y, "element_blank")
+
+  # xlab = FALSE keeps the ggpar hide behavior (title blank)
+  th_false <- ggplot2::ggplot_build(ggballoonplot(dat, xlab = FALSE))$plot$theme
+  expect_s3_class(th_false$axis.title.x, "element_blank")
+})


### PR DESCRIPTION
## Problem
`ggballoonplot()` hardcoded `axis.title.x/y = element_blank()`, so user-supplied `xlab`/`ylab` (passed via `...` to `ggpar()`) were set on the plot but never displayed — issue #639.

## Fix
Blank the axis titles **only when `xlab`/`ylab` are not supplied**. When the user provides them, they are left for `ggpar()` to set and are now shown.

- **Gated / no-regression:** default `ggballoonplot(data)` output is byte-identical (axis titles still blank; verified with a `waldo` comparison of `$theme` and `$labels`).
- `xlab = FALSE` still hides the title (existing `ggpar` convention preserved).

## Tests
New `tests/testthat/test-ggballoonplot.R`: default-blank, labels-honored-when-supplied, one-label-only, and `xlab = FALSE` hiding. Full clean-session suite: **153 tests, 0 failures**.

## Review
Two independent adversarial pre-commit reviewers both returned SAFE (default byte-identical; `xlab=FALSE`/`NULL`/one-label/`facet`/`rotate` paths verified; the `xlab=NA`/vector errors are pre-existing `ggpar` behavior, unchanged here).

Fixes #639
