### PR TITLE
Add a position argument to ggboxplot() (#615)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,12 @@
 
 ## Bug fixes
 
+- `ggboxplot()` now accepts a `position` argument (e.g.
+  `position = position_dodge(0.9)`), like `ggviolin()`/`ggdotplot()` already do.
+  Previously passing `position` errored (`formal argument "position" matched by
+  multiple actual arguments`) because the dodge was hardcoded; the default is
+  unchanged (`position_dodge(0.8)`), so grouped box plots look the same unless
+  you set it (#615).
 - The core plotting functions (`ggscatter()`, `ggboxplot()`, `ggviolin()`,
   `ggline()`, `ggbarplot()`, `gghistogram()`, `ggdensity()`, `ggdotplot()`,
   `ggstripchart()`, `ggerrorplot()`, `ggecdf()`, `ggdotchart()`, `ggpaired()`,

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -58,6 +58,11 @@ NULL
 #'  "bold.italic") and the color (e.g.: "red") of labels. For example font.label
 #'  = list(size = 14, face = "bold", color ="red"). To specify only the size and
 #'  the style, use font.label = list(size = 14, face = "plain").
+#' @param position position adjustment, either as a string, or the result of a
+#'  call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+#'  Used to control the spacing between boxes of grouped box plots. Applies to
+#'  the box and box-error-bar layers; layers added via \code{add} (e.g.
+#'  "jitter") keep their own default positioning.
 #' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr().
 #'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'  theme_minimal(), theme_classic(), theme_void(), ....
@@ -166,6 +171,7 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
                       error.plot = "pointrange",
                       label = NULL, font.label = list(size = 11, color = "black"),
                       label.select = NULL, repel = FALSE, label.rectangle = FALSE,
+                      position = position_dodge(0.8),
                       ggtheme = theme_pubr(), ...) {
   # Default options
   # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -180,7 +186,8 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
     select = select, remove = remove, order = order,
     add = add, add.params = add.params, error.plot = error.plot,
     label = label, font.label = font.label, label.select = label.select,
-    repel = repel, label.rectangle = label.rectangle, ggtheme = ggtheme, ...
+    repel = repel, label.rectangle = label.rectangle, position = position,
+    ggtheme = ggtheme, ...
   )
   if (!missing(data)) .opts$data <- data
   if (!missing(x)) .opts$x <- x
@@ -217,6 +224,7 @@ ggboxplot_core <- function(data, x, y,
                            add = "none", add.params = list(),
                            error.plot = "pointrange",
                            ggtheme = theme_pubr(),
+                           position = position_dodge(0.8),
                            ...) {
   line_width <- .resolve_linewidth_args(
     size = size, linewidth = linewidth, default_linewidth = NULL
@@ -233,12 +241,12 @@ ggboxplot_core <- function(data, x, y,
       # Important, so that the fill grouping is taken into account in the errorbar
       p <- p + geom_exec(
         geomfunc = stat_boxplot, data = data, geom = "errorbar", width = bxp.errorbar.width,
-        color = color, fill = fill, linetype = linetype, position = position_dodge(0.8)
+        color = color, fill = fill, linetype = linetype, position = position
       )
     } else {
       p <- p + geom_exec(
         geomfunc = stat_boxplot, data = data, geom = "errorbar", width = bxp.errorbar.width,
-        color = color, linetype = linetype, position = position_dodge(0.8)
+        color = color, linetype = linetype, position = position
       )
     }
   }
@@ -248,7 +256,7 @@ ggboxplot_core <- function(data, x, y,
     color = color, fill = fill, linetype = linetype,
     size = linewidth, width = width, notch = notch,
     outliers = outliers, outlier.shape = outlier.shape,
-    position = position_dodge(0.8), ...
+    position = position, ...
   )
 
   # Add

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -39,6 +39,7 @@ ggboxplot(
   label.select = NULL,
   repel = FALSE,
   label.rectangle = FALSE,
+  position = position_dodge(0.8),
   ggtheme = theme_pubr(),
   ...
 )
@@ -167,6 +168,12 @@ text labels or not.}
 
 \item{label.rectangle}{logical value. If TRUE, add rectangle underneath the
 text, making it easier to read.}
+
+\item{position}{position adjustment, either as a string, or the result of a
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}). Used
+to control the spacing between boxes of grouped box plots. Applies to the box
+and box-error-bar layers; layers added via \code{add} (e.g. "jitter") keep
+their own default positioning.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-ggboxplot.R
+++ b/tests/testthat/test-ggboxplot.R
@@ -39,3 +39,34 @@ test_that("The position of jittered points is reproducible in ggboxplot", {
     as.data.frame()
   expect_equal(jitter_data, expected_data)
 })
+
+# #615: ggboxplot() crashed when a `position` was supplied (the internal
+# position_dodge(0.8) was hardcoded and collided in geom_exec). `position` is
+# now an argument, so the dodge width is controllable and defaults are unchanged.
+test_that("ggboxplot accepts a position argument without error (#615)", {
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  expect_no_error(
+    ggplot2::ggplot_build(
+      ggboxplot(tg, "dose", "len", color = "supp", position = ggplot2::position_dodge(0.5))
+    )
+  )
+  # bxp.errorbar path too
+  expect_no_error(
+    ggplot2::ggplot_build(
+      ggboxplot(tg, "dose", "len", color = "supp", bxp.errorbar = TRUE,
+                position = ggplot2::position_dodge(0.9))
+    )
+  )
+})
+
+test_that("ggboxplot default dodge is unchanged and width is controllable (#615)", {
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  box_x <- function(p) ggplot2::ggplot_build(p)$data[[1]]$xmin
+  default <- box_x(ggboxplot(tg, "dose", "len", color = "supp"))
+  explicit08 <- box_x(ggboxplot(tg, "dose", "len", color = "supp", position = ggplot2::position_dodge(0.8)))
+  narrow <- box_x(ggboxplot(tg, "dose", "len", color = "supp", position = ggplot2::position_dodge(0.4)))
+  expect_equal(default, explicit08)          # default == dodge(0.8), no regression
+  expect_false(isTRUE(all.equal(default, narrow)))  # width actually changes spacing
+})


### PR DESCRIPTION
## Problem (#615)

`ggboxplot(..., position = position_dodge(0.9))` errored with:

```
formal argument "position" matched by multiple actual arguments
```

`ggboxplot_core()` hardcoded `position = position_dodge(0.8)` in its `geom_exec()` calls while also forwarding `...`, so a user-supplied `position` was passed twice. There was also no way to control the dodge width of grouped box plots.

## Fix

Add a `position = position_dodge(0.8)` argument to the public `ggboxplot()` (and `.opts`) and to `ggboxplot_core()`, and use it in the three `geom_exec()` calls instead of the hardcoded value. This mirrors `ggviolin()` and `ggdotplot()`, which already expose `position` — `ggboxplot()` was the outlier.

The default is unchanged (`position_dodge(0.8)`), so existing grouped box plots render identically unless `position` is set. `position` applies to the box and box-error-bar layers; `add=` layers (e.g. "jitter") keep their own default positioning (documented; unchanged from before).

## Verification

- `position = position_dodge(0.5)` no longer errors and narrows the box spacing; `bxp.errorbar = TRUE` path honored.
- **Default byte-identical**: reviewers compared `ggplot_build()$data` against a pristine `R/ggboxplot.R` from HEAD across 10 scenarios (default grouped/ungrouped, `bxp.errorbar`, `add="jitter"`/`"mean_se"`, `facet.by`, `combine`, `notch`, `select`, `order`) — all identical.
- Interaction with the new `colour` alias verified (binds to the formal, no re-introduced duplicate-position crash).
- New revert-sensitive tests in `tests/testthat/test-ggboxplot.R`; `man/ggboxplot.Rd` updated (checkRd clean); NEWS updated.
- Full suite: `FAIL 0 | PASS 637`.
- Two independent adversarial reviewers: both SAFE.

Fixes #615
