### PR TITLE
compare_means(): support spaced / non-syntactic column names (Fixes #385)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,10 @@
   "Coordinate system already present" warning (#646).
 - `ggpar()` (and the plot functions) now honor `legend.direction` for all legend
   positions; it was previously ignored for `legend = "top"`/`"bottom"` (#652).
+- `compare_means()` no longer errors ("Can't extract columns that don't exist")
+  when a formula variable name contains a space (e.g. ``len ~ `spa ced` ``); the
+  backticks that R adds to non-syntactic term names are now stripped before
+  matching data columns (#385).
 
 ## Tests and docs
 

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -187,7 +187,8 @@ compare_means <- function(formula, data, method = "wilcox.test",
       dplyr::mutate(.y. = factor(.data$.y., levels = unique(.data$.y.)))
     response.var <- ".value."
     group.by <- c(group.by, ".y.")
-    formula <- .collapse(response.var, group, sep = " ~ ") %>% stats::as.formula()
+    formula <- .collapse(glue::backtick(response.var), glue::backtick(group), sep = " ~ ") %>%
+      stats::as.formula()
   }
 
   # Check if comparisons should be done against a reference group
@@ -217,7 +218,8 @@ compare_means <- function(formula, data, method = "wilcox.test",
         dplyr::select(-.group.name.)
       data[[".group."]] <- factor(data[[".group."]], levels = c(".all.", group.levs))
       group <- ".group."
-      formula <- .collapse(response.var, group, sep = " ~ ") %>% stats::as.formula()
+      formula <- .collapse(glue::backtick(response.var), glue::backtick(group), sep = " ~ ") %>%
+        stats::as.formula()
     } else if (!(ref.group %in% group.levs)) {
       stop("Can't find specified reference group: ", ref.group, ". ",
         "Allowed values include one of: ", .collapse(group.levs, sep = ", "),
@@ -347,8 +349,8 @@ compare_means <- function(formula, data, method = "wilcox.test",
 .test <- function(data, formula, method = "t.test", ...) {
   test <- match.fun(method)
 
-  x <- deparse(formula[[2]])
-  group <- attr(stats::terms(formula), "term.labels")
+  x <- .strip_backticks(deparse(formula[[2]]))
+  group <- .strip_backticks(attr(stats::terms(formula), "term.labels"))
 
   if (.is_empty(group)) { # Case of null model
     test.opts <- list(x = .select_vec(data, x), ...)
@@ -381,8 +383,8 @@ compare_means <- function(formula, data, method = "wilcox.test",
 .test_pairwise <- function(data, formula, method = "wilcox.test",
                            paired = FALSE, pool.sd = !paired,
                            ...) {
-  x <- deparse(formula[[2]])
-  group <- attr(stats::terms(formula), "term.labels")
+  x <- .strip_backticks(deparse(formula[[2]]))
+  group <- .strip_backticks(attr(stats::terms(formula), "term.labels"))
 
   # One sample test
   if (.is_empty(group)) {
@@ -477,7 +479,16 @@ compare_means <- function(formula, data, method = "wilcox.test",
 .formula_right_variables <- function(formula) {
   group <- attr(stats::terms(formula), "term.labels")
   if (.is_empty(group)) group <- "1"
-  group
+  # term.labels wraps names with special characters (e.g. spaces) in backticks,
+  # which don't match a data column in dplyr/`[[`. Return the bare column name;
+  # the formula object itself keeps its backticks for base-R/rstatix tests (#385).
+  .strip_backticks(group)
+}
+
+# Remove the surrounding backticks R adds to non-syntactic names in formula terms
+# so the string matches an actual data-frame column name.
+.strip_backticks <- function(x) {
+  gsub("`", "", x)
 }
 
 .update_test_arguments <- function(formula, data, group.by) {

--- a/tests/testthat/test-compare-means-spaced-names.R
+++ b/tests/testthat/test-compare-means-spaced-names.R
@@ -1,0 +1,35 @@
+# Regression tests for #385: compare_means() errored ("Can't extract columns that
+# don't exist") when a formula variable name contains a space, because
+# term.labels wraps such names in backticks, which don't match a data column in
+# dplyr / `[[`.
+
+.df <- ToothGrowth
+.df[["spa ced"]] <- .df$supp
+.df$dose <- factor(.df$dose)
+
+test_that("compare_means() works with a spaced group name (#385)", {
+  expect_no_error(res <- compare_means(len ~ `spa ced`, data = .df))
+  # same result as the equivalent unspaced column (spaced is a copy of supp)
+  ref <- compare_means(len ~ supp, data = ToothGrowth)
+  expect_equal(res$p, ref$p)
+  expect_equal(as.character(res$group1), as.character(ref$group1))
+  expect_equal(as.character(res$group2), as.character(ref$group2))
+})
+
+test_that("spaced group name works for anova and with group.by (#385)", {
+  expect_no_error(compare_means(len ~ `spa ced`, data = .df, method = "anova"))
+  expect_no_error(compare_means(len ~ `spa ced`, data = .df, group.by = "dose"))
+})
+
+test_that("normal (unspaced) formulas are unchanged (no regression, #385)", {
+  a <- compare_means(len ~ supp, data = ToothGrowth)
+  expect_equal(a$method, "Wilcoxon")
+  expect_equal(nrow(a), 1L)
+  # multi-group + group.by path still works
+  expect_no_error(compare_means(len ~ supp, data = ToothGrowth, group.by = "dose"))
+})
+
+test_that(".strip_backticks removes backticks only (#385)", {
+  expect_equal(ggpubr:::.strip_backticks("`spa ced`"), "spa ced")
+  expect_equal(ggpubr:::.strip_backticks("supp"), "supp")
+})


### PR DESCRIPTION
## Problem
`compare_means()` errored on a formula whose variable name contains a space:

```r
ToothGrowth[["spa ced"]] <- ToothGrowth[["supp"]]
compare_means(len ~ `spa ced`, ToothGrowth)
#> Error: Can't extract columns that don't exist. ✖ Column `` `spa ced` `` doesn't exist.
```

## Root cause
`attr(terms(formula), "term.labels")` returns non-syntactic names **wrapped in backticks** (`` `spa ced` ``). That string was then used to index the data with dplyr `.select_vec()` / `[[`, which look for a column literally named `` `spa ced` `` and fail.

## Fix
- New helper `.strip_backticks()`.
- Apply it where a formula name is used to **index data**: `.formula_right_variables()`, `.test()`, `.test_pairwise()`.
- Re-add backticks with `glue::backtick()` in the two `as.formula()` **reconstructions**, so non-syntactic names still parse into a valid formula (the formula object keeps its backticks for base-R / rstatix tests).

**Fully no-regression:** for syntactic names `.strip_backticks()` is a no-op, and a backticked syntactic name is equivalent to the bare name in both `as.formula()` and `term.labels`. Verified 11/11 normal-name cases (basic, `group.by`, `ref.group`, `ref.group=".all."`, anova, kruskal, t.test, pairwise, multi-response, null model, paired) are byte-identical to master.

Scope note: a spaced **response** (left-hand) variable remains a separate pre-existing limitation of `.formula_left_variables()` (unchanged here); #385 is about the group/right-hand variable.

## Tests
New `tests/testthat/test-compare-means-spaced-names.R`: spaced group works and equals the unspaced result; anova + `group.by` with spaced name; normal formulas unchanged; `.strip_backticks` unit check. Clean-session suite: **0 failures**; `test-compare_means.R` / `test-stat_compare_means.R` green.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both proved normal-name output is byte-identical to master (11/11), confirmed all method paths work for spaced names, and that the tests are revert-sensitive and CI-safe.

Fixes #385
