### PR TITLE
stat_regline_equation(): add coef.digits and rr.digits (Fixes #312)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -93,6 +93,9 @@
 - `ggarrange()` gains a `byrow` argument (default `TRUE`) to fill the plot grid
   by column (`byrow = FALSE`) instead of by row; forwarded to
   `cowplot::plot_grid()` (#225).
+- `stat_regline_equation()` gains `coef.digits` and `rr.digits` arguments to
+  control the number of significant digits shown for the regression-equation
+  coefficients and R2; defaults (`2`) reproduce the previous output (#312).
 
 ## Tests and docs
 

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -25,6 +25,10 @@ NULL
 #'   formatted in standard mathematical convention with terms in decreasing
 #'   order of powers (e.g., "y = 2*x + 1"). If \code{FALSE}, terms are in
 #'   increasing order (e.g., "y = 1 + 2*x").
+#' @param coef.digits integer indicating the number of significant digits to use
+#'   for the regression equation coefficients. Default is 2.
+#' @param rr.digits integer indicating the number of significant digits to use
+#'   for R2 and adjusted R2. Default is 2.
 #' @param ... other arguments to pass to \code{\link[ggplot2]{geom_text}} or
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
@@ -96,6 +100,7 @@ stat_regline_equation <- function(
   mapping = NULL, data = NULL, formula = y ~ x,
   label.x.npc = "left", label.y.npc = "top",
   label.x = NULL, label.y = NULL, output.type = "expression", decreasing = TRUE,
+  coef.digits = 2, rr.digits = 2,
   geom = "text", position = "identity", na.rm = FALSE, show.legend = NA,
   inherit.aes = TRUE, ...
 ) {
@@ -110,6 +115,7 @@ stat_regline_equation <- function(
       formula = formula, label.x.npc = label.x.npc, label.y.npc = label.y.npc,
       label.x = label.x, label.y = label.y,
       output.type = output.type, decreasing = decreasing,
+      coef.digits = coef.digits, rr.digits = rr.digits,
       parse = parse, na.rm = na.rm, ...
     )
   )
@@ -120,14 +126,16 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
   required_aes = c("x", "y"),
   default_aes = aes(label = after_stat(eq.label), hjust = after_stat(hjust), vjust = after_stat(vjust)),
   compute_group = function(data, scales, formula, label.x.npc, label.y.npc,
-                           label.x, label.y, output.type, decreasing) {
+                           label.x, label.y, output.type, decreasing,
+                           coef.digits = 2, rr.digits = 2) {
     force(data)
 
     if (length(unique(data$x)) < 2) {
       return(data.frame()) # Not enough data to perform test
     }
 
-    .test <- .stat_lm(formula, data, output.type = output.type, decreasing = decreasing)
+    .test <- .stat_lm(formula, data, output.type = output.type, decreasing = decreasing,
+                      coef.digits = coef.digits, rr.digits = rr.digits)
     # Returns a data frame with label: x, y, hjust, vjust
     .label.pms <- .label_params(
       data = data, scales = scales,
@@ -141,7 +149,8 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
 
 
 # Compute regression line equation
-.stat_lm <- function(formula, data, output.type = "expression", decreasing = TRUE) {
+.stat_lm <- function(formula, data, output.type = "expression", decreasing = TRUE,
+                     coef.digits = 2, rr.digits = 2) {
   res.lm <- stats::lm(formula, data)
   coefs <- stats::coef(res.lm)
 
@@ -150,13 +159,13 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
     coefs <- c(0, coefs)
   }
 
-  rr <- summary(res.lm)$r.squared %>% signif(2)
-  adj.rr <- summary(res.lm)$adj.r.squared %>% signif(2)
+  rr <- summary(res.lm)$r.squared %>% signif(rr.digits)
+  adj.rr <- summary(res.lm)$adj.r.squared %>% signif(rr.digits)
   AIC <- stats::AIC(res.lm) %>% signif(2)
   BIC <- stats::BIC(res.lm) %>% signif(2)
 
   # Build model equation
-  eq.char <- as.character(signif(polynom::as.polynomial(coefs), 2), decreasing = decreasing)
+  eq.char <- as.character(signif(polynom::as.polynomial(coefs), coef.digits), decreasing = decreasing)
   eq.char <- gsub("e([+-]?[0-9]*)", "%*%10^\\1", eq.char)
   if (output.type %in% c("latex", "tex", "tikz")) {
     eq.char <- gsub("*", " ", eq.char, fixed = TRUE)

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -14,6 +14,8 @@ stat_regline_equation(
   label.y = NULL,
   output.type = "expression",
   decreasing = TRUE,
+  coef.digits = 2,
+  rr.digits = 2,
   geom = "text",
   position = "identity",
   na.rm = FALSE,
@@ -65,6 +67,12 @@ for absolute positioning of the label. If too short they will be recycled.}
 formatted in standard mathematical convention with terms in decreasing
 order of powers (e.g., "y = 2*x + 1"). If \code{FALSE}, terms are in
 increasing order (e.g., "y = 1 + 2*x").}
+
+\item{coef.digits}{integer indicating the number of significant digits to use
+for the regression equation coefficients. Default is 2.}
+
+\item{rr.digits}{integer indicating the number of significant digits to use
+for R2 and adjusted R2. Default is 2.}
 
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument

--- a/tests/testthat/test-regline-digits.R
+++ b/tests/testthat/test-regline-digits.R
@@ -1,0 +1,42 @@
+# Regression tests for #312: stat_regline_equation() hardcoded signif(., 2) for
+# the equation coefficients and R^2. New coef.digits / rr.digits control the
+# number of significant digits; defaults (2) reproduce the previous output.
+
+.set <- function() {
+  set.seed(1)
+  data.frame(x = 1:20, y = -3.3462 + 1.02 * (1:20) + rnorm(20))
+}
+.eq_label <- function(d, aes.label = ggplot2::aes(label = ggplot2::after_stat(eq.label)), ...) {
+  p <- ggplot2::ggplot(d, ggplot2::aes(x, y)) + ggplot2::geom_point() +
+    stat_regline_equation(aes.label, ...)
+  as.character(ggplot2::ggplot_build(p)$data[[2]]$label)
+}
+.rr_label <- function(d, ...) {
+  p <- ggplot2::ggplot(d, ggplot2::aes(x, y)) + ggplot2::geom_point() +
+    stat_regline_equation(ggplot2::aes(label = ggplot2::after_stat(rr.label)), ...)
+  as.character(ggplot2::ggplot_build(p)$data[[2]]$label)
+}
+
+test_that("default digits are unchanged (no regression, #312)", {
+  d <- .set()
+  # default equals explicit coef.digits = 2 / rr.digits = 2
+  expect_identical(.eq_label(d), .eq_label(d, coef.digits = 2))
+  expect_identical(.rr_label(d), .rr_label(d, rr.digits = 2))
+  # the default equation is the 2-sig-fig form (slope 1.0 hidden by polynom)
+  expect_match(.eq_label(d), "3.4")
+})
+
+test_that("coef.digits increases equation coefficient precision (#312)", {
+  d <- .set()
+  lab3 <- .eq_label(d, coef.digits = 3)
+  # slope becomes visible at 3 sig figs and intercept shows more digits
+  expect_match(lab3, "1.04")
+  expect_match(lab3, "3.38")
+  expect_false(identical(.eq_label(d), lab3))
+})
+
+test_that("rr.digits controls R^2 precision (#312)", {
+  d <- .set()
+  expect_match(.rr_label(d, rr.digits = 4), "0.9789")
+  expect_false(identical(.rr_label(d, rr.digits = 2), .rr_label(d, rr.digits = 4)))
+})


### PR DESCRIPTION
## Request
`stat_regline_equation()` hardcoded `signif(., 2)`, so users couldn't increase the significant digits of the regression equation — e.g. a slope of `1.02` was rounded to `1` and hidden, showing `y = -3.3 + x` instead of `y = -3.35 + 1.02 x` (#312).

## Fix
Add `coef.digits` (equation coefficients) and `rr.digits` (R² / adjusted R²) arguments, threaded through `StatReglineEquation$compute_group` to `.stat_lm()`. **Defaults are `2`, reproducing the previous output byte-identically**; `AIC`/`BIC` are left unchanged.

## Example
```r
ggplot(d, aes(x, y)) + geom_point() +
  stat_regline_equation(aes(label = paste(after_stat(eq.label), after_stat(rr.label), sep = "~~~~")),
                        coef.digits = 3, rr.digits = 3)
#> y = 1.04 x - 3.38    R^2 = 0.979   (slope now visible)
```

## Tests
New `tests/testthat/test-regline-digits.R`: default equals explicit `coef.digits=2`/`rr.digits=2` (no-regression), `coef.digits=3` exposes more precision, `rr.digits` controls R² digits. Clean-session suite: **507 tests, 0 failures**. `man/stat_regline_equation.Rd` updated (only the pre-existing `\title` checkRd note remains).

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both proved the DEFAULT output is byte-identical to master (48/48 and 5/5 dataset comparisons against `git show HEAD:` behavior), confirmed the params thread through the ggproto layer without unused-param warnings, that `.stat_lm` has no other callers, that all output types (expression/latex/text) work, and that the tests are revert-sensitive and CI-safe.

Fixes #312
