### PR TITLE
stat_cor(): make leading-zero suppression survive plotmath rendering (#540 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,7 +39,10 @@
 - `stat_cor()` gains two label-formatting arguments:
   - `r.leading.zero` — set to `FALSE` to drop the leading zero of the
     correlation coefficient (e.g. `.73` instead of `0.73`), completing
-    APA-style reporting together with `p.leading.zero` (#540).
+    APA-style reporting together with `p.leading.zero` (#540). The dropped
+    leading zero is preserved through plotmath rendering (the value is quoted
+    so it is not silently re-normalized back to `0.73` in the default
+    `expression` output).
   - `p.coef.name` — symbol for the p-value label; use `"P"` for an uppercase
     p-value (#541).
 

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -308,6 +308,13 @@ get_p_label <- function(x, p.digits = 2, accuracy = 0.0001, type = "expression",
   if (type == "expression") {
     label <- gsub(pattern = "p = ", replacement = "italic(p)~`=`~", x = label, fixed = TRUE)
     label <- gsub(pattern = "p < ", replacement = "italic(p)~`<`~", x = label, fixed = TRUE)
+    # Quote a value whose leading zero was explicitly dropped (p.leading.zero =
+    # FALSE) so plotmath renders it literally instead of re-adding the zero
+    # (e.g. .001 -> "0.001"). Scoped to the explicit flag so p.format.style
+    # presets keep their existing numeric rendering (#540).
+    if (!is.null(p.leading.zero) && !p.leading.zero) {
+      label <- .quote_leading_zero_dropped(label)
+    }
   }
   # Optionally use a custom symbol for the p-value label, e.g. uppercase "P" (#541).
   if (!identical(p.coef.name, "p")) {
@@ -357,7 +364,21 @@ get_corcoef_label <- function(x, accuracy = 0.01, prefix = "R", cor.coef.name = 
   if (type == "expression") {
     label <- gsub(pattern = "R2 = ", replacement = "italic(R)^2~`=`~", x = label, fixed = TRUE)
     label <- gsub(pattern = "R = ", replacement = "italic(R)~`=`~", x = label, fixed = TRUE)
+    if (!is.null(leading.zero) && !leading.zero) {
+      label <- .quote_leading_zero_dropped(label)
+    }
   }
   label <- gsub(pattern = "R", cor.coef.name, x = label, fixed = TRUE)
   label
+}
+
+# In plotmath, a bare value whose leading zero was dropped (e.g. .87) is parsed
+# as a number and rendered back WITH the zero (0.87). To make APA-style
+# leading-zero suppression survive rendering, quote such a value so plotmath
+# treats it as a literal string, keeping any minus sign outside the quotes
+# (e.g. italic(R)~`=`~-.87  ->  italic(R)~`=`~-".87"). Only values that start
+# with "." (i.e. already stripped) are affected; "0.87", "1.00", scientific
+# notation are left untouched (#540).
+.quote_leading_zero_dropped <- function(label) {
+  sub("~(-?)(\\.[0-9]+)$", '~\\1"\\2"', label)
 }

--- a/tests/testthat/test-stat_cor.R
+++ b/tests/testthat/test-stat_cor.R
@@ -17,13 +17,16 @@ test_that("stat_cor default label is unchanged (no regression, #540/#541)", {
 })
 
 test_that("stat_cor r.leading.zero = FALSE drops the coefficient leading zero (#540)", {
+  # For expression output the stripped value is QUOTED so plotmath renders it
+  # literally (a bare .20 would be re-normalized to 0.20 at draw time). The
+  # quoted form is what actually renders as ".20"/"-.87".
   lab <- .cor_label(.sp + stat_cor(p.accuracy = 0.001, r.accuracy = 0.01, r.leading.zero = FALSE))
-  expect_true(grepl("italic(R)~`=`~.20", lab, fixed = TRUE))
-  # negative coefficient keeps the minus sign: -0.87 -> -.87
+  expect_true(grepl('italic(R)~`=`~".20"', lab, fixed = TRUE))
+  # negative coefficient keeps the minus sign outside the quotes: -0.87 -> -".87"
   lab.neg <- .cor_label(
     ggscatter(mtcars, "wt", "mpg") + stat_cor(r.accuracy = 0.01, r.leading.zero = FALSE)
   )
-  expect_true(grepl("`=`~-.87", lab.neg, fixed = TRUE))
+  expect_true(grepl('`=`~-".87"', lab.neg, fixed = TRUE))
 })
 
 test_that("stat_cor p.coef.name = 'P' uses an uppercase p-value symbol (#541)", {
@@ -37,7 +40,20 @@ test_that("stat_cor APA style: both leading-zero drops + uppercase P together (#
     p.accuracy = 0.001, r.accuracy = 0.01,
     r.leading.zero = FALSE, p.leading.zero = FALSE, p.coef.name = "P"
   ))
-  expect_equal(lab, "italic(R)~`=`~.20*`,`~italic(P)~`=`~.392")
+  # Both stripped values are quoted (render as .20 / .392 respectively).
+  expect_equal(lab, 'italic(R)~`=`~".20"*`,`~italic(P)~`=`~".392"')
+})
+
+test_that("stat_cor leading-zero drop survives plotmath rendering (#540)", {
+  # Guard against the plotmath re-normalization bug: the stripped value must be
+  # quoted in the expression so it renders literally. A bare `.20` would draw
+  # as `0.20`. Rendering the plot must not error.
+  p <- .sp + stat_cor(r.accuracy = 0.01, r.leading.zero = FALSE, label.x = -1)
+  lab <- .cor_label(p)
+  expect_true(grepl('"', lab, fixed = TRUE))                   # value is quoted
+  # the R coefficient itself is not a bare 0.-prefixed number
+  expect_false(grepl('italic(R)~`=`~0.', lab, fixed = TRUE))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
 })
 
 test_that("stat_cor new label options work with text output (#540/#541)", {


### PR DESCRIPTION
## Follow-up to #700 (#540)

`stat_cor(r.leading.zero = FALSE)` / `p.leading.zero = FALSE` produced the correct label **string** (e.g. `italic(R)~`=`~.87`), and CI + two reviewers (checking `ggplot_build()`) passed. But the confirmation reprex — rendering the actual plot — revealed the leading zero was **still present in the image**: for the default `output.type = "expression"`, plotmath parses a bare `.87` as a *number* and renders it back as `0.87`. A build-invisible, draw-time-only bug.

## Fix

New helper `.quote_leading_zero_dropped()` wraps a leading-zero-dropped value in quotes so plotmath renders it literally, keeping the minus sign outside the quotes:

```
italic(R)~`=`~-.87   ->   italic(R)~`=`~-".87"      # renders  R = -.87
italic(p)~`<`~.001   ->   italic(p)~`<`~".001"      # renders  p < .001
```

Called **only** when `r.leading.zero`/`p.leading.zero` is explicitly `FALSE`, so `p.format.style` presets keep their existing numeric rendering (quoting the apa path would have exposed `.001000000000` trailing-zero garbage — deliberately avoided). Expression output only; text/latex and defaults are byte-identical.

## Verification (by RENDER, not `ggplot_build`)

- Rendered pixels confirmed: `R = -.87, p < .001` (dropped) vs default `R = -0.87` (unchanged); positive r, R², negative r, multi-line (`atop`), text/latex, grouped/faceted, apa preset (no garbage) all correct.
- Regex quotes only bare `.NN` values; `0.87`, `1.00`, `2.2e-16`, `1` untouched.
- New/updated tests in `tests/testthat/test-stat_cor.R` assert the render-correct quoted form and render via `ggplot_gtable(ggplot_build(p))`; revert-sensitive.
- Full suite: `FAIL 0 | PASS 613`.
- Two independent render-focused adversarial reviewers: both SAFE.

Refs #540
