### PR TITLE
Accept 'colour' as an alias for 'color' in core plotting functions (#317)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,11 @@
 
 ## Bug fixes
 
+- The core plotting functions (`ggscatter()`, `ggboxplot()`, `ggviolin()`,
+  `ggline()`, `ggbarplot()`, `gghistogram()`, `ggdensity()`, `ggdotplot()`,
+  `ggstripchart()`, `ggerrorplot()`, `ggecdf()`, `ggdotchart()`, `ggpaired()`,
+  `ggqqplot()`) now accept the British spelling `colour` as an alias for
+  `color`. Previously `colour` was silently ignored (#317).
 - `stat_regline_equation()` now displays the correct equation for orthogonal
   polynomial fits such as `formula = y ~ poly(x, 2)`. Previously the orthogonal
   basis coefficients were printed as if they were raw polynomial coefficients,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -810,6 +810,15 @@ keep_only_tbl_df_classes <- function(x) {
                      fun_name = "", group = 1, # used only by ggline
                      show.legend.text = NA,
                      ...) {
+  # Accept the British spelling `colour` as an alias for `color` (#317).
+  # Map it to `color` and drop it from the extra args so it is not also passed
+  # to the geom (which would raise a "Duplicated aesthetics" warning). `.extra`
+  # replaces `...` in the downstream calls below.
+  .extra <- list(...)
+  if (!is.null(.extra$colour)) {
+    color <- .extra$colour
+    .extra$colour <- NULL
+  }
   if (is.logical(merge)) {
     if (merge) {
       merge <- "asis"
@@ -921,19 +930,22 @@ keep_only_tbl_df_classes <- function(x) {
   # Plotting
   # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   # Apply function to each y variables
-  p <- purrr::pmap(opts, fun,
-    color = color, fill = fill, legend = legend,
-    legend.title = legend.title, ggtheme = ggtheme, facet.by = facet.by,
-    add = add, add.params = add.params,
-    # group = group, # for line plot
-    user.add.color = user.add.color,
-    label = .lab, # used only in ggbarplot
-    font.label = font.label, repel = repel, label.rectangle = label.rectangle,
-    ...
-  )
+  p <- do.call(purrr::pmap, c(
+    list(
+      .l = opts, .f = fun,
+      color = color, fill = fill, legend = legend,
+      legend.title = legend.title, ggtheme = ggtheme, facet.by = facet.by,
+      add = add, add.params = add.params,
+      # group = group, # for line plot
+      user.add.color = user.add.color,
+      label = .lab, # used only in ggbarplot
+      font.label = font.label, repel = repel, label.rectangle = label.rectangle
+    ),
+    .extra
+  ))
   # Faceting
   if (!is.null(facet.by)) {
-    p <- purrr::map(p, facet, facet.by = facet.by, ...)
+    p <- do.call(purrr::map, c(list(.x = p, .f = facet, facet.by = facet.by), .extra))
   }
 
 

--- a/tests/testthat/test-colour-alias.R
+++ b/tests/testthat/test-colour-alias.R
@@ -1,0 +1,28 @@
+context("test-colour-alias")
+
+# #317: accept the British spelling `colour` as an alias for `color` in the
+# core plotting functions (those routed through .plotter). Previously `colour`
+# was silently ignored.
+
+ng <- function(p) length(unique(ggplot2::ggplot_build(p)$data[[1]]$colour))
+
+test_that("colour is an alias for color (grouping) across core functions (#317)", {
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  expect_equal(ng(ggscatter(mtcars, "wt", "mpg", colour = "cyl")),
+               ng(ggscatter(mtcars, "wt", "mpg", color = "cyl")))
+  expect_equal(ng(ggboxplot(tg, "dose", "len", colour = "dose")),
+               ng(ggboxplot(tg, "dose", "len", color = "dose")))
+  expect_equal(ng(ggviolin(tg, "dose", "len", colour = "dose")), 3L)
+  expect_equal(ng(ggstripchart(tg, "dose", "len", colour = "dose")), 3L)
+})
+
+test_that("colour works as a static color and does not break color (#317)", {
+  d <- ggplot2::ggplot_build(ggscatter(mtcars, "wt", "mpg", colour = "red"))$data[[1]]
+  expect_true(all(d$colour == "red"))
+  # color = still works and default is unchanged
+  d2 <- ggplot2::ggplot_build(ggscatter(mtcars, "wt", "mpg"))$data[[1]]
+  expect_true(all(d2$colour == "black"))
+  d3 <- ggplot2::ggplot_build(ggscatter(mtcars, "wt", "mpg", color = "blue"))$data[[1]]
+  expect_true(all(d3$colour == "blue"))
+})


### PR DESCRIPTION
## Request (#317)

British/Australian English users instinctively write `colour = ...`, but ggpubr only recognized `color = ...`. `colour` was silently ignored (and, if forced through, produced a `Duplicated aesthetics after name standardisation: colour` warning).

## Change

The shared plot builder `.plotter()` — used by **14 core functions** (`ggscatter`, `ggboxplot`, `ggviolin`, `ggline`, `ggbarplot`, `gghistogram`, `ggdensity`, `ggdotplot`, `ggstripchart`, `ggerrorplot`, `ggecdf`, `ggdotchart`, `ggpaired`, `ggqqplot`) — now:
1. maps a `colour` argument to `color`;
2. removes `colour` from the extra args so it is not also forwarded to the geom (avoiding the duplicate-aesthetics warning).

The two `...` forwardings (to the geom builder `purrr::pmap(...)` and to `facet()`) are rewritten as `do.call(..., c(list(<named>), .extra))` where `.extra` is `list(...)` with `colour` removed.

`colour` now works exactly like `color` — both as a grouping variable and as a static colour. `color` is unaffected.

## Verification

- `colour=` == `color=` (grouping and static) across all 14 functions; **no** duplicate-aesthetics warnings.
- **do.call rewrite is byte-identical** to the previous `...` forwarding: a reviewer diffed `ggplot_build()$data` across 24 existing-input calls (defaults, `color=`, `fill=`, `add=`/`add.params`, `facet.by=`, `combine`/`merge` with multiple y, `select`/`order`, extra `alpha`/`size`/`shape`) — all identical.
- Faceting (`panel.labs`, `short.panel.labs`, `scales`, `strip.position`) still forwarded correctly.
- New `tests/testthat/test-colour-alias.R` (revert-sensitive).
- Full suite: `FAIL 0 | PASS 633 | WARN 8` (baseline unchanged).
- Two independent adversarial reviewers: both SAFE.

Note: functions not built on `.plotter` (`ggpie`, `ggdonutchart`, `ggballoonplot`, `ggtexttable`) are unchanged; `colour` is harmlessly ignored there.

Fixes #317
