### PR TITLE
Align ggscatterhist() marginal plots with the main scatter axes (#220, #420)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,11 @@
 
 ## Bug fixes
 
+- `ggscatterhist()` now aligns the marginal plots with the main scatter plot's
+  axes. The margins were built from the raw data, so anything that changed the
+  scatter limits (`ellipse = TRUE`, `position` jitter, explicit `xlim`/`ylim`)
+  left the marginal histograms/densities misaligned with the scatter. Each
+  margin now inherits the scatter's axis range (#220, #420).
 - `geom_pwc()` now places comparison brackets over the correct groups when an
   entire x-axis group has only `NA` values. Such a group is dropped before the
   statistical test runs; previously the surviving groups were renumbered from 1,

--- a/R/ggscatterhist.R
+++ b/R/ggscatterhist.R
@@ -163,10 +163,31 @@ ggscatterhist <- function(
     do.call(geom_exec, .)
   yplot <- set_palette(yplot, palette)
 
+  # Align the marginal plot axes with the main scatter plot's data ranges.
+  # The margins are built from the raw data, so any transformation that changes
+  # the scatter limits (e.g. ellipse = TRUE, position jitter, explicit
+  # xlim/ylim) was not reflected in the margins, making them misaligned with the
+  # scatter (#220, #420). Anchor each margin's DATA axis to the scatter's panel
+  # range: set that scale's expansion to zero (the scatter range already
+  # includes expansion) and zoom with coord_*(). The other (count/density) axis
+  # keeps its default expansion. Only linear axes are aligned (see
+  # .get_scatter_ranges): forcing a transformed scatter range onto a raw-data
+  # margin would push it off-screen.
+  sp.ranges <- .get_scatter_ranges(sp)
   # Flip the marginal plots
   if (margin.plot %in% c("density", "histogram")) {
-    yplot <- yplot +
-      coord_flip()
+    if (sp.ranges$x_identity && !is.null(sp.ranges$x)) {
+      xplot <- xplot +
+        scale_x_continuous(expand = expansion(0)) +
+        coord_cartesian(xlim = sp.ranges$x)
+    }
+    if (sp.ranges$y_identity && !is.null(sp.ranges$y)) {
+      yplot <- yplot +
+        scale_x_continuous(expand = expansion(0)) +
+        coord_flip(xlim = sp.ranges$y)
+    } else {
+      yplot <- yplot + coord_flip()
+    }
   } else if (margin.plot %in% c("boxplot")) {
     xplot <- xplot + coord_flip()
   }
@@ -239,6 +260,36 @@ has_cowplot_v0.9 <- function() {
   vv <- as.character(utils::packageVersion("cowplot"))
   cc <- utils::compareVersion(vv, "0.8.0.8") > 0
   cc
+}
+
+# Extract the final x and y coordinate ranges (including expansion) of a built
+# scatter plot, plus whether each axis uses an identity (linear) transformation.
+# Used to align the marginal plots in ggscatterhist() (#220, #420). Alignment is
+# applied only to linear axes: a transformed scatter axis (log, sqrt, ...) lives
+# in different units than the raw-data margins, so forcing its range onto the
+# margin would push the margin off-screen. Falls back gracefully across ggplot2
+# panel_params / scale layouts.
+.get_scatter_ranges <- function(sp) {
+  b <- ggplot2::ggplot_build(sp)
+  pp <- b$layout$panel_params[[1]]
+  axis_range <- function(axis) {
+    r <- pp[[paste0(axis, ".range")]]
+    if (is.null(r) && !is.null(pp[[axis]])) r <- pp[[axis]]$continuous_range
+    r
+  }
+  axis_is_identity <- function(axis) {
+    sc <- b$layout[[paste0("panel_scales_", axis)]][[1]]
+    if (is.null(sc)) return(TRUE)
+    tr <- tryCatch(sc$get_transformation(), error = function(e) NULL)
+    if (is.null(tr)) tr <- tryCatch(sc$trans, error = function(e) NULL)
+    # Treat "can't determine" as linear (the common case); a real transform
+    # reports its name (e.g. "log-10", "sqrt").
+    is.null(tr) || is.null(tr$name) || identical(tr$name, "identity")
+  }
+  list(
+    x = axis_range("x"), y = axis_range("y"),
+    x_identity = axis_is_identity("x"), y_identity = axis_is_identity("y")
+  )
 }
 
 .check_margin_params <- function(params, data, color = "black", fill = NA, linetype = "slid") {

--- a/tests/testthat/test-ggscatterhist.R
+++ b/tests/testthat/test-ggscatterhist.R
@@ -1,0 +1,78 @@
+context("test-ggscatterhist")
+
+# Regression tests for #220 / #420: the marginal plots were built from the raw
+# data, so transformations that change the scatter limits (ellipse, position
+# jitter, explicit limits) were not reflected in the margins, leaving them
+# misaligned with the scatter. The margins now inherit the scatter's ranges.
+
+panel_x_range <- function(p) {
+  pp <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]
+  r <- pp[["x.range"]]
+  if (is.null(r)) r <- pp[["x"]]$continuous_range
+  r
+}
+panel_y_range <- function(p) {
+  pp <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]
+  r <- pp[["y.range"]]
+  if (is.null(r)) r <- pp[["y"]]$continuous_range
+  r
+}
+
+test_that("ggscatterhist marginal plots inherit the scatter's ranges with jitter (#420)", {
+  set.seed(1)
+  res <- ggscatterhist(
+    mpg, x = "displ", y = "hwy",
+    position = ggplot2::position_jitter(width = 5, height = 5, seed = 1),
+    print = FALSE
+  )
+  sp.x <- panel_x_range(res$sp)
+  sp.y <- panel_y_range(res$sp)
+  # xplot (top margin) x-axis matches the scatter x-axis
+  expect_equal(panel_x_range(res$xplot), sp.x, tolerance = 1e-6)
+  # yplot is coord_flip()'d, so its y-axis (post-flip) matches the scatter y-axis
+  expect_equal(panel_y_range(res$yplot), sp.y, tolerance = 1e-6)
+  # the jittered scatter range is much wider than the raw data range: the fix
+  # must have widened the margin beyond the raw displ range (1.6-7.0)
+  expect_lt(sp.x[1], 1.6)
+  expect_gt(sp.x[2], 7.0)
+})
+
+test_that("ggscatterhist marginal plots inherit the scatter's ranges with ellipse (#220)", {
+  res <- ggscatterhist(
+    iris, x = "Sepal.Length", y = "Sepal.Width",
+    color = "Species", ellipse = TRUE, print = FALSE
+  )
+  expect_equal(panel_x_range(res$xplot), panel_x_range(res$sp), tolerance = 1e-6)
+  expect_equal(panel_y_range(res$yplot), panel_y_range(res$sp), tolerance = 1e-6)
+})
+
+test_that("ggscatterhist default still renders and margins align (#220/#420)", {
+  res <- ggscatterhist(iris, x = "Sepal.Length", y = "Sepal.Width", print = FALSE)
+  expect_s3_class(res, "ggscatterhist")
+  expect_equal(panel_x_range(res$xplot), panel_x_range(res$sp), tolerance = 1e-6)
+  expect_equal(panel_y_range(res$yplot), panel_y_range(res$sp), tolerance = 1e-6)
+  expect_no_error(print(res))
+})
+
+test_that("ggscatterhist does NOT force a transformed (log) scatter range onto the raw-data margin (#220/#420)", {
+  # A log-scaled scatter axis lives in different units than the raw-data margin.
+  # The margin must stay in linear data units (visible), NOT be forced to the
+  # scatter's log range (which would push it off-screen). Regression guard.
+  res <- ggscatterhist(mpg, x = "displ", y = "hwy", xscale = "log10", print = FALSE)
+  xplot.range <- panel_x_range(res$xplot)
+  # margin still spans (roughly) the raw displ range 1.6..7.0, not the log range ~0.2..0.9
+  expect_gt(xplot.range[2], 5)
+  expect_gt(xplot.range[1], 1)
+  expect_false(isTRUE(all.equal(xplot.range, panel_x_range(res$sp))))
+  expect_no_error(print(res))
+})
+
+test_that("ggscatterhist preserves the marginal density-axis expansion (no default change, #220/#420)", {
+  # Aligning the DATA axis must not remove the count/density-axis expansion:
+  # the density peak should not sit flush against the panel edge.
+  res <- ggscatterhist(iris, x = "Sepal.Length", y = "Sepal.Width", print = FALSE)
+  dens.range <- panel_y_range(res$xplot)   # xplot's y = density magnitude
+  built <- ggplot2::ggplot_build(res$xplot)$data[[1]]
+  expect_lt(dens.range[1], 0)              # bottom expansion below 0 retained
+  expect_gt(dens.range[2], max(built$y))   # top gap above the peak retained
+})


### PR DESCRIPTION
## Problem (#220, #420)

`ggscatterhist()` builds the marginal histograms/densities from the raw data with their own scales. Anything that changed the **main scatter's** limits was therefore not reflected in the margins, leaving them misaligned:

- `ellipse = TRUE` expands the scatter range, but the margins kept the raw-data range (#220).
- `position` jitter / explicit `xlim`/`ylim` shift or widen the scatter, again leaving the margins on the raw range (#420) — e.g. a density that looks like it spans −4..12 when the data is 1.6..7.0.

## Fix

For density/histogram margins, each margin's **data axis** is anchored to the scatter's panel range: the data scale's expansion is set to zero (the scatter range already includes expansion) and the margin is zoomed with `coord_cartesian()`/`coord_flip()`. The count/density axis keeps its default expansion, so the **default appearance is byte-identical**.

Alignment is applied **only to linear (identity) axes**. A transformed scatter axis (`xscale="log10"`, `yscale="sqrt"`, …) lives in different units than the raw-data margin, so forcing its range would push the margin off-screen; those axes keep the previous (visible) behavior. Boxplot margins are unchanged.

## Verification

- New `tests/testthat/test-ggscatterhist.R` (revert-sensitive): jitter (#420) and ellipse (#220) alignment, default alignment + **density-axis expansion preserved**, and a **log-scale guard** (margin must stay in linear units, not vanish).
- Visually verified: jitter, ellipse, log10 (marginal visible), and default (unchanged).
- Full suite: `FAIL 0 | PASS 602`.
- Two independent adversarial reviewers, two rounds: the first round caught a log/sqrt regression (marginal vanished) which was fixed by scoping to linear axes; both reviewers SAFE on the final diff.

Fixes #220, fixes #420
