### PR TITLE
ggpar(): apply xticks.by and yticks.by together (Fixes #333)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@
 - `stat_compare_means()` no longer fails with a "`*.npc coord ...`" error when a
   grouped `x` value is `0` (or negative); `.group_coord()` now guards against a
   non-positive group index and falls back to the first label coordinate (#594).
+- `ggpar()`/plot functions now apply `xticks.by` and `yticks.by` together; an
+  internal `else if` previously dropped `xticks.by` whenever `yticks.by` was
+  also supplied (#333).
 
 ## Tests and docs
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -432,6 +432,8 @@ keep_only_tbl_df_classes <- function(x) {
 # Set ticks by
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 .set_ticksby <- function(p, xticks.by = NULL, yticks.by = NULL) {
+  # x and y must be handled independently: an `else if` here dropped xticks.by
+  # whenever yticks.by was also supplied (#333).
   if (!is.null(yticks.by)) {
     # Forcing ymin to start at 0 when distribution plot
     gg_mapping <- .get_gg_xy_variables(p)
@@ -439,10 +441,28 @@ keep_only_tbl_df_classes <- function(x) {
     ymin <- NULL
     if (is_density_plot) ymin <- 0
     p <- p + scale_y_continuous(breaks = get_breaks(by = yticks.by, from = ymin))
-  } else if (!is.null(xticks.by)) {
+  }
+  # Skip xticks.by only when x is discrete: adding scale_x_continuous() to a
+  # discrete x (e.g. ggboxplot) errors at draw time, so a discrete x keeps its
+  # default axis (as it silently did when xticks.by was combined with yticks.by
+  # before this fix). Every non-discrete x (numeric, integer, Date, POSIXct)
+  # still receives the continuous scale exactly as before (#333).
+  if (!is.null(xticks.by) && !.is_discrete_x(p)) {
     p <- p + scale_x_continuous(breaks = get_breaks(by = xticks.by))
   }
   p
+}
+
+# TRUE when the plot's x aesthetic resolves to discrete data (factor, character
+# or logical), for which a continuous x scale cannot be applied. Falls back to
+# FALSE (treat as continuous, i.e. apply the scale as before) if x cannot be
+# evaluated, so behavior for non-discrete x is unchanged from previous versions.
+.is_discrete_x <- function(p) {
+  x_data <- tryCatch(
+    rlang::eval_tidy(p$mapping$x, p$data),
+    error = function(e) NULL
+  )
+  is.factor(x_data) || is.character(x_data) || is.logical(x_data)
 }
 
 

--- a/tests/testthat/test-set-ticksby.R
+++ b/tests/testthat/test-set-ticksby.R
@@ -1,0 +1,62 @@
+# Regression tests for #333: when BOTH xticks.by and yticks.by were supplied,
+# .set_ticksby() used an `else if`, so xticks.by was silently ignored.
+
+.x_breaks <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  stats::na.omit(b$layout$panel_params[[1]]$x$breaks)
+}
+.y_breaks <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  stats::na.omit(b$layout$panel_params[[1]]$y$breaks)
+}
+
+test_that("xticks.by and yticks.by both apply when supplied together (#333)", {
+  p <- ggscatter(iris, x = "Sepal.Length", y = "Sepal.Width",
+                 xticks.by = 0.5, yticks.by = 0.5)
+  xb <- .x_breaks(p)
+  yb <- .y_breaks(p)
+  # 0.5 spacing on both axes
+  expect_true(all(abs(diff(xb) - 0.5) < 1e-8))
+  expect_true(all(abs(diff(yb) - 0.5) < 1e-8))
+})
+
+test_that("xticks.by alone is unchanged (no regression, #333)", {
+  p_both  <- ggscatter(iris, x = "Sepal.Length", y = "Sepal.Width", xticks.by = 0.5)
+  xb <- .x_breaks(p_both)
+  expect_true(all(abs(diff(xb) - 0.5) < 1e-8))
+})
+
+test_that("yticks.by alone is unchanged (no regression, #333)", {
+  p <- ggscatter(iris, x = "Sepal.Length", y = "Sepal.Width", yticks.by = 0.5)
+  yb <- .y_breaks(p)
+  expect_true(all(abs(diff(yb) - 0.5) < 1e-8))
+  # x axis keeps ggplot2 default breaks (integers here), i.e. NOT 0.5-spaced
+  xb <- .x_breaks(p)
+  expect_false(isTRUE(all(abs(diff(xb) - 0.5) < 1e-8)))
+})
+
+test_that("xticks.by on a discrete x axis does not error, yticks.by still applies (#333)", {
+  # ggboxplot has a discrete x: applying a continuous x scale would error, so
+  # xticks.by is skipped (as it was silently before), while yticks.by still
+  # works. Must RENDER (draw-time), not just build.
+  p <- ggboxplot(ToothGrowth, x = "supp", y = "len",
+                 xticks.by = 1, yticks.by = 5)
+  expect_no_error(grob <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  expect_s3_class(grob, "gtable")
+  yb <- .y_breaks(p)
+  expect_true(all(abs(diff(yb) - 5) < 1e-8))
+})
+
+test_that(".is_discrete_x detects discrete vs continuous x (#333)", {
+  # numeric x -> continuous -> not discrete
+  expect_false(ggpubr:::.is_discrete_x(
+    ggscatter(iris, x = "Sepal.Length", y = "Sepal.Width")))
+  # factor x -> discrete
+  expect_true(ggpubr:::.is_discrete_x(
+    ggboxplot(ToothGrowth, x = "supp", y = "len")))
+  # Date x is continuous (numeric storage) -> not discrete, so xticks.by still
+  # applies exactly as in previous versions.
+  df <- data.frame(d = as.Date("2020-01-01") + 0:9, y = seq_len(10))
+  pd <- ggplot2::ggplot(df, ggplot2::aes(x = d, y = y)) + ggplot2::geom_point()
+  expect_false(ggpubr:::.is_discrete_x(pd))
+})


### PR DESCRIPTION
## Problem
`ggscatter(..., xticks.by = 0.2, yticks.by = 0.2)` ignored `xticks.by` — the x-axis kept ggplot2's default breaks while the y-axis honored `yticks.by` (issue #333, reported with `iris`).

## Root cause
`.set_ticksby()` (in `R/utilities.R`) used

```r
if (!is.null(yticks.by)) { ... } else if (!is.null(xticks.by)) { ... }
```

so the `else if` never ran when **both** args were supplied, dropping `xticks.by`.

## Fix
Split into two independent `if` blocks. The x branch is gated by a new `.is_discrete_x()` helper so `scale_x_continuous()` is applied only when x is **non-discrete** (numeric, integer, Date, POSIXct, …). A discrete x (e.g. `ggboxplot`/`ggbarplot`) keeps its default axis — because adding a continuous scale to a discrete x errors at draw time, and that is exactly what the old `else if` did (silently skip x) when `xticks.by` was combined with `yticks.by`.

**Fully no-regression:** every input that rendered on master renders identically (verified by reconstructing the old `.set_ticksby` and diffing x/y breaks + render for scatter neither/x-only/y-only/both, discrete-x both & x-only, histogram, and Date x). Only the both-set continuous-x case changes — now `xticks.by` is honored. As a bonus, the same latent bug in `gghistogram` and a discrete-x-only crash are also fixed.

## Tests
New `tests/testthat/test-set-ticksby.R`: both-axes-apply (regression), single-axis unchanged (no-regression), discrete-x renders without error while `yticks.by` still applies (no-regression), and `.is_discrete_x` unit checks incl. Date-x-is-continuous. Clean-session suite: **445 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers signed off SAFE on this exact diff. An earlier round caught a real regression (discrete-x + both-args erroring where master rendered); the `.is_discrete_x` gate fixes it so discrete-x plots are byte-identical to master. The only remaining behavioral delta both reviewers surfaced is the semantically-meaningless "logical x + `xticks.by` only" edge (where master was itself inconsistent) — dismissible, no realistic user path.

Fixes #333
