### PR TITLE
stat_compare_means(): note comparisons= p-values are unadjusted (Fixes #293)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,6 +113,10 @@
   response) rather than pooling all groups together, so a grouped adjustment
   matches filtering to one group and adjusting there. This changes `p.adj` values
   for calls that use `group.by`; ungrouped calls are unchanged (#200).
+- `stat_compare_means(comparisons = )` now emits a one-time message (and the docs
+  note) clarifying that the displayed pairwise p-values are **not** adjusted for
+  multiple comparisons, pointing to `geom_pwc()` / `stat_pvalue_manual()` +
+  `compare_means(p.adjust.method = )` for corrected p-values (#293).
 
 ## Tests and docs
 

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -14,6 +14,12 @@ NULL
 #' @param comparisons A list of length-2 vectors. The entries in the vector are
 #'  either the names of 2 values on the x-axis or the 2 integers that correspond
 #'  to the index of the groups of interest, to be compared.
+#'
+#'  Note: when \code{comparisons} is specified, each pairwise test is computed
+#'  independently and the displayed p-values are \strong{not} adjusted for
+#'  multiple comparisons. For p-values corrected for multiple testing, use
+#'  \code{\link{geom_pwc}()}, or \code{\link{stat_pvalue_manual}()} together with
+#'  \code{\link{compare_means}(..., p.adjust.method = )}.
 #' @param hide.ns logical value. If TRUE, hide ns symbol when displaying
 #'  significance levels.
 #' @param label character string specifying label type. Allowed values include
@@ -177,6 +183,27 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
   )
 
   if (!is.null(comparisons)) {
+    # The `comparisons` path draws each pairwise test independently (via
+    # ggsignif::geom_signif) and shows UNADJUSTED p-values. Warn once per session
+    # when there is more than one comparison, so users aren't misled into thinking
+    # the p-values are corrected for multiple testing (#293).
+    if (length(comparisons) > 1) {
+      rlang::inform(
+        c(
+          paste0(
+            "`stat_compare_means()` with `comparisons` displays *unadjusted* ",
+            "p-values (no correction for multiple comparisons)."
+          ),
+          i = paste0(
+            "For p-values adjusted for multiple comparisons, use `geom_pwc()`, ",
+            "or `stat_pvalue_manual()` together with ",
+            "`compare_means(..., p.adjust.method = )`."
+          )
+        ),
+        .frequency = "once",
+        .frequency_id = "ggpubr_stat_compare_means_comparisons_unadjusted"
+      )
+    }
     method.info <- .method_info(method)
     method <- method.info$method
 

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -82,7 +82,13 @@ for wilcoxon test.}
 
 \item{comparisons}{A list of length-2 vectors. The entries in the vector are
 either the names of 2 values on the x-axis or the 2 integers that correspond
-to the index of the groups of interest, to be compared.}
+to the index of the groups of interest, to be compared.
+
+Note: when \code{comparisons} is specified, each pairwise test is computed
+independently and the displayed p-values are \strong{not} adjusted for
+multiple comparisons. For p-values corrected for multiple testing, use
+\code{\link{geom_pwc}()}, or \code{\link{stat_pvalue_manual}()} together with
+\code{\link{compare_means}(..., p.adjust.method = )}.}
 
 \item{hide.ns}{logical value. If TRUE, hide ns symbol when displaying
 significance levels.}

--- a/tests/testthat/test-compare-means-comparisons-note.R
+++ b/tests/testthat/test-compare-means-comparisons-note.R
@@ -1,0 +1,36 @@
+# Regression tests for #293: stat_compare_means(comparisons = ) shows UNADJUSTED
+# p-values. Users are now informed once per session (message + docs) and pointed
+# to the adjusted-pairwise alternatives.
+
+.cmp3 <- list(c("0.5", "1"), c("1", "2"), c("0.5", "2"))
+
+test_that("multi-comparison stat_compare_means informs about unadjusted p-values (#293)", {
+  old <- options(rlib_message_verbosity = "verbose")  # force the once-message
+  on.exit(options(old), add = TRUE)
+  expect_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = .cmp3),
+    "unadjusted"
+  )
+  # the note points to the adjusted-pairwise alternatives
+  expect_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = .cmp3),
+    "geom_pwc|stat_pvalue_manual"
+  )
+})
+
+test_that("single comparison does NOT emit the note (#293)", {
+  old <- options(rlib_message_verbosity = "verbose")
+  on.exit(options(old), add = TRUE)
+  expect_no_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = list(c("0.5", "1")))
+  )
+})
+
+test_that("stat_compare_means(comparisons=) still renders (no regression, #293)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len") +
+    stat_compare_means(comparisons = .cmp3)
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})


### PR DESCRIPTION
## Problem
`stat_compare_means(comparisons = ...)` displays pairwise p-values that are **not** adjusted for multiple comparisons (the path delegates each test to `ggsignif::geom_signif`). Several users noted this is misleading — people assume the pairwise p-values on their boxplots are corrected when they are not (#293).

## Fix (chosen approach: one-time message + docs)
The full adjusted-pairwise capability already exists via `geom_pwc()` and `stat_pvalue_manual()` + `compare_means(p.adjust.method = )`, so rather than retrofit the `geom_signif` delegation, this makes the current behaviour explicit:

- When `comparisons` has **more than one** comparison, emit a **one-time-per-session** informational message (`rlang::inform(..., .frequency = "once")`) stating the p-values are unadjusted and pointing to `geom_pwc()`/`stat_pvalue_manual()`.
- Document the same caveat on the `comparisons` argument.

**No plot-output change:** the message is a pure side effect — the constructed layer and the rendered plot are identical to before. It is a message (not a warning), so it won't trip `R CMD check --as-cran` `error_on = "warning"`. A single comparison (where adjustment is moot) does not emit it.

## Tests
New `tests/testthat/test-compare-means-comparisons-note.R`: a multi-comparison call emits the "unadjusted" note pointing to `geom_pwc`/`stat_pvalue_manual`; a single comparison does not; the plot still renders. Uses base `options(rlib_message_verbosity = "verbose")` (no undeclared `withr` dependency). Clean-session suite: **546 tests, 0 failures**; `man/stat_compare_means.Rd` updated (`checkRd` clean).

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed the built layer data / grob are identical to master (message is side-effect-only), that it is a message (not warning) firing once for `>1` comparison at layer construction (not per-facet/per-build, no internal callers), that `rlang` is declared in Imports, that the test uses no undeclared deps and is revert-sensitive, and that no pre-existing test breaks.

Fixes #293
