### PR TITLE
ggpar(): honor xlim/ylim with orientation='horizontal' (Fixes #646)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,10 @@
   The facet argument `scales` was being partial-matched to the violin `scale`
   parameter; it is now read with exact matching, so `scales` controls faceting
   and the violin `scale` keeps its default (#398).
+- `xlim`/`ylim` are now honored with `orientation = "horizontal"` (and
+  `rotate = TRUE`). The limits are passed to `coord_flip()` instead of a separate
+  `coord_cartesian()` that was silently replaced, which also removes the
+  "Coordinate system already present" warning (#646).
 
 ## Tests and docs
 

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -171,6 +171,7 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
                   ...) {
   original.p <- p
   if (rotate) orientation <- "horizontal"
+  orientation <- match.arg(orientation, c("vertical", "horizontal", "reverse"))
 
   if (is_ggplot(original.p)) {
     list.plots <- list(original.p)
@@ -198,14 +199,17 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
         font.xtickslab = font.xtickslab, font.ytickslab = font.ytickslab
       )
       p <- .set_ticksby(p, xticks.by, yticks.by)
-      p <- p + .set_axis_limits(xlim, ylim)
+      # For horizontal orientation the limits are passed to coord_flip() below;
+      # adding coord_cartesian() here would be replaced by coord_flip(), dropping
+      # the limits and warning about two coordinate systems (#646).
+      if (orientation != "horizontal") p <- p + .set_axis_limits(xlim, ylim)
       p <- .set_legend(p, legend, legend.title, font.legend)
       p <- .set_scale(p, xscale = xscale, yscale = yscale, format.scale = format.scale)
       p <- .labs(p, main, xlab, ylab,
         font.main, font.x, font.y,
         submain = submain, caption = caption, font.submain = font.submain, font.caption = font.caption
       )
-      p <- .set_orientation(p, orientation)
+      p <- .set_orientation(p, orientation, xlim = xlim, ylim = ylim)
       if (font.family != "") {
         p <- p + theme(text = element_text(family = font.family))
       }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -165,10 +165,14 @@ keep_only_tbl_df_classes <- function(x) {
 # Set plot orientation
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 .set_orientation <-
-  function(p, orientation = c("vertical", "horizontal", "reverse")) {
+  function(p, orientation = c("vertical", "horizontal", "reverse"),
+           xlim = NULL, ylim = NULL) {
     ori <- match.arg(orientation)
     if (ori == "horizontal") {
-      p + coord_flip()
+      # Pass the axis limits into coord_flip() (in the original, pre-flip
+      # coordinates, so ylim still refers to the value axis). A separate
+      # coord_cartesian() would be dropped when coord_flip() replaces it (#646).
+      p + coord_flip(xlim = xlim, ylim = ylim)
     } else if (ori == "reverse") {
       p + scale_y_reverse()
     } else {

--- a/tests/testthat/test-orientation-axis-limits.R
+++ b/tests/testthat/test-orientation-axis-limits.R
@@ -1,0 +1,57 @@
+# Regression tests for #646: with orientation = "horizontal", xlim/ylim were
+# dropped because coord_flip() replaced the coord_cartesian() that carried the
+# limits (also emitting "Coordinate system already present"). Limits are now
+# passed into coord_flip().
+
+.df <- data.frame(x = c("a", "b", "c"), y = c(10, 20, 30))
+
+.range_of <- function(p, ax) {
+  ggplot2::ggplot_build(p)$layout$panel_params[[1]][[ax]]
+}
+# Capture both messages and warnings emitted while CONSTRUCTING and building the
+# plot. The "Coordinate system already present" note is emitted as a message at
+# construction time (when coord_flip replaces coord_cartesian), so we must build
+# the plot inside the handlers, not pass in a finished plot.
+.construct_notes <- function(expr) {
+  notes <- character(0)
+  withCallingHandlers(
+    {
+      p <- force(expr)
+      ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+    },
+    message = function(m) { notes[[length(notes) + 1]] <<- conditionMessage(m); invokeRestart("muffleMessage") },
+    warning = function(w) { notes[[length(notes) + 1]] <<- conditionMessage(w); invokeRestart("muffleWarning") }
+  )
+  notes
+}
+
+test_that("ylim is honored with orientation='horizontal' (#646)", {
+  p <- ggbarplot(.df, x = "x", y = "y", fill = "x",
+                 orientation = "horizontal", ylim = c(0, 50))
+  # After coord_flip the value (y) axis is the horizontal one: x.range
+  r <- .range_of(p, "x.range")
+  expect_true(min(r) <= 0 + 1e-8 && max(r) >= 50 - 1e-8)
+  # no "Coordinate system already present" note (message or warning)
+  expect_false(any(grepl(
+    "already present",
+    .construct_notes(ggbarplot(.df, x = "x", y = "y", fill = "x",
+                               orientation = "horizontal", ylim = c(0, 50)))
+  )))
+})
+
+test_that("vertical orientation ylim is unchanged (no regression, #646)", {
+  p <- ggbarplot(.df, x = "x", y = "y", fill = "x", ylim = c(0, 50))
+  r <- .range_of(p, "y.range")
+  expect_true(min(r) <= 0 + 1e-8 && max(r) >= 50 - 1e-8)
+  expect_false(any(grepl(
+    "already present",
+    .construct_notes(ggbarplot(.df, x = "x", y = "y", fill = "x", ylim = c(0, 50)))
+  )))
+})
+
+test_that("horizontal without limits, and reverse, still render (no regression, #646)", {
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+    ggbarplot(.df, x = "x", y = "y", fill = "x", orientation = "horizontal"))))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+    ggbarplot(.df, x = "x", y = "y", fill = "x", orientation = "reverse"))))
+})


### PR DESCRIPTION
## Problem
`ggbarplot(..., orientation = "horizontal", ylim = c(0, 50))` (and `rotate = TRUE`) ignored `ylim` and emitted:

> Coordinate system already present. Adding new coordinate system, which will replace the existing one.

## Root cause
`ggpar()` added `coord_cartesian(xlim, ylim)` for the limits and then `.set_orientation()` added `coord_flip()`, which **replaced** the `coord_cartesian` — so the limits were lost and ggplot2 warned about two coordinate systems.

## Fix
- Resolve `orientation` once via `match.arg()`.
- Apply the limits with `coord_cartesian()` only for non-horizontal orientations; for horizontal, pass them into `coord_flip(xlim = xlim, ylim = ylim)` (its `xlim`/`ylim` are in the original, pre-flip coordinates, so `ylim` still refers to the value axis, matching the documented meaning).

**No regression:** vertical and reverse are unchanged (limits via `coord_cartesian`); horizontal *without* limits is byte-identical (`coord_flip(NULL, NULL)` ≡ `coord_flip()`, verified). Only the previously-broken horizontal-with-limits case changes.

## Tests
New `tests/testthat/test-orientation-axis-limits.R`: `ylim` honored under horizontal (value axis spans the limit) with no "already present" note (captured as a construction message — revert-sensitive); vertical `ylim` unchanged (no-regression); horizontal-no-limits and reverse still render. Clean-session suite: **479 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed the fix works (value axis honors `ylim`, warning gone), that non-horizontal paths are byte-identical to master (including `coord_flip(NULL,NULL) ≡ coord_flip()`), that `ylim` still limits the value axis, that `.set_orientation`'s new args are optional (single caller), and that the tests are revert-sensitive and CI-safe. One reviewer noted the message assertion was originally a no-op; it has since been strengthened to capture the construction-time message.

Fixes #646
