### PR TITLE
compare_means(): adjust p-values within each group.by level (Fixes #200)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,10 @@
 - `ggmaplot()` now draws the non-significant ("NS") points behind the significant
   ones, so the up/down-regulated hits are no longer hidden under the grey NS
   cloud; the legend order (Up, Down, NS) is unchanged (#365).
+- `compare_means()` now adjusts p-values **within** each `group.by` level (and
+  response) rather than pooling all groups together, so a grouped adjustment
+  matches filtering to one group and adjusting there. This changes `p.adj` values
+  for calls that use `group.by`; ungrouped calls are unchanged (#200).
 
 ## Tests and docs
 

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -291,13 +291,18 @@ compare_means <- function(formula, data, method = "wilcox.test",
   )
 
   .y. <- p.adj <- p <- NULL
-  pvalue.adj <- res %>%
-    group_by(.y.) %>%
-    reframe(p.adj = stats::p.adjust(p, method = p.adjust.method))
+  # Adjust p-values WITHIN each grouping level (group.by) x response (.y.), not
+  # pooled across all groups, so a grouped adjustment matches filtering to one
+  # group and adjusting there (#200). Without group.by this reduces to grouping
+  # by .y. only (the previous behavior). Use group_by + mutate (not reframe) so
+  # the row order is preserved and p.adj stays aligned with p.format/p.signif.
+  adjust.by <- intersect(unique(c(group.by, ".y.")), colnames(res))
   res <- res %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(adjust.by))) %>%
+    dplyr::mutate(p.adj = stats::p.adjust(p, method = p.adjust.method)) %>%
     dplyr::ungroup() %>%
     mutate(
-      p.adj = pvalue.adj$p.adj, p.format = pvalue.format, p.signif = pvalue.signif,
+      p.format = pvalue.format, p.signif = pvalue.signif,
       method = method.name
     )
 

--- a/tests/testthat/test-compare-means-padjust-group.R
+++ b/tests/testthat/test-compare-means-padjust-group.R
@@ -1,0 +1,45 @@
+# Regression tests for #200: compare_means() adjusted p-values across ALL groups
+# pooled together instead of within each group.by level, so a grouped adjustment
+# did not match filtering to one group and adjusting there.
+
+suppressPackageStartupMessages(library(dplyr))
+
+test_that("grouped p.adjust matches filter-then-adjust within a group (#200)", {
+  grouped <- compare_means(len ~ dose, ToothGrowth, method = "t.test",
+                           p.adjust.method = "bonferroni", group.by = "supp") %>%
+    as.data.frame()
+  filtered <- ToothGrowth %>% filter(supp == "OJ") %>%
+    compare_means(len ~ dose, ., method = "t.test",
+                  p.adjust.method = "bonferroni", group.by = "supp") %>%
+    as.data.frame()
+  oj <- grouped[grouped$supp == "OJ", ]
+  oj <- oj[order(oj$group1, oj$group2), ]
+  filtered <- filtered[order(filtered$group1, filtered$group2), ]
+  expect_equal(oj$p.adj, filtered$p.adj)
+})
+
+test_that("grouped bonferroni adjusts by within-group comparison count (#200)", {
+  grouped <- compare_means(len ~ dose, ToothGrowth, method = "t.test",
+                           p.adjust.method = "bonferroni", group.by = "supp") %>%
+    as.data.frame()
+  # 3 comparisons per supp group -> p.adj ~= min(1, p * 3), NOT p * 6
+  # (tolerance covers the 2-sig-fig rounding but still rules out the old x6)
+  expect_equal(grouped$p.adj, pmin(1, grouped$p * 3), tolerance = 0.05)
+})
+
+test_that("ungrouped p.adjust is unchanged: adjusts across all comparisons (no regression, #200)", {
+  ungrouped <- compare_means(len ~ dose, ToothGrowth, method = "t.test",
+                             p.adjust.method = "bonferroni") %>%
+    as.data.frame()
+  # 3 comparisons total -> p * 3 (same as before this change)
+  expect_equal(ungrouped$p.adj, pmin(1, ungrouped$p * 3), tolerance = 0.05)
+})
+
+test_that("p.adj stays aligned with p / group1 / group2 rows (#200)", {
+  r <- compare_means(len ~ dose, ToothGrowth, method = "t.test",
+                     p.adjust.method = "bonferroni", group.by = "supp") %>%
+    as.data.frame()
+  # p.adj must be >= p for every row (adjustment never decreases a p-value here)
+  expect_true(all(r$p.adj >= r$p - 1e-12))
+  expect_equal(nrow(r), 6L)
+})


### PR DESCRIPTION
## Problem
`compare_means()` adjusted p-values across **all** `group.by` groups pooled together (it grouped only by `.y.`), so a grouped adjustment didn't match filtering to a single group and adjusting there (#200):

```r
compare_means(len ~ dose, ToothGrowth, method = "t.test",
              p.adjust.method = "bonferroni", group.by = "supp")
#> OJ dose 1-vs-2  p.adj = 0.24   (= p * 6, all groups pooled)

ToothGrowth %>% dplyr::filter(supp == "OJ") %>%
  compare_means(len ~ dose, ., method = "t.test", p.adjust.method = "bonferroni")
#> dose 1-vs-2      p.adj = 0.12   (= p * 3)
```

## Fix
Adjust p-values **within each `group.by` level × response (`.y.`)** rather than pooling:

```r
adjust.by <- intersect(unique(c(group.by, ".y.")), colnames(res))
res <- res %>%
  dplyr::group_by(dplyr::across(dplyr::all_of(adjust.by))) %>%
  dplyr::mutate(p.adj = stats::p.adjust(p, method = p.adjust.method)) %>%
  dplyr::ungroup() %>% ...
```

Now the grouped OJ result is `0.12`, matching the filter-then-adjust. **Ungrouped calls are byte-identical** (with `group.by = NULL`, `adjust.by = ".y."`, exactly the previous grouping). The switch from `reframe()` + positional assignment to `group_by() %>% mutate()` also preserves row order, keeping `p.adj` aligned with `p.format`/`p.signif` (strictly safer than the old positional assign).

**Note:** for omnibus tests (`method = "anova"`/`"kruskal.test"`) combined with `group.by`, each group has a single p-value, so within-group adjustment applies no cross-group correction (previously it pooled across groups). This is the consistent consequence of the "match a filtered single-group analysis" semantics.

## Tests
New `tests/testthat/test-compare-means-padjust-group.R`: grouped p.adj equals filter-then-adjust; grouped bonferroni uses the within-group comparison count (×3, not ×6); **ungrouped p.adj unchanged**; p.adj stays row-aligned. Clean-session suite: **542 tests, 0 failures**; existing `test-compare_means.R`/`test-stat_compare_means.R` pass.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both proved ungrouped output is byte-identical to master (single & multi-response), grouped == filter-then-adjust for bonferroni/holm/BH/none, that the `mutate` change fixes a latent positional-assignment misalignment risk, and that ref.group / multi-column group.by / anova / kruskal paths all behave correctly.

Fixes #200
