### PR TITLE
ggtexttable(): style individual header cells with table_cell_font() (Fixes #535)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,9 @@
 - `stat_regline_equation()` gains `coef.digits` and `rr.digits` arguments to
   control the number of significant digits shown for the regression-equation
   coefficients and R2; defaults (`2`) reproduce the previous output (#312).
+- `table_cell_font()` and `table_cell_bg()` can now style an individual header
+  cell (`row = 1`), not only body cells; they previously matched only the
+  `core-*` grobs and silently did nothing for the header (#535).
 
 ## Tests and docs
 

--- a/R/ggtexttable.R
+++ b/R/ggtexttable.R
@@ -338,7 +338,9 @@ table_cell_font <- function(tab, row, column, face = NULL, size = NULL, color = 
   tabGrob <- get_tablegrob(tab)
   cells <- expand.grid(row = row, column = column)
   for (i in seq_len(nrow(cells))) {
-    tc <- .find_cell(tabGrob, cells$row[i], cells$column[i], "core-fg")
+    # Match the body cells ("core-fg") as well as the header row ("colhead-fg"),
+    # so an individual header cell can be styled (row 1), not only body cells (#535).
+    tc <- .find_cell(tabGrob, cells$row[i], cells$column[i], c("core-fg", "colhead-fg"))
     tabGrob$grobs[tc][[1]][["gp"]] <- grid::gpar(fontface = face, fontsize = size, col = color)
   }
   tab_return_same_class_as_input(tabGrob, input = tab)
@@ -350,7 +352,9 @@ table_cell_bg <- function(tab, row, column, fill = NULL, color = NULL, linewidth
   tabGrob <- get_tablegrob(tab)
   cells <- expand.grid(row = row, column = column)
   for (i in seq_len(nrow(cells))) {
-    tc <- .find_cell(tabGrob, cells$row[i], cells$column[i], "core-bg")
+    # Match body ("core-bg") and header ("colhead-bg") backgrounds, so a single
+    # header cell background can be changed too (#535).
+    tc <- .find_cell(tabGrob, cells$row[i], cells$column[i], c("core-bg", "colhead-bg"))
     tabGrob$grobs[tc][[1]][["gp"]] <- grid::gpar(
       fill = fill, col = color, lwd = linewidth, alpha = alpha
     )
@@ -360,7 +364,7 @@ table_cell_bg <- function(tab, row, column, fill = NULL, color = NULL, linewidth
 
 .find_cell <- function(tab, row, column, name = "core-fg") {
   l <- tab$layout
-  which(l$t == row & l$l == column & l$name == name)
+  which(l$t == row & l$l == column & l$name %in% name)
 }
 
 #' @export

--- a/tests/testthat/test-table-cell-header-font.R
+++ b/tests/testthat/test-table-cell-header-font.R
@@ -1,0 +1,39 @@
+# Regression tests for #535: table_cell_font()/table_cell_bg() can now style an
+# individual header cell (row 1, "colhead-*"), not only body cells ("core-*").
+
+.df <- data.frame(Group = c("a", "b", "c"), Value = c(1, 2, 3))
+
+.cell_gp <- function(tab, row, column, names) {
+  tg <- ggpubr:::get_tablegrob(tab)
+  l <- tg$layout
+  i <- which(l$t == row & l$l == column & l$name %in% names)
+  tg$grobs[[i]]$gp
+}
+
+test_that("table_cell_font() styles a single header cell (#535)", {
+  tab <- ggtexttable(.df, rows = NULL)
+  tab <- table_cell_font(tab, row = 1, column = 2, face = "italic", color = "red")
+  gp <- .cell_gp(tab, 1, 2, c("core-fg", "colhead-fg"))
+  # grid normalises fontface = "italic" into font = c(italic = 3L)
+  expect_equal(names(gp$font), "italic")
+  expect_equal(gp$col, "red")
+  # the other header cell is untouched
+  gp1 <- .cell_gp(tab, 1, 1, c("core-fg", "colhead-fg"))
+  expect_false(identical(gp1$col, "red"))
+})
+
+test_that("table_cell_bg() styles a single header cell background (#535)", {
+  tab <- ggtexttable(.df, rows = NULL)
+  tab <- table_cell_bg(tab, row = 1, column = 2, fill = "yellow")
+  gp <- .cell_gp(tab, 1, 2, c("core-bg", "colhead-bg"))
+  expect_equal(gp$fill, "yellow")
+})
+
+test_that("body-cell styling is unchanged (no regression, #535)", {
+  tab <- ggtexttable(.df, rows = NULL)
+  tab <- table_cell_font(tab, row = 2, column = 1, face = "bold", color = "blue")
+  gp <- .cell_gp(tab, 2, 1, "core-fg")
+  expect_equal(names(gp$font), "bold")
+  expect_equal(gp$col, "blue")
+  expect_no_error(print(tab))
+})


### PR DESCRIPTION
## Request
Style an **individual header cell** of a `ggtexttable()` — e.g. make one column name italic — rather than the whole header row (#535).

## Root cause
`table_cell_font()` / `table_cell_bg()` looked up only the body grobs (`core-fg` / `core-bg`) via `.find_cell()`, so targeting the header row (`row = 1`, grob name `colhead-fg`) matched nothing and silently did nothing.

## Fix
`.find_cell()` now matches a **set** of grob names (`l$name %in% name`), and the two functions pass both the body and header segments (`c("core-fg","colhead-fg")` / `c("core-bg","colhead-bg")`). So `row = 1` now styles the header cell.

**No regression:** the header (`t == 1`, `colhead-*`) and body (`t >= 2`, `core-*`) never share a layout row, so a body cell still matches exactly one grob — byte-identical to before (verified: same grob index). Row-name headers (`rowhead-*`, column 1) are a different segment and are never matched. The other two `.find_cell` callers pass scalar names, for which `%in%` is identical to `==`.

## Example
```r
tab <- ggtexttable(head(mtcars[, 1:3]), theme = ttheme("light"))
# italicise + colour only the "mpg" header cell:
tab <- table_cell_font(tab, row = 1, column = 2, face = "italic", color = "red")
```
(A superscript / math column name is available separately via `colnames.style = colnames_style(parse = TRUE)`.)

## Tests
New `tests/testthat/test-table-cell-header-font.R`: a single header cell can be font- and background-styled while the other header cell is untouched (regression), and body-cell styling is unchanged (no-regression). Clean-session suite: **0 failures** (514–518 tests).

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed body-cell selection is byte-identical, that no addressed `(t,l)` ever matches more than one grob (tested with row names, `tab_add_title`/`footnote`, and all themes), that the only two `.find_cell` callers are these functions, and that the tests are revert-sensitive and CI-safe.

Fixes #535
