### PR TITLE
ggsummarytable(): add angle argument (Fixes #595)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@
   `NA_character_` instead of stringifying to `"p = NA"`).
 - `ggballoonplot()` now honors user-supplied `xlab`/`ylab` instead of always
   blanking the axis titles; axis titles are still blank by default (@issue 639).
+- `ggsummarytable()` gains an `angle` argument to rotate the summary-table text;
+  default (`angle = 0`) is unchanged (@issue 595).
 
 ## Tests and docs
 

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -11,6 +11,8 @@ NULL
 #' @param table.font.size the summary table font size.
 #' @param position Position adjustment, either as a string, or the result of a
 #'   call to a position adjustment function.
+#' @param angle numeric value specifying the rotation angle (in degrees) of the
+#'   summary table text. Default is 0.
 #' @param summaries summary stats to display in the table. Possible values are
 #'   those returned by the function \code{\link[rstatix]{get_summary_stats}()},
 #'   including: \code{"n", "min", "max",  "median",  "q1", "q2", "q3", "mad",
@@ -98,7 +100,7 @@ NULL
 #' @export
 ggsummarytable <- function(data, x, y, digits = 0, size = 3, color = "black", palette = NULL,
                            facet.by = NULL, labeller = "label_value", position = "identity",
-                           ggtheme = theme_pubr(), ...) {
+                           angle = 0, ggtheme = theme_pubr(), ...) {
   if (missing(ggtheme) & !is.null(facet.by)) {
     ggtheme <- theme_pubr(border = TRUE)
   }
@@ -123,7 +125,7 @@ ggsummarytable <- function(data, x, y, digits = 0, size = 3, color = "black", pa
       geom_text,
       data = df,
       label = "label", size = size, color = color, group = group,
-      position = position
+      position = position, angle = angle
     )
   p <- ggpar(p, ggtheme = ggtheme, palette = palette, xlab = x, ...)
   if (!is.null(facet.by)) p <- facet(p, facet.by = facet.by, labeller = labeller, ...)

--- a/man/ggsummarystats.Rd
+++ b/man/ggsummarystats.Rd
@@ -18,6 +18,7 @@ ggsummarytable(
   facet.by = NULL,
   labeller = "label_value",
   position = "identity",
+  angle = 0,
   ggtheme = theme_pubr(),
   ...
 )
@@ -76,6 +77,9 @@ labelled by both grouping variable names and levels) and "label_value"
 
 \item{position}{Position adjustment, either as a string, or the result of a
 call to a position adjustment function.}
+
+\item{angle}{numeric value specifying the rotation angle (in degrees) of the
+summary table text. Default is 0.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -1,0 +1,11 @@
+
+test_that("ggsummarytable forwards angle to the text layer (#595)", {
+  # Regression: angle rotates the summary-table text
+  p90 <- ggsummarytable(ToothGrowth, x = "dose", y = "len",
+                        summaries = "mean", angle = 90)
+  expect_true(all(ggplot2::layer_data(p90, 1)$angle == 90))
+
+  # No-regression: default (no angle) is unchanged (angle 0)
+  p0 <- ggsummarytable(ToothGrowth, x = "dose", y = "len", summaries = "mean")
+  expect_true(all(ggplot2::layer_data(p0, 1)$angle == 0))
+})


### PR DESCRIPTION
## Problem
`ggsummarytable()` couldn't rotate its summary-table text: the `geom_text` layer never received an `angle` (extra `...` went to `ggpar()`, not the text) — issue #595.

## Fix
Add an `angle = 0` argument to `ggsummarytable()` and forward it to the text layer (`angle` is already whitelisted in `geom_exec()`).

- **Gated / no-regression:** default `ggsummarytable(...)` output is byte-identical (`geom_text`'s intrinsic default angle is already 0; layer data `identical()`).
- The higher-level `ggsummarystats()` is unchanged (its internal `ggsummarytable()` call doesn't pass `angle`).

## Tests
New `tests/testthat/test-ggsummarystats.R`: rotation applied (`angle=90`) and default unchanged (`angle=0`). Clean-session suite: **154 tests, 0 failures**.

## Docs
`man/ggsummarystats.Rd` hand-edited to add `angle` in the existing roxygen format (verified byte-identical to a fresh roxygen regen; avoids an unrelated `RoxygenNote` version bump).

## Review
Two independent adversarial pre-commit reviewers both returned SAFE (default byte-identical; rotation works; `ggsummarystats`/`facet`/dodge paths verified; doc consistent for `R CMD check`).

Fixes #595
