### PR TITLE
ggline(): support two grouping variables (Fixes #616, #375)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,10 @@
 - `stat_compare_means()` now forwards the `family` argument to the comparison
   bracket labels; it was previously ignored whenever `comparisons` was set
   (#592, #624).
+- `ggline()` now supports two grouping variables at once (e.g. `color` and
+  `linetype`, or an explicit `group` plus `color`); these are combined into a
+  single interaction group so the right points are connected. Previously this
+  errored with "the condition has length > 1" (#616, #375).
 
 ## Tests and docs
 

--- a/R/ggline.R
+++ b/R/ggline.R
@@ -280,11 +280,40 @@ ggline_core <- function(data, x, y, group = 1,
     data_sum <- data
   }
 
+  # Remember whether the user supplied an explicit grouping variable (a data
+  # column, not the default group = 1). Following ggplot2 semantics, an explicit
+  # group takes precedence over aesthetic-derived grouping (see below).
+  explicit.group <- if (length(group) == 1 && is.character(group) &&
+    group %in% names(data)) {
+    group
+  } else {
+    NULL
+  }
+
   .cols <- unique(c(color, linetype, group))
   if (any(.cols %in% names(data))) {
     .in <- which(.cols %in% names(data))
     group <- .cols[.in]
     if (is.null(add.params$group)) add.params$group <- group[1]
+  }
+
+  # When several variables define the grouping (e.g. color and linetype map to
+  # different columns), a length > 1 group aesthetic otherwise errored (#616,
+  # #375). Resolve to a single group column, matching ggplot2:
+  #  - an explicit `group` variable takes precedence (group by it alone);
+  #  - otherwise combine the aesthetic variables into one interaction group so
+  #    the right points are connected.
+  # The single-variable case is unchanged (group stays length 1).
+  if (length(group) > 1) {
+    if (!is.null(explicit.group)) {
+      group <- explicit.group
+    } else {
+      data_sum[[".ggpubr.group"]] <- do.call(
+        interaction,
+        c(data_sum[group], list(drop = TRUE, lex.order = TRUE))
+      )
+      group <- ".ggpubr.group"
+    }
   }
 
   p <- ggplot(data, create_aes(list(x = x, y = y)))

--- a/tests/testthat/test-ggline-multi-group.R
+++ b/tests/testthat/test-ggline-multi-group.R
@@ -1,0 +1,71 @@
+# Regression tests for #616 / #375: ggline() errored ("condition has length > 1")
+# when two different variables defined the grouping (e.g. color + linetype, or an
+# explicit group + color), because the internal `group` became a length-2 vector.
+
+.n_line_groups <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  # the line layer carries both a group column and >2 rows per line
+  idx <- which(vapply(b$data, function(d)
+    all(c("group", "linetype") %in% names(d)) && nrow(d) > 2, logical(1)))
+  length(unique(b$data[[idx[1]]]$group))
+}
+
+test_that("ggline() combines color + linetype into one grouping (#616)", {
+  set.seed(1)
+  data <- data.frame(
+    x = rep(seq(0, 1, length.out = 10), 4),
+    type  = rep(c("poly", "poly", "inv", "inv"), each = 10),
+    order = rep(c("low", "high", "low", "high"), each = 10)
+  )
+  data$val <- data$x + as.integer(factor(paste(data$type, data$order)))
+  p <- ggline(data, x = "x", y = "val", linetype = "type", color = "order",
+              numeric.x.axis = TRUE)
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  # 2 types x 2 orders = 4 lines, matching geom_line(aes(linetype=, color=))
+  expect_equal(.n_line_groups(p), 4L)
+})
+
+test_that("ggline() supports explicit group + color (#375)", {
+  df2 <- data.frame(
+    supp = rep(c("VC", "OJ", "VC"), each = 3),
+    dose = rep(c("D0.5", "D1", "D2"), 3),
+    len  = c(6.8, 15, 33, 4.2, 10, 29.5, 12, 6, 14.2),
+    num  = as.character(rep(1:3, each = 3))
+  )
+  p <- ggline(df2, "dose", "len", group = "num", color = "supp")
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  # 3 num groups (matching geom_line(aes(group=num, color=supp)))
+  expect_equal(.n_line_groups(p), 3L)
+})
+
+test_that("ggline() explicit group takes precedence over color (#375)", {
+  # supp appears with BOTH num values (full factorial): an explicit group must
+  # group by `num` ALONE (matching geom_line(aes(group=num, color=supp))), not
+  # by interaction(supp, num).
+  dfe <- data.frame(
+    dose = rep(c("D0.5", "D1", "D2"), 4),
+    num  = as.character(rep(c(1, 1, 2, 2), each = 3)),
+    supp = rep(c("VC", "OJ"), times = 6),
+    len  = 1:12
+  )
+  p <- ggline(dfe, "dose", "len", group = "num", color = "supp")
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  # 2 num groups, NOT 4 interaction groups
+  expect_equal(.n_line_groups(p), 2L)
+  # matches geom_line's explicit-group grouping
+  gl <- ggplot2::ggplot_build(
+    ggplot2::ggplot(dfe, ggplot2::aes(dose, len, group = num, color = supp)) +
+      ggplot2::geom_line()
+  )
+  expect_equal(.n_line_groups(p), length(unique(gl$data[[1]]$group)))
+})
+
+test_that("ggline() single grouping variable is unchanged (no regression, #616)", {
+  p <- ggline(ToothGrowth, x = "dose", y = "len", color = "supp", add = "mean_se")
+  b <- ggplot2::ggplot_build(p)
+  # the new .ggpubr.group column must NOT be introduced in the single-var path
+  expect_false(any(vapply(b$data,
+    function(d) ".ggpubr.group" %in% names(d), logical(1))))
+  expect_no_error(ggplot2::ggplot_gtable(b))
+  expect_equal(.n_line_groups(p), 2L)
+})


### PR DESCRIPTION
## Problem
`ggline()` errored with `the condition has length > 1` whenever **two different variables** defined the grouping:

- `ggline(data, x, y, linetype = "type", color = "order")` — two aesthetics (#616)
- `ggline(df2, "dose", "len", group = "num", color = "supp")` — explicit `group` + `color` (#375)

The equivalent `geom_line(aes(...))` works. Internally, `group` became a length-2 character vector, which broke `create_aes()`/`is_parsable_aes()`.

## Fix
Resolve the grouping to a **single** group column, matching ggplot2 semantics:

- an **explicit** `group` variable takes precedence (group by it alone);
- otherwise the aesthetic variables (e.g. `color` + `linetype`) are combined into one `interaction()` group so the right points are connected.

**Fully no-regression:** the new branch fires only when ≥ 2 *distinct* grouping columns are supplied — which always errored before — so every single-variable call is byte-identical (the added blocks are provable no-ops when `group` is length 1).

Verified to match `geom_line()`'s grouping exactly:
- #616 (color + linetype) → 4 line groups = `geom_line`
- #375 nested data → 3 groups = `geom_line`
- factorial edge (color varies within an explicit group) → 2 groups = `geom_line` (explicit `group` wins; not `interaction(color, group)`)

## Tests
New `tests/testthat/test-ggline-multi-group.R`: color+linetype combine (#616), explicit group+color (#375), explicit-group precedence on a full-factorial edge case (asserts 2 groups, cross-checked against `geom_line`), and a single-variable no-regression test asserting the synthetic `.ggpubr.group` column is never introduced. Clean-session suite: **460 tests, 0 failures**.

## Review
Reviewed over two rounds by independent read-only adversarial reviewers. The first round caught a real blocker: the initial version combined ALL grouping columns, which over-split lines when an explicit `group` was combined with a color varying within it (4 vs `geom_line`'s 2). The fix now gives explicit `group` precedence; two final reviewers both returned SAFE, confirming the blocker is fixed, `geom_line` parity across all cases, and zero regression (branch is a no-op for length-1 group). Visually verified for both issues.

Fixes #616
Fixes #375
