### PR TITLE
get_breaks(): anchor xticks.by/yticks.by to round multiples (Fixes #313)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,10 @@
 - `theme_pubr()` now draws the axis tick marks in black with linewidth `0.5`,
   matching the axis lines; previously the ticks inherited a lighter grey/thinner
   style, visibly inconsistent when zoomed (#668).
+- `xticks.by`/`yticks.by` now anchor the axis breaks to round multiples of the
+  step (e.g. 0, 100, 200) instead of the slightly-negative expanded axis minimum,
+  which produced odd labels such as `-20, 80, 180` on bar plots with
+  `ylim = c(0, 400)` (#313).
 
 ## Tests and docs
 

--- a/R/get_breaks.R
+++ b/R/get_breaks.R
@@ -74,7 +74,12 @@ get_breaks_position <- function(by, from = NULL, to = NULL) {
     }
     rng <- range(x)
     if (rng[1] > 0 & is.null(from)) from <- 0
-    xmin <- ifelse(is.null(from), floor(rng[1]), from)
+    # Anchor the first break to a multiple of `by` so the ticks land on round
+    # numbers (e.g. 0, 100, 200) even when the axis range dips slightly below 0
+    # from the default scale expansion; otherwise the breaks started at the
+    # expanded minimum (e.g. -19, 81, 181) (#313). Out-of-range breaks are
+    # dropped by the scale.
+    xmin <- ifelse(is.null(from), floor(rng[1] / by) * by, from)
     xmax <- ifelse(is.null(to), rng[2], to)
     seq(from = xmin, to = xmax, by = by)
   }

--- a/tests/testthat/test-get-breaks-anchor.R
+++ b/tests/testthat/test-get-breaks-anchor.R
@@ -1,0 +1,41 @@
+# Regression tests for #313: yticks.by / xticks.by produced breaks anchored at
+# the expanded (slightly negative) axis minimum -- e.g. -19, 81, 181 or
+# -20, 80, 180 -- instead of round multiples 0, 100, 200. get_breaks() now
+# anchors the first break to a multiple of `by`.
+
+.ybreaks <- function(p) {
+  stats::na.omit(ggplot2::ggplot_build(p)$layout$panel_params[[1]]$y$breaks)
+}
+
+.df <- data.frame(trt = factor(c("a", "b", "c")), value = c(120, 250, 380))
+
+test_that("yticks.by gives round breaks anchored at 0, not the negative expansion (#313)", {
+  p <- ggbarplot(.df, "trt", "value", fill = "grey", yticks.by = 100)
+  yb <- .ybreaks(p)
+  expect_true(all(yb %% 100 == 0))          # round multiples of 100
+  expect_false(any(yb < 0))                 # no negative break label
+  expect_true(0 %in% yb)
+})
+
+test_that("ylim + yticks.by shows 0..400 round breaks (the #313 report)", {
+  p <- ggbarplot(.df, "trt", "value", fill = "grey", ylim = c(0, 400), yticks.by = 100)
+  yb <- .ybreaks(p)
+  expect_setequal(yb, c(0, 100, 200, 300, 400))
+})
+
+test_that("get_breaks() anchors the first break to a multiple of `by` (#313)", {
+  f <- get_breaks(by = 100)
+  # expanded range dipping below 0 -> breaks still land on 0, 100, ...
+  expect_true(all(f(c(-19, 399)) %% 100 == 0))
+  expect_true(0 %in% f(c(-19, 399)))
+  # genuinely negative data -> still round multiples
+  expect_true(all(f(c(-50, 380)) %% 100 == 0))
+})
+
+test_that("strictly-positive-data breaks are unchanged (no regression, #313/#333)", {
+  # xticks.by on positive scatter data: visible breaks identical to before
+  p <- ggscatter(iris, x = "Sepal.Length", y = "Sepal.Width", xticks.by = 0.5)
+  xb <- stats::na.omit(ggplot2::ggplot_build(p)$layout$panel_params[[1]]$x$breaks)
+  expect_true(all(abs(diff(xb) - 0.5) < 1e-8))
+  expect_true(min(xb) >= 4 && max(xb) <= 8)
+})


### PR DESCRIPTION
## Problem
`ggbarplot(..., ylim = c(0, 400), yticks.by = 100)` showed y-axis labels **-20, 80, 180, 280, 380** instead of **0, 100, 200, 300, 400** — the reporter saw "-20 instead of 0", and a follow-up comment noted "yticks.by not working properly" (#313).

## Root cause
`get_breaks_position()` set `xmin <- floor(rng[1])`, where `rng[1]` is the scale's **expanded** range minimum. For a bar plot the default 5% expansion makes that minimum slightly negative (~-19/-20), so `seq(-19, ..., 100)` produced -19, 81, 181, … (or -20, 80, 180 with `ylim`).

## Fix
Anchor the first break to a multiple of `by`: `xmin <- floor(rng[1] / by) * by`. Breaks then land on round numbers (0, 100, 200, …) and ggplot2 drops any that fall outside the visible range.

**No regression for strictly-positive data:** the preceding `if (rng[1] > 0 & is.null(from)) from <- 0` sets `from = 0`, so the changed `ifelse` branch is only reached when `rng[1] <= 0`. Positive-data breaks (e.g. `ggscatter(..., xticks.by = 0.5)`) are byte-identical. Only ranges whose minimum is ≤ 0 change — non-negative data whose expansion dips below 0 (the bug) and genuinely-negative data (which now also gets round multiples).

## Tests
New `tests/testthat/test-get-breaks-anchor.R`: `yticks.by` gives round non-negative breaks; `ylim + yticks.by` → 0,100,200,300,400; `get_breaks()` anchors to a multiple of `by`; strictly-positive `xticks.by` breaks unchanged. Clean-session suite: **532 tests, 0 failures**; existing `test-set-ticksby.R` still passes.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both proved positive-data output is byte-identical to master (the `floor` branch is unreachable when `rng[1] > 0`), that the fix produces the expected round breaks, that fractional `by` has no off-by-one drift (~1e-16), that `by = 0` errors equivalently to master, that other `get_breaks` paths (`from`/`to`/`n`, density `from = 0`) are untouched, and that the tests are revert-sensitive and CI-safe.

Fixes #313
