### PR TITLE
ggmaplot(): draw NS points behind the significant hits (Fixes #365)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,9 @@
   step (e.g. 0, 100, 200) instead of the slightly-negative expanded axis minimum,
   which produced odd labels such as `-20, 80, 180` on bar plots with
   `ylim = c(0, 400)` (#313).
+- `ggmaplot()` now draws the non-significant ("NS") points behind the significant
+  ones, so the up/down-regulated hits are no longer hidden under the grey NS
+  cloud; the legend order (Up, Down, NS) is unchanged (#365).
 
 ## Tests and docs
 

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -189,6 +189,13 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
   font.label$color <- ifelse(is.null(font.label$color), "black", font.label$color)
   font.label$face <- ifelse(is.null(font.label$face), "plain", font.label$face)
 
+  # Draw the non-significant ("NS") points first (behind) so the significant
+  # Up/Down points are plotted on top and remain visible; the data was ordered
+  # by padj, which otherwise put the NS points last and hid the significant hits
+  # (#365). Stable ordering keeps the factor levels (and thus the legend) intact.
+  is.ns <- as.character(data$sig) == "NS"
+  data <- data[order(!is.ns), ]
+
   # Plot
   mean <- lfc <- sig <- name <- padj <- NULL
   p <- ggplot(data, aes(x = mean, y = lfc)) +

--- a/tests/testthat/test-ggmaplot-ns-order.R
+++ b/tests/testthat/test-ggmaplot-ns-order.R
@@ -1,0 +1,25 @@
+# Regression test for #365: ggmaplot() drew the non-significant ("NS") points
+# last, so they covered the significant Up/Down points. NS points are now drawn
+# first (behind) and the significant points remain visible on top.
+
+test_that("ggmaplot() draws NS points before the significant ones (#365)", {
+  data(diff_express, package = "ggpubr", envir = environment())
+  p <- ggmaplot(diff_express, fdr = 0.05, fc = 2, size = 0.5, top = 0)
+  d <- p$data   # the (reordered) data passed to ggplot / geom_point
+  is_ns <- as.character(d$sig) == "NS"
+  # every NS row comes before every significant row (drawn behind)
+  if (any(is_ns) && any(!is_ns)) {
+    expect_lt(max(which(is_ns)), min(which(!is_ns)))
+  }
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})
+
+test_that("ggmaplot() legend keeps the Up / Down / NS order (no regression, #365)", {
+  data(diff_express, package = "ggpubr", envir = environment())
+  p <- ggmaplot(diff_express, fdr = 0.05, fc = 2, top = 0)
+  levs <- levels(p$data$sig)
+  # NS remains the last legend entry; Up/Down first
+  expect_match(levs[1], "^Up")
+  expect_match(levs[2], "^Down")
+  expect_equal(levs[length(levs)], "NS")
+})


### PR DESCRIPTION
## Problem
`ggmaplot()` drew the grey non-significant ("NS") points **on top of** the coloured significant (Up/Down) points, hiding the hits (#365). The data is ordered by padj, so NS (high padj) ended up last → drawn last → on top.

## Fix
Reorder the plotting data with a **stable** sort so NS rows are drawn first (behind) and the significant points on top:

```r
is.ns <- as.character(data$sig) == "NS"
data <- data[order(!is.ns), ]
```

This matches the reporter's "bring NS to the start" request. It is placed after `labs_data` and the counts are computed, so **only the point draw order changes** — the factor levels / legend (Up, Down, NS) and their order, the counts, the palette→level colour mapping, the top-gene labels (and their positions), and the threshold lines are all unchanged (verified `identical()` against master; the data frame is a pure permutation).

## Tests
New `tests/testthat/test-ggmaplot-ns-order.R`: every NS row precedes every significant row in the plotting data (revert-sensitive — fails on master, which draws NS last), the plot renders, and the legend keeps the Up/Down/NS order. Clean-session suite: **537 tests, 0 failures**; existing `test-ggmaplot.R` still passes.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both reconstructed master and proved the legend, counts, palette, `labs_data` (same genes, same positions), and `geom_hline` are byte-identical — the sole difference is NS-behind vs NS-on-top. Edge cases (all-NS, all-significant, absent sig level, `top>0`, `label.select`, `label.rectangle`) all render with the NS-behind invariant holding. Visually verified: the coloured significant points are now visible on top of the grey NS cloud.

Fixes #365
