### PR TITLE
ggpar(): honor legend.direction for all legend positions (Fixes #652)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,8 @@
   `rotate = TRUE`). The limits are passed to `coord_flip()` instead of a separate
   `coord_cartesian()` that was silently replaced, which also removes the
   "Coordinate system already present" warning (#646).
+- `ggpar()` (and the plot functions) now honor `legend.direction` for all legend
+  positions; it was previously ignored for `legend = "top"`/`"bottom"` (#652).
 
 ## Tests and docs
 

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -41,6 +41,10 @@ NULL
 #'   c("top", "bottom", "left", "right", "none"). To remove the legend use
 #'   legend = "none". Legend position can be also specified using a numeric
 #'   vector c(x, y); see details section.
+#' @param legend.direction character specifying the layout of legend items.
+#'   Allowed values are "horizontal" or "vertical". Useful to override the
+#'   default direction, e.g. to stack items vertically with
+#'   \code{legend = "bottom"}.
 #' @param legend.title legend title, e.g.: \code{legend.title = "Species"}. Can
 #'   be also a list, \code{legend.title = list(color = "Species", linetype = "Species",
 #'   shape = "Species")}.
@@ -158,7 +162,7 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
                   xscale = c("none", "log2", "log10", "sqrt"),
                   yscale = c("none", "log2", "log10", "sqrt"),
                   format.scale = FALSE,
-                  legend = NULL,
+                  legend = NULL, legend.direction = NULL,
                   legend.title = NULL, font.legend = NULL,
                   ticks = TRUE, tickslab = TRUE, font.tickslab = NULL,
                   font.xtickslab = font.tickslab, font.ytickslab = font.tickslab,
@@ -203,7 +207,7 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
       # adding coord_cartesian() here would be replaced by coord_flip(), dropping
       # the limits and warning about two coordinate systems (#646).
       if (orientation != "horizontal") p <- p + .set_axis_limits(xlim, ylim)
-      p <- .set_legend(p, legend, legend.title, font.legend)
+      p <- .set_legend(p, legend, legend.title, font.legend, legend.direction)
       p <- .set_scale(p, xscale = xscale, yscale = yscale, format.scale = format.scale)
       p <- .labs(p, main, xlab, ylab,
         font.main, font.x, font.y,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -386,11 +386,17 @@ keep_only_tbl_df_classes <- function(x) {
 # Legends
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 .set_legend <- function(p, legend = NULL,
-                        legend.title = NULL, font.legend = NULL) {
+                        legend.title = NULL, font.legend = NULL,
+                        legend.direction = NULL) {
   if (is.null(legend.title)) legend.title <- waiver()
   font <- .parse_font(font.legend)
 
   if (!is.null(legend)) p <- p + theme(legend.position = legend)
+  # legend.direction was previously ignored for legend = "top"/"bottom" (it only
+  # took effect via ggplot2 defaults for "left"/"right"); apply it explicitly (#652).
+  if (!is.null(legend.direction)) {
+    p <- p + theme(legend.direction = legend.direction)
+  }
 
   # Handle legend.title - skip if empty string (used to hide legend title)
   # Empty string causes "Ignoring unknown labels" warnings in ggplot2

--- a/man/ggpar.Rd
+++ b/man/ggpar.Rd
@@ -29,6 +29,7 @@ ggpar(
   yscale = c("none", "log2", "log10", "sqrt"),
   format.scale = FALSE,
   legend = NULL,
+  legend.direction = NULL,
   legend.title = NULL,
   font.legend = NULL,
   ticks = TRUE,
@@ -102,6 +103,11 @@ formatted when xscale or yscale = "log2" or "log10".}
 c("top", "bottom", "left", "right", "none"). To remove the legend use
 legend = "none". Legend position can be also specified using a numeric
 vector c(x, y); see details section.}
+
+\item{legend.direction}{character specifying the layout of legend items.
+Allowed values are "horizontal" or "vertical". Useful to override the
+default direction, e.g. to stack items vertically with
+\code{legend = "bottom"}.}
 
 \item{legend.title}{legend title, e.g.: \code{legend.title = "Species"}. Can
 be also a list, \code{legend.title = list(color = "Species", linetype = "Species",

--- a/tests/testthat/test-legend-direction.R
+++ b/tests/testthat/test-legend-direction.R
@@ -1,0 +1,23 @@
+# Regression test for #652: legend.direction was ignored for legend = "bottom"/"top"
+# (it only took effect via ggplot2 defaults for "left"/"right").
+
+.df <- transform(mtcars, cyl = as.factor(cyl))
+
+test_that("legend.direction is applied with legend='bottom' (#652)", {
+  p <- ggscatter(.df, x = "wt", y = "mpg", color = "cyl",
+                 legend = "bottom", legend.direction = "vertical")
+  expect_equal(p$theme$legend.direction, "vertical")
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})
+
+test_that("legend.direction still works with legend='right' (#652)", {
+  p <- ggscatter(.df, x = "wt", y = "mpg", color = "cyl",
+                 legend = "right", legend.direction = "horizontal")
+  expect_equal(p$theme$legend.direction, "horizontal")
+})
+
+test_that("omitting legend.direction leaves it unset (no regression, #652)", {
+  p <- ggscatter(.df, x = "wt", y = "mpg", color = "cyl", legend = "bottom")
+  expect_null(p$theme$legend.direction)
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})


### PR DESCRIPTION
## Problem
`legend.direction` was ignored for `legend = "bottom"` / `"top"` — it only took effect for `"left"`/`"right"` (via ggplot2 defaults). e.g. `ggscatter(df, "wt", "mpg", color = "cyl", legend = "bottom", legend.direction = "vertical")` drew a horizontal legend.

## Root cause
`ggpar()` never applied `legend.direction`; it fell into the function's unused `...`.

## Fix
Add a `legend.direction` formal to `ggpar()` and apply it via `theme(legend.direction = ...)` in `.set_legend()`. **Gated on non-NULL**, so omitting it is byte-identical to before — this activates a previously-ignored argument, it does not change any currently-rendered plot. Invalid values still error at build time via ggplot2 (no ggpubr-side validation needed).

## Tests
New `tests/testthat/test-legend-direction.R`: direction honored with `legend="bottom"` and `"right"` (regression), and left unset when omitted (no-regression). Clean-session suite: **484 tests, 0 failures**. `man/ggpar.Rd` updated; `tools::checkRd()` clean.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed the fix works across all 8 position×direction combinations, that omitting the arg leaves the theme untouched (gated no-regression), that no plot function has a colliding `legend.direction` formal (no double-binding), and that the tests are revert-sensitive and CI-safe.

Fixes #652
