### PR TITLE
theme_pubr(): draw axis ticks black/0.5 to match axis lines (Fixes #668)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,9 @@
 - `table_cell_font()` and `table_cell_bg()` can now style an individual header
   cell (`row = 1`), not only body cells; they previously matched only the
   `core-*` grobs and silently did nothing for the header (#535).
+- `theme_pubr()` now draws the axis tick marks in black with linewidth `0.5`,
+  matching the axis lines; previously the ticks inherited a lighter grey/thinner
+  style, visibly inconsistent when zoomed (#668).
 
 ## Tests and docs
 

--- a/R/theme_pubr.R
+++ b/R/theme_pubr.R
@@ -75,6 +75,10 @@ theme_pubr <- function(base_size = 12, base_family = "",
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
       axis.line = axis.line, axis.text = element_text(color = "black"),
+      # Match the tick marks to the axis lines (black, 0.5); by default they
+      # inherited a lighter grey/thinner style, visibly inconsistent when zoomed
+      # (#668).
+      axis.ticks = element_line(colour = "black", linewidth = 0.5),
       legend.key = element_blank(),
       strip.background = element_rect(fill = "#F2F2F2", colour = "black", linewidth = 0.7),
       plot.margin = plot.margin,

--- a/tests/testthat/test-theme-pubr-ticks.R
+++ b/tests/testthat/test-theme-pubr-ticks.R
@@ -1,0 +1,31 @@
+# Regression test for #668: theme_pubr() left axis.ticks inheriting a lighter
+# grey/thinner style while axis.line was black/0.5, visibly inconsistent when
+# zoomed. Ticks now match the axis lines.
+
+test_that("theme_pubr() axis.ticks match axis.line (black, 0.5) (#668)", {
+  th <- theme_pubr()
+  ticks <- ggplot2::calc_element("axis.ticks", th)
+  line <- ggplot2::calc_element("axis.line", th)
+  expect_equal(ticks$colour, "black")
+  expect_equal(ticks$linewidth, 0.5)
+  # consistent with the axis line
+  expect_equal(ticks$colour, line$colour)
+  expect_equal(ticks$linewidth, line$linewidth)
+})
+
+test_that("theme_pubr(border = TRUE) also has black/0.5 ticks (#668)", {
+  ticks <- ggplot2::calc_element("axis.ticks", theme_pubr(border = TRUE))
+  expect_equal(ticks$colour, "black")
+  expect_equal(ticks$linewidth, 0.5)
+})
+
+test_that("theme_pubr() still renders and other elements are intact (#668)", {
+  p <- ggplot2::ggplot(data.frame(x = 1:3, y = c("A", "B", "C")),
+                       ggplot2::aes(x, y)) +
+    ggplot2::geom_point() + theme_pubr()
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  th <- theme_pubr()
+  # unrelated elements unchanged
+  expect_true(inherits(th$panel.grid.major, "element_blank"))
+  expect_equal(ggplot2::calc_element("axis.text", th)$colour, "black")
+})


### PR DESCRIPTION
## Problem
`theme_pubr()` sets the axis **lines** to black / linewidth `0.5`, but left the axis **tick marks** inheriting `theme_bw`'s lighter grey (`grey20`), slightly-thinner style. At normal zoom it looks fine, but it's visibly inconsistent when exporting to PDF and zooming in (#668).

## Fix
Add `axis.ticks = element_line(colour = "black", linewidth = 0.5)` to `theme_pubr()`, matching the axis lines — the change the reporter proposed and asked to apply by default.

**Scope:** this is an intentional (maintainer-approved) visual change. It is strictly limited to `axis.ticks` — verified element-by-element that no other theme element changes across `border`, `margin`, `legend`, `x.text.angle`, and `base_size` variations. Tick length and minor ticks are unchanged, and `ggpar()`'s own `.set_ticks()` merges cleanly (ticks stay black/0.5, no warnings).

## Tests
New `tests/testthat/test-theme-pubr-ticks.R`: ticks are black/0.5 and equal to `axis.line` (default and `border = TRUE`), the plot still renders, and unrelated elements (blank grid, black axis text) are intact. Clean-session suite: **523 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both diffed the full theme object between master and the fix across 7–13 parameter combinations and confirmed `axis.ticks` (+ its inherited `.x`/`.y`) is the ONLY element that changes; both verified ggpar compatibility, no deprecation warnings, unchanged tick length, revert-sensitive tests, and that no existing test asserted the old grey tick color.

Fixes #668
