### PR TITLE
ggpar(): apply legend.title to size/alpha legends (Fixes #412)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,8 @@
   default (`angle = 0`) is unchanged (#595).
 - `ggmaplot()` gains a `line.color` argument to set the threshold line color;
   default ("black") is unchanged (#322).
+- `ggpar(legend.title = )` now also titles `size` and `alpha` legends, not just
+  `colour`/`fill`/`linetype`/`shape` (#412).
 
 ## Tests and docs
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -404,6 +404,8 @@ keep_only_tbl_df_classes <- function(x) {
       if ("fill" %in% used_aes) labs_args$fill <- legend.title
       if ("linetype" %in% used_aes) labs_args$linetype <- legend.title
       if ("shape" %in% used_aes) labs_args$shape <- legend.title
+      if ("size" %in% used_aes) labs_args$size <- legend.title
+      if ("alpha" %in% used_aes) labs_args$alpha <- legend.title
       if (length(labs_args) > 0) {
         p <- p + do.call(ggplot2::labs, labs_args)
       }

--- a/tests/testthat/test-ggpar-legend-title.R
+++ b/tests/testthat/test-ggpar-legend-title.R
@@ -1,0 +1,20 @@
+test_that("ggpar legend.title applies to size and alpha legends (#412)", {
+  lab <- function(p, a) ggplot2::ggplot_build(p)$plot$labels[[a]]
+
+  # Regression: legend.title now titles a size legend and an alpha legend
+  ps <- ggpar(ggscatter(mtcars, "wt", "mpg", size = "qsec"),
+              legend.title = "Size title")
+  expect_equal(lab(ps, "size"), "Size title")
+  pa <- ggpar(ggscatter(mtcars, "wt", "mpg", alpha = "qsec"),
+              legend.title = "Alpha title")
+  expect_equal(lab(pa, "alpha"), "Alpha title")
+
+  # No-regression: color aesthetic path unchanged
+  pc <- ggpar(ggscatter(mtcars, "wt", "mpg", color = "cyl"),
+              legend.title = "Color title")
+  expect_equal(lab(pc, "colour"), "Color title")
+
+  # No-regression: without legend.title the size label is untouched
+  pd <- ggscatter(mtcars, "wt", "mpg", size = "qsec")
+  expect_equal(lab(pd, "size"), "qsec")
+})


### PR DESCRIPTION
## Problem
`ggpar(legend.title = )` set the title only for `colour`/`fill`/`linetype`/`shape` legends, so a `size` or `alpha` legend (e.g. a bubble chart) kept its default variable-name title — issue #412.

## Fix
Extend the `labs_args` block in `.set_legend()` to also cover `size` and `alpha`.

- **Gated / no-regression:** the new lines only fire when `legend.title` is set AND the aesthetic is actually mapped (`used_aes` is built from real aes mappings, never static params). Without `legend.title`, or on a plot with no size/alpha aesthetic, output is byte-identical. `legend.title = ""` (hide) and the `legend.title = list(...)` form are untouched.

## Tests
New `tests/testthat/test-ggpar-legend-title.R`: size and alpha titled (regression), colour path unchanged, and default size label untouched (no-regression). Clean-session suite: **156 tests, 0 failures**.

## Review
Two independent, read-only adversarial pre-commit reviewers both returned SAFE (byte-identical skip paths verified with `options(warn=2)`; `used_aes` never fires on a static `size=`; empty/list branches intact; test revert-sensitive and `R CMD check`-clean).

Note: as with the existing colour/fill/… behavior, a plot mapping multiple aesthetics shares the single scalar `legend.title`; the `legend.title = list(...)` form remains the escape hatch for per-legend titles.

Fixes #412
