### PR TITLE
stat_compare_means(): forward family to comparison brackets (Fixes #592, #624)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,9 @@
 - `ggpar()`/plot functions now apply `xticks.by` and `yticks.by` together; an
   internal `else if` previously dropped `xticks.by` whenever `yticks.by` was
   also supplied (#333).
+- `stat_compare_means()` now forwards the `family` argument to the comparison
+  bracket labels; it was previously ignored whenever `comparisons` was set
+  (#592, #624).
 
 ## Tests and docs
 

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -185,6 +185,9 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
     pms <- list(...)
     size <- ifelse(is.null(pms$size), 3.88, pms$size)
     color <- ifelse(is.null(pms$color), "black", pms$color)
+    # Forward the font family to the bracket labels; without this it was dropped
+    # in the comparisons path while it worked in the default path (#592, #624).
+    family <- ifelse(is.null(pms$family), "", pms$family)
 
     if (is.null(label)) {
       mapped_label <- .get_stat_compare_means_label_from_mapping(mapping)
@@ -208,6 +211,7 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
       comparisons = comparisons, y_position = label.y,
       test = method, test.args = method.args,
       step_increase = step.increase, size = bracket.size, textsize = size, color = color,
+      family = family,
       map_signif_level = map_signif_level, tip_length = tip.length,
       data = data, vjust = vjust
     )

--- a/tests/testthat/test-compare-means-family.R
+++ b/tests/testthat/test-compare-means-family.R
@@ -1,0 +1,38 @@
+# Regression tests for #592 / #624: stat_compare_means(family = ...) was ignored
+# when `comparisons` was set (the comparisons path delegates to
+# ggsignif::geom_signif and did not forward `family`).
+
+.text_family <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  fam <- character(0)
+  for (i in seq_along(b$data)) {
+    d <- b$data[[i]]
+    if ("family" %in% names(d)) fam <- c(fam, unique(as.character(d$family)))
+  }
+  fam
+}
+
+cmp <- list(c("0.5", "1"), c("1", "2"))
+
+test_that("family is forwarded to comparison brackets (#592, #624)", {
+  p <- ggboxplot(ToothGrowth, x = "dose", y = "len") +
+    stat_compare_means(comparisons = cmp, method = "t.test", family = "mono")
+  expect_true("mono" %in% .text_family(p))
+  # renders at draw time
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})
+
+test_that("default family is unchanged when comparisons set (no regression, #592)", {
+  p <- ggboxplot(ToothGrowth, x = "dose", y = "len") +
+    stat_compare_means(comparisons = cmp, method = "t.test")
+  fam <- .text_family(p)
+  # No non-empty family is forced onto the labels (ggsignif default is "").
+  expect_true(length(fam) == 0 || all(fam == ""))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})
+
+test_that("family still works in the non-comparisons path (no regression, #592)", {
+  p <- ggboxplot(ToothGrowth, x = "dose", y = "len") +
+    stat_compare_means(method = "t.test", family = "mono")
+  expect_true("mono" %in% .text_family(p))
+})


### PR DESCRIPTION
## Problem
`stat_compare_means(..., family = "Times New Roman")` (or any font) was **ignored** whenever the `comparisons` argument was set — the bracket p-value labels kept the default font. Without `comparisons`, `family` worked. Reported in #592 and #624 (duplicates).

## Root cause
In `R/stat_compare_means.R`, the `if (!is.null(comparisons))` branch delegates to `ggsignif::geom_signif()` and forwarded only `size` and `color` from `...` — never `family`.

## Fix
Extract `family` from `...` (default `""`, mirroring the adjacent `size`/`color` lines) and pass `family = family` to `geom_signif()`. `geom_signif()` has a `family` formal (default `""`) and `GeomSignif` carries `family` in its `default_aes`, so this reaches the label grob.

**Fully no-regression:** when `family` is not supplied it resolves to `""`, which is `geom_signif`'s own default — so the built layer is byte-identical to before (verified with `identical()` against a `geom_signif` call with no `family`).

## Tests
New `tests/testthat/test-compare-means-family.R`: family forwarded to brackets (regression), default family unchanged with comparisons (no-regression), family still works in the non-comparisons path (no-regression). Uses `method = "t.test"` to avoid unrelated wilcox tie warnings; asserts the `family` aesthetic value in built data (no installed-font dependency). Clean-session suite: **450 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both proved the default-font case is byte-identical to master, confirmed the fix works for `family="serif"`/`"mono"`, verified there is no double-pass of `family` into `geom_signif` (the call lists explicit args and does not spread `...`), and that the tests are revert-sensitive and CI-safe. Visually verified: comparison-bracket labels render in serif vs the default sans.

Fixes #592
Fixes #624
