### PR TITLE
ggviolin(): fix crash with scales='free' (Fixes #398)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,10 @@
   applied to an aesthetic actually mapped in the plot. Unnamed palettes are
   unchanged, and a named palette whose names genuinely don't match still warns
   (#642).
+- `ggviolin()` no longer crashes with `scales = "free"` (or `"free_x"`/`"free_y"`).
+  The facet argument `scales` was being partial-matched to the violin `scale`
+  parameter; it is now read with exact matching, so `scales` controls faceting
+  and the violin `scale` keeps its default (#398).
 
 ## Tests and docs
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -126,11 +126,14 @@ keep_only_tbl_df_classes <- function(x) {
 .violin_params <- function(...) {
   x <- list(...)
   res <- list()
-  res$stat <- ifelse(!is.null(x$stat), x$stat, "ydensity")
-  res$draw_quantiles <- x$draw_quantiles
-  res$scale <- ifelse(!is.null(x$scale), x$scale, "area")
-  res$trim <- ifelse(!is.null(x$trim), x$trim, TRUE)
-  res$adjust <- x$adjust # Bandwidth adjustment for kernel density (Issue #552)
+  # Use exact ([[) matching, not $, so a facet argument like scales = "free"
+  # is not partial-matched to the violin `scale` parameter (which would set an
+  # invalid scale and crash geom_violin at draw time, #398).
+  res$stat <- ifelse(!is.null(x[["stat"]]), x[["stat"]], "ydensity")
+  res$draw_quantiles <- x[["draw_quantiles"]]
+  res$scale <- ifelse(!is.null(x[["scale"]]), x[["scale"]], "area")
+  res$trim <- ifelse(!is.null(x[["trim"]]), x[["trim"]], TRUE)
+  res$adjust <- x[["adjust"]] # Bandwidth adjustment for kernel density (Issue #552)
   return(res)
 }
 

--- a/tests/testthat/test-ggviolin-scales.R
+++ b/tests/testthat/test-ggviolin-scales.R
@@ -1,0 +1,37 @@
+# Regression tests for #398: ggviolin(scales = "free") crashed at draw time
+# ("object 'violinwidth' not found") because .violin_params() used `$`, which
+# partial-matched the facet argument `scales` to the violin `scale` parameter,
+# setting an invalid scale = "free".
+
+test_that("ggviolin() with scales='free' renders (no crash) (#398)", {
+  expect_no_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      ggviolin(ToothGrowth, x = "dose", y = "len", scales = "free")
+    ))
+  )
+  # violinwidth must be computed (its absence caused the crash)
+  d <- ggplot2::ggplot_build(
+    ggviolin(ToothGrowth, x = "dose", y = "len", scales = "free"))$data[[1]]
+  expect_true("violinwidth" %in% names(d))
+})
+
+test_that("ggviolin() scales='free' reaches faceting, not the violin scale (#398)", {
+  p <- ggviolin(iris, x = "Species", y = "Sepal.Length",
+                facet.by = "Species", scales = "free")
+  b <- ggplot2::ggplot_build(p)
+  expect_true(isTRUE(b$layout$facet$params$free$x))
+  expect_true(isTRUE(b$layout$facet$params$free$y))
+  # the violin scale itself stays at its default, NOT "free"
+  expect_equal(p$layers[[1]]$stat_params$scale, "area")
+})
+
+test_that("ggviolin() explicit scale= is still honored (no regression, #398)", {
+  expect_equal(
+    ggviolin(ToothGrowth, x = "dose", y = "len", scale = "count")$layers[[1]]$stat_params$scale,
+    "count"
+  )
+  expect_equal(
+    ggviolin(ToothGrowth, x = "dose", y = "len")$layers[[1]]$stat_params$scale,
+    "area"
+  )
+})


### PR DESCRIPTION
## Problem
`ggviolin(ToothGrowth, y = "len", scales = "free")` (also `"free_x"`/`"free_y"`) crashed at draw time:

> Error ... object 'violinwidth' not found  ·  "Problem while converting geom to grob"

## Root cause
`.violin_params(...)` read parameters with `$`, which does **partial matching** on lists: `list(scales = "free")$scale` returns `"free"`. That set the violin `scale` parameter to `"free"` (valid values: `area`/`count`/`width`), so `StatYdensity` never produced the `violinwidth` column that `GeomViolin` needs → draw crash. `scales` is a **facet** argument and must not be read as the violin `scale`.

## Fix
Use exact `[[` matching in `.violin_params()`, so `scales` is never mistaken for `scale`. Now:
- `scales = "free"` correctly drives faceting (verified: `layout$facet$params$free$x/$y == TRUE`), and the violin `scale` keeps its default `"area"`.
- explicit `scale = "count"` (and `trim`, `adjust`, `stat`) are still honored — no regression.

## Tests
New `tests/testthat/test-ggviolin-scales.R`: renders without crash and computes `violinwidth` (regression); `scales="free"` reaches faceting while the violin scale stays `"area"`; explicit `scale="count"`/default `"area"` honored (no-regression). Clean-session suite: **473 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed all four `scales` variants render with `violinwidth` present, that `scales` reaches faceting (not the violin scale), that the `$`→`[[` change preserves every explicit/default parameter, and that the tests are revert-sensitive and CI-safe.

Fixes #398
