### PR TITLE
Add numeric.x.axis argument to ggbarplot() (#463)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,14 @@
   - `p.coef.name` — symbol for the p-value label; use `"P"` for an uppercase
     p-value (#541).
 
+## New features
+
+- `ggbarplot()` gains a `numeric.x.axis` argument (already available in
+  `ggline()` and `ggerrorplot()`). With `numeric.x.axis = TRUE` the x variable
+  is kept numeric instead of being coerced to a discrete factor, so bars are
+  drawn at their numeric x positions (e.g. a time axis). Default is `FALSE`
+  (unchanged behavior) (#463).
+
 ## Bug fixes
 
 - `ggboxplot()` now accepts a `position` argument (e.g.

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -11,6 +11,11 @@ NULL
 #' @param sort.by.groups logical value. If TRUE the data are sorted by groups.
 #' Used only when sort.val != "none".
 #' @param top a numeric value specifying the number of top elements to be shown.
+#' @param numeric.x.axis logical. If TRUE, x axis will be treated as numeric.
+#'   Default is FALSE. Useful, for example, to plot bars at their numeric x
+#'   positions (e.g. a time axis) instead of at equally-spaced discrete
+#'   categories. Ignored when \code{order} is set or \code{sort.val != "none"},
+#'   which require a discrete x axis.
 #' @param label specify whether to add labels on the bar plot. Allowed values
 #'   are: \itemize{ \item \strong{logical value}: If TRUE, y values is added as
 #'   labels on the bar plot \item \strong{character vector}: Used as text
@@ -180,6 +185,7 @@ ggbarplot <- function(data, x, y, combine = FALSE, merge = FALSE,
                       sort.val = c("none", "desc", "asc"), sort.by.groups = TRUE,
                       top = Inf,
                       position = position_stack(),
+                      numeric.x.axis = FALSE,
                       ggtheme = theme_pubr(),
                       ...) {
   # Default options
@@ -196,7 +202,7 @@ ggbarplot <- function(data, x, y, combine = FALSE, merge = FALSE,
     lab.pos = lab.pos, lab.vjust = lab.vjust, lab.hjust = lab.hjust,
     lab.nb.digits = lab.nb.digits,
     sort.val = sort.val, sort.by.groups = sort.by.groups, top = top,
-    position = position, ggtheme = ggtheme, ...
+    position = position, numeric.x.axis = numeric.x.axis, ggtheme = ggtheme, ...
   )
 
   if (!missing(data)) .opts$data <- data
@@ -251,16 +257,15 @@ ggbarplot_core <- function(data, x, y,
                            add.params = list(),
                            error.plot = "errorbar",
                            position = position_stack(),
+                           numeric.x.axis = FALSE,
                            ggtheme = theme_pubr(),
                            ...) {
   sort.val <- match.arg(sort.val)
+  xx <- .select_vec(data, x)
   if (!is.null(order)) {
     data[[x]] <- factor(data[[x]], levels = order)
-  } else {
-    xx <- .select_vec(data, x)
-    if (inherits(xx, c("character", "numeric"))) {
-      data[[x]] <- as.factor(data[[x]])
-    }
+  } else if (inherits(xx, c("character", "numeric")) & !numeric.x.axis) {
+    data[[x]] <- as.factor(data[[x]])
   }
   error.plot <- error.plot[1]
   lab.pos <- match.arg(lab.pos)
@@ -292,7 +297,7 @@ ggbarplot_core <- function(data, x, y,
 
     add <- setdiff(add, .center)
     names(data_sum)[which(names(data_sum) == .center)] <- y
-    if (inherits(xx, c("character", "numeric"))) {
+    if (inherits(xx, c("character", "numeric")) & !numeric.x.axis) {
       data_sum[, x] <- .select_vec(data_sum, x) %>% as.factor()
     }
   } else {

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -38,6 +38,7 @@ ggbarplot(
   sort.by.groups = TRUE,
   top = Inf,
   position = position_stack(),
+  numeric.x.axis = FALSE,
   ggtheme = theme_pubr(),
   ...
 )
@@ -140,6 +141,12 @@ Allowed values are "none" (no sorting), "asc" (for ascending) or "desc" (for des
 Used only when sort.val != "none".}
 
 \item{top}{a numeric value specifying the number of top elements to be shown.}
+
+\item{numeric.x.axis}{logical. If TRUE, x axis will be treated as numeric.
+Default is FALSE. Useful, for example, to plot bars at their numeric x
+positions (e.g. a time axis) instead of at equally-spaced discrete
+categories. Ignored when \code{order} is set or \code{sort.val != "none"},
+which require a discrete x axis.}
 
 \item{position}{A position adjustment to use on the data for this layer. This
 can be used in various ways, including to prevent overplotting and

--- a/tests/testthat/test-ggbarplot-numeric-x.R
+++ b/tests/testthat/test-ggbarplot-numeric-x.R
@@ -1,0 +1,30 @@
+context("test-ggbarplot-numeric-x")
+
+# #463: numeric.x.axis (already available in ggline/ggerrorplot) is now
+# supported by ggbarplot. Default (FALSE) keeps the discrete-factor x axis.
+
+x_is_discrete <- function(p) {
+  ggplot2::ggplot_build(p)$layout$panel_scales_x[[1]]$is_discrete()
+}
+
+test_that("ggbarplot default keeps a discrete x axis (no regression, #463)", {
+  df <- data.frame(x = c(1, 2, 5, 10), y = c(3, 5, 4, 8))
+  expect_true(x_is_discrete(ggbarplot(df, "x", "y")))
+})
+
+test_that("ggbarplot numeric.x.axis = TRUE gives a numeric x axis (#463)", {
+  df <- data.frame(x = c(1, 2, 5, 10), y = c(3, 5, 4, 8))
+  p <- ggbarplot(df, "x", "y", numeric.x.axis = TRUE, width = 1)
+  expect_false(x_is_discrete(p))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+  # bars sit at their numeric x positions
+  bx <- ggplot2::ggplot_build(p)$data[[1]]$x
+  expect_equal(sort(bx), c(1, 2, 5, 10))
+})
+
+test_that("ggbarplot numeric.x.axis works with summary (mean_se) (#463)", {
+  df <- data.frame(x = rep(c(1, 2, 5), each = 4), y = rnorm(12, 5))
+  p <- ggbarplot(df, "x", "y", add = "mean_se", numeric.x.axis = TRUE, width = 0.8)
+  expect_false(x_is_discrete(p))
+  expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
+})


### PR DESCRIPTION
## Request (#463)

`numeric.x.axis` is implemented for `ggline()` (#35) and `ggerrorplot()` (#280); this ports it to `ggbarplot()`.

## Change

Add `numeric.x.axis = FALSE` to `ggbarplot()` (and `ggbarplot_core()`). With `numeric.x.axis = TRUE`, the x variable is kept numeric instead of being coerced to a discrete factor, so bars are drawn at their numeric x positions (e.g. a time axis). The default is `FALSE`, so existing bar plots are unchanged.

Implementation mirrors `ggline`: the two `as.factor(x)` coercions in `ggbarplot_core()` are gated with `& !numeric.x.axis`. `xx` (the raw x vector) is now computed once at the top of `ggbarplot_core()` so it is always defined (previously only assigned in the no-`order` branch but referenced later in the summary path — a latent tidy-up). Ignored when `order` is set or `sort.val != "none"` (documented; those require a discrete axis).

## Verification

- `ggbarplot(df, "x", "y", numeric.x.axis = TRUE)` gives a numeric (non-discrete) x scale with bars at their true positions; works with `add="mean_se"` and grouping; matches `ggline(numeric.x.axis = TRUE)`.
- **Default byte-identical**: reviewers diffed `ggplot_build()$data` against a pristine HEAD copy across 11 scenarios (character/numeric x, `mean_se`, `fill` dodge, `facet.by`, `sort.val`, `order`, `label`, `position`, `combine`, `order`+`mean_se`) — all identical.
- New revert-sensitive tests (`tests/testthat/test-ggbarplot-numeric-x.R`); roxygen + `man/ggbarplot.Rd` updated (checkRd clean); NEWS updated.
- Full suite: `FAIL 0 | PASS 643`.
- Two independent adversarial reviewers: both SAFE (100%).

Fixes #463
