### PR TITLE
Fix annotate_figure() figure label shifting with label length (#185)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -126,6 +126,10 @@
   positions the text — `"center"`/`"right"` anchor the title/footnote across the
   table width instead of around a fixed point — and the text is no longer clipped
   when it is wider than the table (#302).
+- `annotate_figure()`: the figure label (`fig.lab`) now uses a length-independent
+  horizontal justification, so labels of different lengths keep the same anchor
+  and captions align across figures; previously a longer label was shifted away
+  from the corner (#185).
 
 ## Tests and docs
 

--- a/R/annotate_figure.R
+++ b/R/annotate_figure.R
@@ -63,10 +63,25 @@ annotate_figure <- function(p,
   annot.args <- list(top = top, bottom = bottom, left = left, right = right) %>%
     .compact()
 
-  lab.args <- list(label = fig.lab, position = fig.lab.pos) %>%
-    .compact()
-  if (!missing(fig.lab.size)) lab.args$size <- fig.lab.size
-  if (!missing(fig.lab.face)) lab.args$fontface <- fig.lab.face
+  # Anchor the figure label with a length-independent horizontal justification.
+  # cowplot::draw_figure_label() uses hjust = -0.1 / 1.1 for the left/right
+  # positions, a width-proportional offset, so a longer label is pushed further
+  # from the corner and captions no longer align across figures (#185). Use a
+  # fixed hjust (0 for left, 1 for right; the centre positions already use 0, as
+  # cowplot did) with a fixed x anchor; vertical placement matches cowplot.
+  fig.lab.args <- switch(fig.lab.pos,
+    "top.left"     = list(x = 0.01, y = 1, hjust = 0, vjust = 1.1),
+    "top"          = list(x = 0.50, y = 1, hjust = 0, vjust = 1.1),
+    "top.right"    = list(x = 0.99, y = 1, hjust = 1, vjust = 1.1),
+    "bottom.left"  = list(x = 0.01, y = 0, hjust = 0, vjust = -0.1),
+    "bottom"       = list(x = 0.50, y = 0, hjust = 0, vjust = -0.1),
+    "bottom.right" = list(x = 0.99, y = 0, hjust = 1, vjust = -0.1)
+  )
+  lab.args <- c(list(label = fig.lab), fig.lab.args)
+  # Preserve the previous default label size/face, which cowplot::draw_figure_label()
+  # took from the current theme text (not draw_plot_label's bold/16 default) (#185).
+  lab.args$size <- if (!missing(fig.lab.size)) fig.lab.size else ggplot2::theme_get()$text$size
+  lab.args$fontface <- if (!missing(fig.lab.face)) fig.lab.face else ggplot2::theme_get()$text$face
 
 
   if (!.is_empty(annot.args)) {
@@ -75,7 +90,7 @@ annotate_figure <- function(p,
   }
 
   if (!is.null(fig.lab)) {
-    p <- cowplot::ggdraw(p) + do.call(cowplot::draw_figure_label, lab.args)
+    p <- cowplot::ggdraw(p) + do.call(cowplot::draw_plot_label, lab.args)
   }
 
   p

--- a/tests/testthat/test-annotate-figure-label.R
+++ b/tests/testthat/test-annotate-figure-label.R
@@ -1,0 +1,46 @@
+# Regression tests for #185: annotate_figure(fig.lab=) positioned the label with
+# cowplot's width-proportional hjust (-0.1 / 1.1), so a longer label was pushed
+# further from the corner and figure captions no longer aligned across figures.
+# The label now uses a length-independent hjust (0 / 1) and a fixed x anchor.
+
+.fig <- ggarrange(ggboxplot(ToothGrowth, "dose", "len"), ncol = 1)
+
+.lab_layer <- function(p) {
+  # the figure label is the last (GeomText) layer added by draw_plot_label
+  i <- utils::tail(which(vapply(p$layers,
+    function(l) inherits(l$geom, "GeomText"), logical(1))), 1)
+  p$layers[[i]]
+}
+
+test_that("fig.lab hjust is length-independent, not cowplot's -0.1 (#185)", {
+  short <- .lab_layer(annotate_figure(.fig, fig.lab = "A", fig.lab.pos = "top.left"))
+  long  <- .lab_layer(annotate_figure(.fig, fig.lab = "A very long figure label", fig.lab.pos = "top.left"))
+  # top.left -> hjust 0 (was -0.1)
+  expect_equal(short$aes_params$hjust, 0)
+  # hjust and x anchor identical regardless of label length -> captions align
+  expect_equal(short$aes_params$hjust, long$aes_params$hjust)
+  expect_equal(short$data$x, long$data$x)
+})
+
+test_that("fig.lab positions map to fixed hjust 0/0.5?/1 (#185)", {
+  tl <- .lab_layer(annotate_figure(.fig, fig.lab = "L", fig.lab.pos = "top.left"))
+  tr <- .lab_layer(annotate_figure(.fig, fig.lab = "R", fig.lab.pos = "top.right"))
+  expect_equal(tl$aes_params$hjust, 0)
+  expect_equal(tr$aes_params$hjust, 1)
+})
+
+test_that("annotate_figure(fig.lab=) still renders (#185)", {
+  expect_no_error(print(annotate_figure(.fig, fig.lab = "Fig 1", fig.lab.face = "bold")))
+  expect_no_error(print(annotate_figure(.fig, fig.lab = "Fig 1", fig.lab.pos = "bottom.right")))
+})
+
+test_that("default fig.lab size/face are unchanged (no regression, #185)", {
+  d <- .lab_layer(annotate_figure(.fig, fig.lab = "Fig 1"))
+  # cowplot::draw_figure_label defaulted to the theme text size/face (11pt/plain),
+  # NOT draw_plot_label's 16/bold -> preserve that default.
+  expect_equal(d$aes_params$size, ggplot2::theme_get()$text$size / ggplot2::.pt)
+  expect_equal(d$aes_params$fontface, ggplot2::theme_get()$text$face)
+  # explicit size/face still honored
+  e <- .lab_layer(annotate_figure(.fig, fig.lab = "X", fig.lab.size = 20, fig.lab.face = "italic"))
+  expect_equal(e$aes_params$fontface, "italic")
+})


### PR DESCRIPTION
## Problem (#185)

`annotate_figure(fig.lab = ...)` positioned the figure label with `cowplot::draw_figure_label()`, whose left/right positions use a **width-proportional** horizontal justification (`hjust = -0.1 / 1.1`). A longer label was therefore pushed further away from the corner, so figure captions of different lengths no longer aligned across panels.

## Fix

Anchor the label with a fixed, **length-independent** justification via `cowplot::draw_plot_label()`:

| position | x | hjust | vjust |
|---|---|---|---|
| top.left / bottom.left | 0.01 | 0 | 1.1 / -0.1 |
| top / bottom | 0.50 | 0 | 1.1 / -0.1 |
| top.right / bottom.right | 0.99 | 1 | 1.1 / -0.1 |

The default label **size/face** are still taken from the current theme text (11pt / plain) — matching `draw_figure_label`'s previous default, **not** `draw_plot_label`'s 16pt/bold — so the default appearance is byte-identical to before. `fig.lab.size` / `fig.lab.face` remain honored.

## Verification

- New `tests/testthat/test-annotate-figure-label.R` (revert-sensitive for both the hjust fix and the default size/face no-regression).
- Default appearance confirmed byte-identical to master (size 3.866058, plain, black, family ""); short vs long labels now share the same anchor.
- Full suite: `FAIL 0 | PASS 574` (7 pre-existing unrelated warnings).

Fixes #185
