### PR TITLE
Fix stat_regline_equation() wrong equation for orthogonal poly() (#653)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,15 @@
 
 ## Bug fixes
 
+- `stat_regline_equation()` now displays the correct equation for orthogonal
+  polynomial fits such as `formula = y ~ poly(x, 2)`. Previously the orthogonal
+  basis coefficients were printed as if they were raw polynomial coefficients,
+  giving a wrong equation that did not match the fitted curve. For a simple
+  `poly(x, k)` term with an intercept, the equation is now computed from an
+  equivalent `raw = TRUE` fit (identical curve, R², AIC, BIC). Linear,
+  `raw = TRUE`, and `I(x^2)` formulas are unaffected; no-intercept models and
+  transformed poly arguments (e.g. `poly(log(x), 2)`) keep their previous
+  behavior (#653).
 - `ggscatterhist()` now aligns the marginal plots with the main scatter plot's
   axes. The margins were built from the raw data, so anything that changed the
   scatter limits (`ellipse = TRUE`, `position` jitter, explicit `xlim`/`ylim`)

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -154,6 +154,23 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
   res.lm <- stats::lm(formula, data)
   coefs <- stats::coef(res.lm)
 
+  # With an orthogonal poly() fit (the default, raw = FALSE), coef() returns
+  # coefficients in the orthogonal basis, but the displayed equation treats them
+  # as raw polynomial coefficients (c0 + c1 x + c2 x^2 + ...), giving a wrong
+  # equation (#653). For a simple poly(x, k) term with an intercept, refit with
+  # raw = TRUE - an identical fit - to obtain the correct raw coefficients for
+  # display. R^2/AIC/BIC are unchanged (same fit) and stay from the original
+  # model. .polynomial_raw_formula() returns NULL for cases that are not safe to
+  # rewrite (no intercept, transformed poly argument, ...), leaving the original
+  # coefficients untouched.
+  raw.formula <- .polynomial_raw_formula(formula)
+  if (!is.null(raw.formula)) {
+    coefs <- tryCatch(
+      stats::coef(stats::lm(raw.formula, data)),
+      error = function(e) coefs
+    )
+  }
+
   formula.rhs.chr <- as.character(formula)[3]
   if (grepl("-1", formula.rhs.chr) || grepl("- 1", formula.rhs.chr)) {
     coefs <- c(0, coefs)
@@ -211,4 +228,48 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
     dplyr::select(rr, adj.rr, AIC, BIC, everything())
 
   z
+}
+
+# If a formula fits an ORTHOGONAL polynomial - poly(x, k) or poly(x, k, raw =
+# FALSE) - return an equivalent formula using raw = TRUE, whose coefficients are
+# the raw polynomial coefficients suitable for display. Returns NULL when no
+# rewrite is needed or cannot be done safely, in which case the original
+# coefficients are used (unchanged behavior):
+#   * no poly(), or poly() already raw = TRUE, or a raw form such as y ~ x /
+#     y ~ x + I(x^2);
+#   * a model without an intercept (- 1): an orthogonal poly() without an
+#     intercept does NOT fit the same curve as its raw = TRUE counterpart, so
+#     rewriting would not be an identical fit;
+#   * a poly() whose first argument is itself a call, e.g. poly(log(x), 2): the
+#     simple textual rewrite can't be applied reliably.
+# Only a single, simple poly(<var>, ...) term is rewritten (#653).
+.polynomial_raw_formula <- function(formula) {
+  rhs <- paste(deparse(formula[[3]]), collapse = "")
+  # Match one simple poly() call with no nested parentheses in its arguments.
+  poly.call <- regmatches(rhs, regexpr("poly\\s*\\([^()]*\\)", rhs))
+  if (length(poly.call) != 1) {
+    return(NULL)
+  }
+  if (grepl("raw\\s*=\\s*TRUE", poly.call)) {
+    return(NULL)
+  }
+  # No-intercept models: orthogonal vs raw poly are not the same fit.
+  if (grepl("-\\s*1(\\b|$)", rhs)) {
+    return(NULL)
+  }
+  if (grepl("raw\\s*=", poly.call)) {
+    # explicit raw = FALSE (or other) -> force raw = TRUE
+    new.call <- sub("raw\\s*=\\s*[^,)]+", "raw = TRUE", poly.call)
+  } else {
+    # no raw argument -> add it inside the poly() call
+    new.call <- sub("\\)\\s*$", ", raw = TRUE)", poly.call)
+  }
+  rhs <- sub(poly.call, new.call, rhs, fixed = TRUE)
+  tryCatch(
+    stats::as.formula(
+      paste(deparse(formula[[2]]), "~", rhs),
+      env = environment(formula)
+    ),
+    error = function(e) NULL
+  )
 }

--- a/tests/testthat/test-regline-digits.R
+++ b/tests/testthat/test-regline-digits.R
@@ -40,3 +40,60 @@ test_that("rr.digits controls R^2 precision (#312)", {
   expect_match(.rr_label(d, rr.digits = 4), "0.9789")
   expect_false(identical(.rr_label(d, rr.digits = 2), .rr_label(d, rr.digits = 4)))
 })
+
+# Regression tests for #653: stat_regline_equation() displayed the orthogonal
+# poly() coefficients as if they were raw polynomial coefficients, giving a
+# wrong equation. It now refits with raw = TRUE for display.
+
+test_that("stat_regline_equation shows the correct raw polynomial for poly(x, 2) (#653)", {
+  test_db <- data.frame(
+    x = c(0, -0.1297, -0.2185, -0.2795),
+    y = c(0.7569, 0.7396, 0.6561, 0.5476)
+  )
+  eq <- function(formula) {
+    p <- ggplot2::ggplot(test_db, ggplot2::aes(x, y)) + ggplot2::geom_point() +
+      stat_regline_equation(
+        ggplot2::aes(label = ggplot2::after_stat(eq.label)),
+        formula = formula, coef.digits = 3
+      )
+    as.character(ggplot2::ggplot_build(p)$data[[2]]$label)
+  }
+  # correct raw equation: y = -4.24 x^2 - 0.447 x + 0.756
+  lab.orth <- eq(y ~ poly(x, 2))
+  expect_match(lab.orth, "-4.24", fixed = TRUE)
+  expect_match(lab.orth, "0.756", fixed = TRUE)
+  # orthogonal poly() now matches raw = TRUE (same fitted curve)
+  expect_identical(lab.orth, eq(y ~ poly(x, 2, raw = TRUE)))
+  # the buggy orthogonal coefficient (~ -0.0716) must NOT appear
+  expect_false(grepl("0.0716", lab.orth, fixed = TRUE))
+})
+
+test_that("stat_regline_equation linear/raw/I() equations are unchanged (#653)", {
+  d <- .set()
+  # y ~ x has no poly() -> untouched
+  expect_match(.eq_label(d), "3.4")
+  # helper: rewrite only orthogonal poly()
+  expect_null(.polynomial_raw_formula(y ~ x))
+  expect_null(.polynomial_raw_formula(y ~ poly(x, 2, raw = TRUE)))
+  expect_null(.polynomial_raw_formula(y ~ x + I(x^2)))
+  expect_equal(
+    deparse(.polynomial_raw_formula(y ~ poly(x, 2))),
+    "y ~ poly(x, 2, raw = TRUE)"
+  )
+  expect_equal(
+    deparse(.polynomial_raw_formula(y ~ poly(x, 3, raw = FALSE))),
+    "y ~ poly(x, 3, raw = TRUE)"
+  )
+})
+
+test_that("stat_regline_equation skips unsafe poly rewrites (#653)", {
+  # No-intercept: orthogonal poly() != raw poly() fit -> leave as-is
+  expect_null(.polynomial_raw_formula(y ~ poly(x, 2) - 1))
+  # Transformed poly argument: cannot rewrite reliably -> leave as-is
+  expect_null(.polynomial_raw_formula(y ~ poly(log(x), 2)))
+  # These still render without error (fall back to original coefficients)
+  d <- data.frame(x = 1:20, y = (1:20)^2 + rnorm(20))
+  p <- ggplot2::ggplot(d, ggplot2::aes(x, y)) + ggplot2::geom_point() +
+    stat_regline_equation(formula = y ~ poly(x, 2) - 1)
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})


### PR DESCRIPTION
## Problem (#653)

`stat_regline_equation(formula = y ~ poly(x, 2))` displayed a **mathematically wrong** equation. It printed the coefficients of the *orthogonal* polynomial basis (`coef(lm(y ~ poly(x, 2)))`) as if they were *raw* polynomial coefficients (`c0 + c1 x + c2 x^2`), so the shown equation did not match the fitted curve.

For the reported data it showed `y = -0.072 x^2 + 0.15 x + 0.68` instead of the correct `y = -4.24 x^2 - 0.45 x + 0.76`.

## Fix

For a simple `poly(x, k)` term **with an intercept**, refit with `raw = TRUE` — an identical fit whose coefficients *are* the raw polynomial coefficients — and use those for the displayed equation (`.polynomial_raw_formula()` helper). R², adj. R², AIC and BIC are unchanged (same fit) and still read from the original model.

The rewrite is intentionally conservative — it returns `NULL` (leaving behavior unchanged) when it can't guarantee an identical fit:
- linear (`y ~ x`), already-raw (`poly(..., raw = TRUE)`), and `y ~ x + I(x^2)` formulas;
- no-intercept models (`y ~ poly(x, 2) - 1`) — orthogonal ≠ raw fit there;
- transformed poly arguments (`poly(log(x), 2)`).

## Verification

- **Render-verified**: the issue's example now shows `y = -4.24 x^2 - 0.447 x + 0.756` (`coef.digits = 3`), and the polynomial matches the drawn `stat_smooth(formula = y ~ poly(x, 2))` curve (max eval error ~0.005).
- Correct across degrees 2/3/4; grouped/faceted plots render with correct per-group equations.
- New/updated tests in `tests/testthat/test-regline-digits.R` (revert-sensitive; cover the fix, the no-regression formulas, and the explicit skip cases).
- Full suite: `FAIL 0 | PASS 626`.
- Two independent adversarial reviewers (render-focused), two rounds: both SAFE; the second round hardened the edge-case handling they flagged.

Fixes #653
