### PR TITLE
theme_pubr(): render facet strip border at full width (strip.clip='off') (#668 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,13 @@
 - `theme_pubr()` now draws the axis tick marks in black with linewidth `0.5`,
   matching the axis lines; previously the ticks inherited a lighter grey/thinner
   style, visibly inconsistent when zoomed (#668).
+- `theme_pubr()` now sets `strip.clip = "off"` so the facet strip background
+  border renders at its full `linewidth`. With the `ggplot2` (>= 3.5.0) default
+  (`strip.clip = "on"`) the border was clipped to the strip area, cutting the
+  outer half of the stroke so it looked thinner and misaligned with the panel
+  when zoomed (follow-up to #668). Note: a facet label wider than its panel now
+  overflows the strip instead of being truncated; restore clipping with
+  `+ theme(strip.clip = "on")` if needed.
 - `xticks.by`/`yticks.by` now anchor the axis breaks to round multiples of the
   step (e.g. 0, 100, 200) instead of the slightly-negative expanded axis minimum,
   which produced odd labels such as `-20, 80, 180` on bar plots with

--- a/R/theme_pubr.R
+++ b/R/theme_pubr.R
@@ -11,6 +11,13 @@ NULL
 #'  axis lines, ticks, texts and titles. \item \strong{clean_table_theme()}:
 #'  Clean the the theme of a table, such as those created by
 #'  \code{\link{ggsummarytable}()}}.
+#' @details \code{theme_pubr()} sets \code{strip.clip = "off"} so that the facet
+#'  strip background border is drawn at its full width (with the ggplot2 default
+#'  \code{strip.clip = "on"} the border is clipped to the strip area and renders
+#'  thinner than requested). As a side effect, a facet label that is wider than
+#'  its panel will overflow the strip instead of being truncated; if that is a
+#'  problem for very long labels, restore clipping with
+#'  \code{+ theme(strip.clip = "on")}.
 #' @param base_size base font size
 #' @param base_family base font family
 #' @param border logical value. Default is FALSE. If TRUE, add panel border.
@@ -81,6 +88,12 @@ theme_pubr <- function(base_size = 12, base_family = "",
       axis.ticks = element_line(colour = "black", linewidth = 0.5),
       legend.key = element_blank(),
       strip.background = element_rect(fill = "#F2F2F2", colour = "black", linewidth = 0.7),
+      # Don't clip the facet strip background to the strip area: by default
+      # ggplot2 (>= 3.5.0) clips it, which cuts the outer half of the strip's
+      # border stroke so it renders thinner than the requested linewidth and
+      # looks misaligned with the panel/axis lines when zoomed (follow-up to
+      # the tick-consistency fix in #668).
+      strip.clip = "off",
       plot.margin = plot.margin,
       legend.position = legend,
       complete = TRUE

--- a/man/theme_pubr.Rd
+++ b/man/theme_pubr.Rd
@@ -62,6 +62,15 @@ axis.}
  Clean the the theme of a table, such as those created by
  \code{\link{ggsummarytable}()}}.
 }
+\details{
+\code{theme_pubr()} sets \code{strip.clip = "off"} so that the facet
+strip background border is drawn at its full width (with the ggplot2 default
+\code{strip.clip = "on"} the border is clipped to the strip area and renders
+thinner than requested). As a side effect, a facet label that is wider than
+its panel will overflow the strip instead of being truncated; if that is a
+problem for very long labels, restore clipping with
+\code{+ theme(strip.clip = "on")}.
+}
 \examples{
 p <- ggplot(mtcars, aes(x = wt, y = mpg)) +
   geom_point(aes(color = gear))

--- a/tests/testthat/test-theme-pubr-ticks.R
+++ b/tests/testthat/test-theme-pubr-ticks.R
@@ -29,3 +29,25 @@ test_that("theme_pubr() still renders and other elements are intact (#668)", {
   expect_true(inherits(th$panel.grid.major, "element_blank"))
   expect_equal(ggplot2::calc_element("axis.text", th)$colour, "black")
 })
+
+# Follow-up to #668: with the ggplot2 (>= 3.5.0) default (strip.clip = "on"),
+# the facet strip background border is clipped to the strip area, so the outer
+# half of the border stroke is cut and the border renders thinner than the
+# requested linewidth -- misaligned with the panel/axis when zoomed. theme_pubr()
+# now sets strip.clip = "off" so the strip border renders at its full width.
+test_that("theme_pubr() sets strip.clip = 'off' so the strip border isn't clipped (#668)", {
+  expect_equal(theme_pubr()$strip.clip, "off")
+  expect_equal(theme_pubr(border = TRUE)$strip.clip, "off")
+})
+
+test_that("theme_pubr() faceted plot renders with a full-width strip border (#668)", {
+  df <- data.frame(x = c(1, 2, 3, 1, 2, 3), y = c(2, 3, 4, 1, 5, 3),
+                   g = rep(c("G1", "G2"), each = 3))
+  p <- ggplot2::ggplot(df, ggplot2::aes(x, y)) +
+    ggplot2::geom_point() + ggplot2::facet_wrap(~g) + theme_pubr()
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  # strip.background linewidth preserved (border consistency, not thinned)
+  strip <- ggplot2::calc_element("strip.background", theme_pubr())
+  expect_equal(strip$linewidth, 0.7)
+  expect_equal(strip$colour, "black")
+})


### PR DESCRIPTION
## Follow-up to #668

After the axis-tick consistency fix in #668, the reporter noted a similar misalignment on `facet_wrap()`'s `strip.background`.

**Root cause.** With the `ggplot2` (>= 3.5.0) default `strip.clip = "on"`, the facet strip background border rect is clipped to the strip area, so the outer half of the border stroke is cut. The strip border therefore rendered thinner than its requested `linewidth` (0.7) and looked misaligned with the panel/axis lines when zoomed — the same class of issue as the ticks in #668.

**Fix.** `theme_pubr()` now sets `strip.clip = "off"`, so the strip background border renders at its full width. `strip.clip` exists since ggplot2 3.5.0 and ggpubr already requires `ggplot2 (>= 3.5.2)`, so no version guard is needed.

**Documented tradeoff.** With `strip.clip = "off"`, a facet label *wider than its panel* overflows the strip instead of being truncated. This is disclosed in `?theme_pubr` and NEWS; users can restore clipping with `+ theme(strip.clip = "on")`.

## Verification

- Pixel check: strip border renders full-width (6px @300dpi) vs the clipped 3px before.
- New regression tests in `tests/testthat/test-theme-pubr-ticks.R` (revert-sensitive: `theme_bw()$strip.clip == "on"`, so the assertions fail without the fix).
- Only `theme_pubr()` changes; `theme_pubclean()`/`theme_classic2()` keep the stock behavior. Non-faceted plots and `ggboxplot`/`ggscatter`/`ggline` `facet.by=` wrappers render unchanged.
- Full suite: `FAIL 0 | PASS 586`.
- Two independent adversarial reviewers: both SAFE (border fix confirmed, no regressions, overflow tradeoff acceptable and now documented).

Refs #668
