### PR TITLE
facet(): honor named panel.labs (Fixes #643)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,9 @@
   default ("black") is unchanged (#322).
 - `ggpar(legend.title = )` now also titles `size` and `alpha` legends, not just
   `colour`/`fill`/`linetype`/`shape` (#412).
+- `facet()`/`panel.labs`: a NAMED `panel.labs` vector is now matched to the data
+  levels by name, fixing mislabeled panels when the order differed; unnamed
+  labels still map positionally (#643).
 
 ## Tests and docs
 

--- a/R/facet.R
+++ b/R/facet.R
@@ -154,7 +154,16 @@ facet <- function(p, facet.by, nrow = NULL, ncol = NULL,
       )
     }
 
-    names(provided.levels) <- current.levels
+    if (!is.null(names(provided.levels)) &&
+        all(current.levels %in% names(provided.levels))) {
+      # Named labels covering every data level: match them to the levels by
+      # name, so they aren't mis-assigned when the order differs (#643).
+      provided.levels <- provided.levels[current.levels]
+    } else {
+      # Unnamed labels (or names that don't cover the levels): map positionally
+      # to the data levels, preserving the previous default behavior.
+      names(provided.levels) <- current.levels
+    }
     .labels[[variable]] <- provided.levels
   }
 

--- a/tests/testthat/test-facet-panel-labs.R
+++ b/tests/testthat/test-facet-panel-labs.R
@@ -1,0 +1,20 @@
+test_that(".create_labeller honors named panel.labs, else maps positionally (#643)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)  # levels "0.5","1","2"
+
+  # Named labels covering all levels (given in a different order) are matched by name
+  lab <- .create_labeller(df, list(dose = c("2" = "High", "0.5" = "Low", "1" = "Mid")))
+  res <- lab(data.frame(dose = factor(c("0.5", "1", "2"))))$dose
+  expect_equal(res, c("Low", "Mid", "High"))
+
+  # No-regression: UNnamed labels still map positionally
+  lab2 <- .create_labeller(df, list(dose = c("Low", "Mid", "High")))
+  res2 <- lab2(data.frame(dose = factor(c("0.5", "1", "2"))))$dose
+  expect_equal(res2, c("Low", "Mid", "High"))
+
+  # No-regression: names that do NOT cover the data levels fall back to positional
+  # (same as the previous behavior, which discarded the names)
+  lab3 <- .create_labeller(df, list(dose = c(a = "Low", b = "Mid", c = "High")))
+  res3 <- lab3(data.frame(dose = factor(c("0.5", "1", "2"))))$dose
+  expect_equal(res3, c("Low", "Mid", "High"))
+})


### PR DESCRIPTION
## Problem
`facet()`/`panel.labs`: `.create_labeller()` did `names(provided.levels) <- current.levels`, discarding any user-supplied names on a `panel.labs` vector. A **named** `panel.labs` given in a different order than the data levels was therefore mislabeled (mapped positionally) — issue #643.

## Fix
Match labels to the data levels **by name** when the vector is named *and* its names cover every level; otherwise fall back to the original positional mapping.

- **Fully no-regression:** unnamed vectors, and named vectors whose names don't cover the levels, map exactly as before (byte-identical, no new error). Only the "named vector whose names are the data levels" case changes — now honored by name.

## Tests
New `tests/testthat/test-facet-panel-labs.R`: named-reordered → correct by name (regression), unnamed → positional (no-regression), and named-not-covering → positional fallback (no-regression). Clean-session suite: **157 tests, 0 failures**.

## Review
Two independent, read-only adversarial pre-commit reviewers both returned SAFE. Each compared new output against a reconstruction of the old behavior for every input class (all byte-identical), verified the fix at the rendered strip-grob level, proved the by-name subset can't drop/dup/NA (equal-length guard + unique levels ⇒ names are a permutation), and confirmed multi-var faceting + revert-sensitive tests.

Fixes #643
