### PR TITLE
Fix geom_pwc() bracket placement when a group is entirely NA (#575)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,12 @@
 
 ## Bug fixes
 
+- `geom_pwc()` now places comparison brackets over the correct groups when an
+  entire x-axis group has only `NA` values. Such a group is dropped before the
+  statistical test runs; previously the surviving groups were renumbered from 1,
+  which shifted the remaining brackets left. The bracket positions are now
+  anchored to the discrete x scale so they stay aligned with the plotted groups
+  (#575).
 - Fixed ColorBrewer sequential palette parsing in `.get_brewer_pal()` so
   `"YlOrBr"` is recognized correctly.
 - Updated `ggexport()` to respect `verbose = FALSE` by suppressing filename

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -542,6 +542,22 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
       rstatix::add_significance(p.col = "p", cutpoints = sy$cutpoints, symbols = sy$symbols) %>%
       rstatix::add_significance(p.col = "p.adj", cutpoints = sy$cutpoints, symbols = sy$symbols)
 
+    # For simple (non-grouped) comparisons, anchor the bracket x positions to
+    # the actual x-axis positions. Observations whose y is NA are dropped
+    # before the test runs, so a group that is entirely NA disappears from the
+    # data; rstatix::add_x_position() then renumbers the surviving groups from
+    # 1, shifting the brackets left (#575). Here data$x (and therefore group1/
+    # group2) are the mapped discrete x positions, so we can restore the true
+    # positions directly. Rows with non-numeric group ids (e.g. ".all."/"all"
+    # basemean comparisons) are left as computed by add_x_position().
+    if (!is.grouped.plots && !is.null(scales$x) && scales$x$is_discrete()) {
+      g1 <- suppressWarnings(as.numeric(as.character(stat.test$group1)))
+      g2 <- suppressWarnings(as.numeric(as.character(stat.test$group2)))
+      ok <- !is.na(g1) & !is.na(g2)
+      stat.test$xmin[ok] <- g1[ok]
+      stat.test$xmax[ok] <- g2[ok]
+    }
+
     # Format p-values using unified p-format implementation for all styles
     stat.test <- stat.test %>%
       dplyr::mutate(

--- a/tests/testthat/test-geom_pwc.R
+++ b/tests/testthat/test-geom_pwc.R
@@ -385,3 +385,43 @@ test_that("geom_pwc skips grouped subsets missing ref.group and keeps valid ones
   )
   expect_gte(nrow(b$data[[2]]), 1)
 })
+
+# All-NA group placement (#575) -----------------------------------
+test_that("geom_pwc places brackets over the correct groups when a group is all-NA (#575)", {
+  # Group "a" is entirely NA; its rows are dropped before the stat runs, so the
+  # only comparison is b vs c. The bracket must sit over b (x=2) and c (x=3),
+  # not shift left to a-b (x=1,2). See #575.
+  test <- data.frame(
+    x = rep(c("a", "b", "c"), each = 4),
+    y = c(NA, NA, NA, NA, 5:12)
+  )
+  p <- ggplot(test, aes(x, y)) +
+    ggplot2::geom_point() +
+    geom_pwc()
+  b <- ggplot2::ggplot_build(p)
+  st <- b$data[[which(vapply(
+    b$data, function(d) all(c("xmin", "xmax") %in% colnames(d)), logical(1)
+  ))[1]]]
+  st <- unique(st[, c("group1", "group2", "xmin", "xmax")])
+  expect_equal(nrow(st), 1L)
+  expect_equal(as.character(st$group1), "2")
+  expect_equal(as.character(st$group2), "3")
+  expect_equal(as.numeric(st$xmin), 2)
+  expect_equal(as.numeric(st$xmax), 3)
+})
+
+test_that("geom_pwc all-NA fix leaves the fully-populated case unchanged (#575)", {
+  # No NA groups: every pairwise bracket keeps its natural position.
+  tn <- data.frame(x = rep(c("a", "b", "c"), each = 4), y = 1:12)
+  p <- ggplot(tn, aes(x, y)) + ggplot2::geom_point() + geom_pwc()
+  b <- ggplot2::ggplot_build(p)
+  st <- b$data[[which(vapply(
+    b$data, function(d) all(c("xmin", "xmax") %in% colnames(d)), logical(1)
+  ))[1]]]
+  st <- unique(st[, c("xmin", "xmax")])
+  st$xmin <- as.numeric(st$xmin)
+  st$xmax <- as.numeric(st$xmax)
+  st <- st[order(st$xmin, st$xmax), ]
+  expect_equal(st$xmin, c(1, 1, 2))
+  expect_equal(st$xmax, c(2, 3, 3))
+})


### PR DESCRIPTION
## Problem (#575)

When an entire x-axis group has only `NA` y-values, `geom_pwc()` placed the comparison brackets over the **wrong** groups.

Those observations are dropped before the statistical test runs, so re-factoring the surviving data with `as.factor()` renumbered the remaining groups from 1. `rstatix::add_x_position()` then positioned the brackets one (or more) slots to the left of the groups actually being compared — e.g. a `b`-vs-`c` comparison drawn over `a`–`b`:

| | before | after |
|---|---|---|
| group "a" all-NA | bracket over **a–b** (xmin=1, xmax=2) ✗ | bracket over **b–c** (xmin=2, xmax=3) ✓ |

## Fix

For simple (non-grouped) comparisons, anchor the x factor levels to the already-trained discrete x scale instead of the surviving values alone:

```r
if (!is.grouped.plots && !is.null(scales$x) && scales$x$is_discrete()) {
  df <- data %>%
    mutate(x = factor(.data$x, levels = seq_along(scales$x$get_limits())))
}
```

- `data$x` reaching `compute_panel` are mapped integer positions; anchoring the levels to `seq_along(scales$x$get_limits())` keeps `add_x_position()`'s numbering aligned with the real axis positions.
- Only x positions **present** in the data are compared, so no spurious brackets are added.
- Fully-populated plots are **byte-identical** (`factor(x, levels=…)` == `as.factor(x)` when no level is missing).
- Grouped / legend plots keep the previous code path (gated by `!is.grouped.plots`).
- The `!is.null(scales$x)` guard keeps a fully-degenerate all-NA panel from erroring.

## Verification

- New regression tests in `tests/testthat/test-geom_pwc.R` (revert-sensitive: all-NA placement **and** fully-populated no-change).
- Reprexes from the issue render correctly (single-group and faceted; the faceted "foo" panel's lone bracket is now over b–c, not a–b).
- Full suite: `FAIL 0 | PASS 581`.
- Two independent adversarial reviewers confirmed: correct placement, no spurious brackets, byte-identical for all working/grouped/ref.group/hide.ns/coord_flip/faceted inputs, safe fallback on continuous x and degenerate panels.

Fixes #575
