### PR TITLE
ggboxplot(): forward coef to allow coef = 0 to omit whiskers (Fixes #517)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,8 @@
   note) clarifying that the displayed pairwise p-values are **not** adjusted for
   multiple comparisons, pointing to `geom_pwc()` / `stat_pvalue_manual()` +
   `compare_means(p.adjust.method = )` for corrected p-values (#293).
+- `ggboxplot()` now forwards `coef` to `geom_boxplot()`, so `coef = 0` can be used
+  to omit the whiskers; it was previously dropped by `geom_exec()` (#517).
 
 ## Tests and docs
 

--- a/R/geom_exec.R
+++ b/R/geom_exec.R
@@ -36,7 +36,7 @@ geom_exec <- function(geomfunc = NULL, data = NULL,
     "stroke",
     # boxplot
     "outlier.colour", "outlier.shape", "outlier.size", "outliers",
-    "outlier.stroke", "notch", "notchwidth", "varwidth",
+    "outlier.stroke", "notch", "notchwidth", "varwidth", "coef",
     # dot plot
     "binwidth", "binaxis", "method", "binpositions",
     "stackdir", "stackratio", "dotsize",

--- a/tests/testthat/test-ggboxplot-coef.R
+++ b/tests/testthat/test-ggboxplot-coef.R
@@ -1,0 +1,23 @@
+# Regression test for #517: ggboxplot() ignored `coef` (it was not in geom_exec's
+# allowed_options), so `coef = 0` could not be used to omit the whiskers.
+
+.nowhisker <- function(p) {
+  d <- ggplot2::ggplot_build(p)$data[[1]]
+  all(abs(d$ymin - d$lower) < 1e-9 & abs(d$ymax - d$upper) < 1e-9)
+}
+
+test_that("ggboxplot(coef = 0) omits the whiskers (#517)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len", coef = 0)
+  expect_true(.nowhisker(p))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})
+
+test_that("ggboxplot() default keeps whiskers (no regression, #517)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len")
+  expect_false(.nowhisker(p))
+  # coef = 1.5 (the geom_boxplot default) is byte-identical to not passing coef
+  d0 <- ggplot2::ggplot_build(p)$data[[1]]
+  d1 <- ggplot2::ggplot_build(ggboxplot(ToothGrowth, "dose", "len", coef = 1.5))$data[[1]]
+  expect_equal(d0$ymin, d1$ymin)
+  expect_equal(d0$ymax, d1$ymax)
+})


### PR DESCRIPTION
## Request
Omit the boxplot whiskers in `ggboxplot()`, the way `coef = 0` does for `geom_boxplot()` (#517).

## Root cause
`coef` was missing from `geom_exec()`'s `allowed_options` whitelist, so `ggboxplot(..., coef = 0)` silently dropped it and the whiskers were still drawn at the default `coef = 1.5` extent.

## Fix
Add `"coef"` to the boxplot section of the whitelist so `geom_exec()` forwards it to `geom_boxplot()` (whose `StatBoxplot` uses it to compute the whisker extent). `coef = 0` now omits the whiskers.

**No regression:** the default is unchanged (`coef = 1.5` is `geom_boxplot`'s default — built `ymin`/`ymax` are byte-identical to not passing `coef`). Passing `coef` to a non-boxplot ggpubr function behaves exactly like every other geom-specific whitelist entry (e.g. `notch`, `trim`): ggplot2 emits its own harmless "Ignoring unknown parameters" warning — no error — and only if a user passes the nonsensical arg there.

## Tests
New `tests/testthat/test-ggboxplot-coef.R`: `coef = 0` omits whiskers and renders; default keeps whiskers; `coef = 1.5` byte-identical to default. Clean-session suite: **551 tests, 0 failures**.

## Review
Two independent, read-only adversarial reviewers both returned SAFE. Both confirmed the whisker omission works, the default is byte-identical, and — the key risk — that forwarding `coef` causes NO error in any non-boxplot ggpubr function (`ggscatter`/`ggline`/`ggviolin`/`ggbarplot`/`gghistogram`/`ggdotplot`/`ggstripchart`/`ggdensity`) nor in the `add=` layers (`jitter`/`mean_se`/`dotplot`), and that the tests are revert-sensitive.

Fixes #517
