### PR TITLE
ggmaplot(): add line.color argument (Fixes #322)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,9 +48,11 @@
 - Updated `create_p_label()` to preserve `NA` values in `p.format` (returning
   `NA_character_` instead of stringifying to `"p = NA"`).
 - `ggballoonplot()` now honors user-supplied `xlab`/`ylab` instead of always
-  blanking the axis titles; axis titles are still blank by default (@issue 639).
+  blanking the axis titles; axis titles are still blank by default (#639).
 - `ggsummarytable()` gains an `angle` argument to rotate the summary-table text;
-  default (`angle = 0`) is unchanged (@issue 595).
+  default (`angle = 0`) is unchanged (#595).
+- `ggmaplot()` gains a `line.color` argument to set the threshold line color;
+  default ("black") is unchanged (#322).
 
 ## Tests and docs
 

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -52,6 +52,8 @@ NULL
 #'  values include "padj" and "fc" for selecting by adjusted p values or fold
 #'  changes, respectively.
 #' @param label.select character vector specifying some labels to show.
+#' @param line.color color of the horizontal threshold lines (the central line
+#'   at 0 and the two fold-change cutoff lines). Default is "black".
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
 #' @return returns a ggplot.
 #' @examples
@@ -102,6 +104,7 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
                      top = 15, select.top.method = c("padj", "fc"),
                      label.select = NULL,
                      main = NULL, xlab = "Log2 mean expression", ylab = "Log2 fold change",
+                     line.color = "black",
                      ggtheme = theme_classic(), ...) {
   if (!base::inherits(data, c("matrix", "data.frame", "DataFrame", "DE_Results", "DESeqResults"))) {
     stop("data must be an object of class matrix, data.frame, DataFrame, DE_Results or DESeqResults")
@@ -217,7 +220,7 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
     labs(x = xlab, y = ylab, title = main, color = "") + # to remove legend title use color = ""
     geom_hline(
       yintercept = c(0, -log2(fc), log2(fc)), linetype = c(1, 2, 2),
-      color = c("black", "black", "black")
+      color = line.color
     )
 
   p <- ggpar(p, palette = palette, ggtheme = ggtheme, ...)

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -22,6 +22,7 @@ ggmaplot(
   main = NULL,
   xlab = "Log2 mean expression",
   ylab = "Log2 fold change",
+  line.color = "black",
   ggtheme = theme_classic(),
   ...
 )
@@ -98,6 +99,9 @@ hide xlab.}
 
 \item{ylab}{character vector specifying y axis labels. Use ylab = FALSE to
 hide ylab.}
+
+\item{line.color}{color of the horizontal threshold lines (the central line
+at 0 and the two fold-change cutoff lines). Default is "black".}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-ggmaplot.R
+++ b/tests/testthat/test-ggmaplot.R
@@ -1,0 +1,12 @@
+test_that("ggmaplot line.color controls the threshold line color (#322)", {
+  data("diff_express", package = "ggpubr")
+  hline_color <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    i <- which(sapply(b$data, function(d) "yintercept" %in% names(d)))[1]
+    unique(b$data[[i]]$colour)
+  }
+  # No-regression: default threshold lines are black
+  expect_equal(hline_color(ggmaplot(diff_express)), "black")
+  # Regression: line.color changes them
+  expect_equal(hline_color(ggmaplot(diff_express, line.color = "red")), "red")
+})


### PR DESCRIPTION
## Problem
`ggmaplot()`'s threshold `geom_hline()` had a hardcoded black color (`c("black","black","black")`), so the dash-line color couldn't be changed — requested by the reporter in a comment on #322.

## Fix
Add a `line.color = "black"` argument to `ggmaplot()`, used for the central (0) line and the two fold-change cutoff lines.

- **Gated / no-regression:** default output is byte-identical — a scalar `"black"` recycles to the three lines, reproducing the old `c("black","black","black")` result (`identical()` confirmed). Linetypes `c(1,2,2)` unchanged.
- A scalar recolors all three lines; a length-3 vector recolors them individually.

## Tests
New `tests/testthat/test-ggmaplot.R`: default lines black (no-regression) and `line.color="red"` recolors (regression). Clean-session suite: **155 tests, 0 failures**.

## Docs
`man/ggmaplot.Rd` hand-edited (usage + `\item` in signature order); `tools::checkRd()` reports 0 issues. (Avoids an unrelated `RoxygenNote` version bump.)

## Review
Two independent, read-only adversarial pre-commit reviewers both returned SAFE (default byte-identical; scalar/vector recolor works; no `...`/`ggpar`/`palette`/`top` regression; doc consistent for `R CMD check`).

Fixes #322
