### PR TITLE
ggpar(): silence spurious named-palette warning (Fixes #642)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,11 @@
   `linetype`, or an explicit `group` plus `color`); these are combined into a
   single interaction group so the right points are connected. Previously this
   errored with "the condition has length > 1" (#616, #375).
+- A NAMED `palette` vector no longer emits a spurious "No shared levels found
+  between `names(values)` ..." warning; the manual color/fill scale is now only
+  applied to an aesthetic actually mapped in the plot. Unnamed palettes are
+  unchanged, and a named palette whose names genuinely don't match still warns
+  (#642).
 
 ## Tests and docs
 

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -189,8 +189,7 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
   for (i in seq_along(list.plots)) {
     p <- list.plots[[i]]
     if (is_ggplot(p)) {
-      p <- p + .ggcolor(palette) +
-        .ggfill(palette)
+      p <- .apply_palette(p, palette)
       if (!is.null(ggtheme)) p <- p + ggtheme # labs_pubr() +
       if (!is.null(gradient.cols)) p <- p + .gradient_col(gradient.cols)
 

--- a/R/utilities_color.R
+++ b/R/utilities_color.R
@@ -44,6 +44,34 @@
   fill_palette(palette = palette, ...)
 }
 
+# Aesthetics mapped in a plot (plot-level + all layer-level mappings)
+.mapped_aesthetics <- function(p) {
+  used <- names(p$mapping)
+  for (layer in p$layers) {
+    used <- c(used, names(layer$mapping))
+  }
+  unique(used)
+}
+
+# Apply the color/fill palette to a plot.
+# For an UNNAMED palette (or NULL) the previous behavior is preserved exactly:
+# both the color and fill scales are added. For a NAMED palette, the manual
+# scale is only added for an aesthetic actually mapped in the plot -- adding
+# scale_color/fill_manual() with named values to an aesthetic whose data has
+# none of those names raises a spurious "No shared levels found ..." warning at
+# draw time (#642).
+.apply_palette <- function(p, palette) {
+  is_named_palette <- !is.null(palette) &&
+    !is.null(names(palette)) && any(nzchar(names(palette)))
+  if (!is_named_palette) {
+    return(p + .ggcolor(palette) + .ggfill(palette))
+  }
+  used <- .mapped_aesthetics(p)
+  if (any(c("colour", "color") %in% used)) p <- p + .ggcolor(palette)
+  if ("fill" %in% used) p <- p + .ggfill(palette)
+  p
+}
+
 
 # Helper function to use palette from ggsci package
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tests/testthat/test-named-palette.R
+++ b/tests/testthat/test-named-palette.R
@@ -1,0 +1,51 @@
+# Regression tests for #642: a NAMED palette vector triggered a spurious
+# "No shared levels found between `names(values)` ..." warning at draw time,
+# because ggpar() applied BOTH scale_color_manual and scale_fill_manual even
+# when only one of color/fill was mapped to a variable.
+
+.build_warnings <- function(p) {
+  ws <- character(0)
+  withCallingHandlers(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)),
+    warning = function(w) {
+      ws[[length(ws) + 1]] <<- conditionMessage(w)
+      invokeRestart("muffleWarning")
+    }
+  )
+  ws
+}
+.no_shared <- "No shared levels"
+
+test_that("named palette on a fill-only plot does not warn (#642)", {
+  df <- data.frame(prop = c(0.4, 0.6),
+                   my_categories = c("X", "Y"), label = c("40%", "60%"))
+  pal <- c("X" = "red", "Y" = "blue")
+  p <- ggpie(df, "prop", fill = "my_categories", label = "label", palette = pal)
+  expect_false(any(grepl(.no_shared, .build_warnings(p))))
+  # fill colors are still applied by name
+  fills <- unique(ggplot2::ggplot_build(p)$data[[1]]$fill)
+  expect_setequal(fills, c("red", "blue"))
+})
+
+test_that("named palette on a color-only plot does not warn (#642)", {
+  p <- ggline(ToothGrowth, "dose", "len", color = "supp",
+              palette = c("OJ" = "red", "VC" = "blue"))
+  expect_false(any(grepl(.no_shared, .build_warnings(p))))
+})
+
+test_that("unnamed palette keeps applying both color and fill (no regression, #642)", {
+  # boxplot with color mapped: unnamed palette must still color it
+  p <- ggboxplot(ToothGrowth, "dose", "len", color = "supp",
+                 palette = c("red", "blue"))
+  expect_false(any(grepl(.no_shared, .build_warnings(p))))
+  cols <- unique(ggplot2::ggplot_build(p)$data[[1]]$colour)
+  expect_setequal(cols, c("red", "blue"))
+})
+
+test_that("named palette with non-matching names still warns (#642)", {
+  # user-supplied names genuinely don't match the data -> ggplot2's warning is
+  # legitimate and must be preserved.
+  p <- ggboxplot(ToothGrowth, "dose", "len", fill = "supp",
+                 palette = c("A" = "red", "B" = "blue"))
+  expect_true(any(grepl(.no_shared, .build_warnings(p))))
+})


### PR DESCRIPTION
## Problem
A **named** `palette` vector produced a spurious warning at draw time:

> No shared levels found between `names(values)` of the manual scale and the data's colour values.

e.g. `ggpie(df, "prop", fill = "my_categories", label = "label", palette = c("X" = "red", "Y" = "blue"))`. The plot rendered fine, but the warning was confusing.

## Root cause
`ggpar()` unconditionally added BOTH `scale_color_manual(values = palette)` and `scale_fill_manual(values = palette)`. For a fill-only plot, the color scale received the named values but the colour aesthetic wasn't mapped to a variable → no shared levels → ggplot2 warns.

## Fix
New `.apply_palette(p, palette)`:
- **Unnamed palette / `NULL`** (the common case — `c("red","blue")`, `"jco"`, `"Blues"`, numeric): unchanged — both scales added, byte-identical to before.
- **Named palette**: the manual scale is added only for an aesthetic actually mapped in the plot (`names(p$mapping)` + layer mappings). So a fill-only plot gets only the fill scale; a color-only plot only the color scale.

A named palette whose names **genuinely don't match** the data still warns (that warning is legitimate).

## Tests
New `tests/testthat/test-named-palette.R`: named palette on a fill-only plot doesn't warn and still colors by name (regression); named palette on a color-only plot doesn't warn; unnamed palette still colors both (no-regression); non-matching names still warn (preserve legitimate warning). Clean-session suite: **466 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. One compared the new `.apply_palette` against a faithful reconstruction of the old `p + .ggcolor + .ggfill` across **12 plot functions** (ggboxplot color & fill, ggviolin, ggbarplot, ggline, ggdotplot, gghistogram, ggstripchart, ggscatter, ggpie, ggdonutchart) — every mapped aesthetic gets byte-identical colors, and the warning fired only in the old path. Unnamed/NULL/brewer/ggsci/numeric palettes are provably unchanged.

Fixes #642
