### PR TITLE
stat_compare_means(): fix error when a grouped x value is 0 (Fixes #594)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,9 @@
 - `facet()`/`panel.labs`: a NAMED `panel.labs` vector is now matched to the data
   levels by name, fixing mislabeled panels when the order differed; unnamed
   labels still map positionally (#643).
+- `stat_compare_means()` no longer fails with a "`*.npc coord ...`" error when a
+  grouped `x` value is `0` (or negative); `.group_coord()` now guards against a
+  non-positive group index and falls back to the first label coordinate (#594).
 
 ## Tests and docs
 

--- a/R/utilities_label.R
+++ b/R/utilities_label.R
@@ -99,7 +99,11 @@
 # group.id the id of groups as returned by ggplot_build()
 .group_coord <- function(coord.values, group.id) {
   if (!.is_empty(coord.values)) {
-    coord.values <- ifelse(length(coord.values) >= group.id,
+    # group.id must be a valid 1-based index; a non-positive id (e.g. when the
+    # group value is derived from an x position of 0) would make
+    # coord.values[group.id] empty and produce NA. Fall back to the first value
+    # (recycling) in that case (#594).
+    coord.values <- ifelse(length(coord.values) >= group.id & group.id > 0,
       coord.values[group.id], coord.values[1]
     )
   }

--- a/tests/testthat/test-group-coord-zero-id.R
+++ b/tests/testthat/test-group-coord-zero-id.R
@@ -1,0 +1,40 @@
+# Regression tests for #594: stat_compare_means() failed when the grouped x
+# value was 0 (or <= 0), because that value was used as a 1-based group index
+# in .group_coord(), yielding coord.values[0] -> NA and a downstream
+# ".npc coord ... should be ..." error.
+
+test_that(".group_coord falls back to the first value for a non-positive id (#594)", {
+  # group.id = 0 must not produce NA; it recycles to the first coord value.
+  expect_equal(ggpubr:::.group_coord("left", 0), "left")
+  expect_equal(ggpubr:::.group_coord(c("left", "right"), 0), "left")
+  expect_equal(ggpubr:::.group_coord(c(0, 3), 0), 0)
+})
+
+test_that(".group_coord is unchanged for valid 1-based ids (no regression, #594)", {
+  # Every previously-working id (>= 1) behaves exactly as before.
+  expect_equal(ggpubr:::.group_coord(c("a", "b", "c"), 1), "a")
+  expect_equal(ggpubr:::.group_coord(c("a", "b", "c"), 2), "b")
+  expect_equal(ggpubr:::.group_coord(c("a", "b", "c"), 3), "c")
+  # id longer than the vector recycles to the first value (unchanged behavior).
+  expect_equal(ggpubr:::.group_coord(c("a", "b"), 3), "a")
+  # empty coord values pass through untouched.
+  expect_equal(ggpubr:::.group_coord(NULL, 0), NULL)
+})
+
+test_that("stat_compare_means() renders when a grouped x value is 0 (#594)", {
+  data <- data.frame(
+    x = c(0, 0, 0, 0, 3, 3, 3, 3, 0, 0, 0, 0, 3, 3, 3, 3),
+    y = c(1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8,
+          1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8),
+    group = rep(c("A", "B"), each = 8)
+  )
+  p <- ggplot2::ggplot(data, ggplot2::aes(x = x, y = y, color = group)) +
+    ggplot2::geom_point() +
+    stat_compare_means(label = "p.signif")
+  # Full render (not just build) so any draw-time error surfaces; must not warn
+  # with the "Computation failed" message the bug produced.
+  expect_no_warning(
+    grob <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+  )
+  expect_s3_class(grob, "gtable")
+})


### PR DESCRIPTION
## Problem
`stat_compare_means()` fails with

> Computation failed in `stat_compare_means()`. Caused by error in `.check_npc_coord()`: '*.npc coord for x axis should be either a numeric value in [0-1] or a character strings ...'

whenever a grouped `x` value is `0` (any x that resolves to a non-positive group index) — issue #594, reported with an exact repro.

## Root cause
The multiple-grouping-vars branch in `R/stat_compare_means.R` passes `group.ids = .test$x` (the x **data value**) as a 1-based group index into `.group_coord(coord.values, group.id)`. When `x = 0`, `group.id = 0`, so `coord.values[0]` is empty and `ifelse(length(coord.values) >= 0, coord.values[0], coord.values[1])` returns `NA`, which `.check_npc_coord()` rejects.

## Fix
Guard `.group_coord()` so a non-positive `group.id` falls back to the first coordinate (recycling):

```r
ifelse(length(coord.values) >= group.id & group.id > 0,
       coord.values[group.id], coord.values[1])
```

**Fully no-regression:** for every `group.id >= 1` (all currently-working calls) the added conjunct is always TRUE, so the result is byte-identical to before. Only the previously-erroring `group.id <= 0` path changes (from `NA` → first coordinate).

## Tests
New `tests/testthat/test-group-coord-zero-id.R`: unit asserts that a non-positive id recycles to the first value (regression), that ids `>= 1` are unchanged incl. recycling (no-regression), and a full-render test of the #594 repro that must not warn. Clean-session suite: **434 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both reconstructed the old `.group_coord` and compared outputs across a `group.id ∈ {-2..3}` × varied-`coord.values` grid — byte-identical for every `group.id >= 1`, differing only in the already-broken `<= 0` domain. One further confirmed the multiple-grouping path sets `.by = "panel"`, which overrides hjust/vjust to 0.5, so `group.id = 0` cannot corrupt label positioning downstream either. Repro verified by full `ggplot_gtable` render (not just build).

Fixes #594
