### PR TITLE
Add tip.length.ref for constant bracket tips (#362)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,7 +61,11 @@
   y-axis range (`ylim`/`scale_y_*`), which renders at the same physical fraction
   across plots and therefore gives visually constant tip lengths regardless of
   the data range - useful to keep tips consistent across facets or across
-  separate plots with different scales (#362).
+  separate plots with different scales (#362). `stat_compare_means(comparisons =)`
+  draws its brackets via `ggsignif::geom_signif()` and does not support
+  `tip.length.ref`; passing it there now emits an informative message pointing to
+  `stat_pvalue_manual(..., tip.length.ref = "axis")` instead of being silently
+  ignored (#362).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,15 @@
   drawn at their numeric x positions (e.g. a time axis). Default is `FALSE`
   (unchanged behavior) (#463).
 
+- `geom_bracket()` and `stat_pvalue_manual()` gain a `tip.length.ref` argument
+  controlling what `tip.length` is a fraction of. With the default
+  `tip.length.ref = "data"` the tips are a fraction of the data range (unchanged
+  behavior). With `tip.length.ref = "axis"` the tips are a fraction of the
+  y-axis range (`ylim`/`scale_y_*`), which renders at the same physical fraction
+  across plots and therefore gives visually constant tip lengths regardless of
+  the data range - useful to keep tips consistent across facets or across
+  separate plots with different scales (#362).
+
 ## Bug fixes
 
 - `ggboxplot()` now accepts a `position` argument (e.g.

--- a/R/geom_bracket.R
+++ b/R/geom_bracket.R
@@ -8,9 +8,22 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
     if (length(params$tip.length) == length(params$xmin)) params$tip.length <- rep(params$tip.length, each = 2)
     return(params)
   },
-  compute_group = function(data, scales, tip.length) {
+  compute_group = function(data, scales, tip.length, tip.length.ref = "data") {
     yrange <- scales$y$range$range
     y.scale.range <- yrange[2] - yrange[1]
+    # Reference range used to convert the fractional `tip.length` into data units.
+    # Default ("data"): fraction of the trained data range (historical behavior) -
+    # tips scale with the data, so plots with different data ranges get different
+    # absolute tips. "axis": fraction of the y-axis range (limits set via ylim /
+    # scale_y_*), which renders at the same physical fraction across plots and so
+    # gives visually constant tips regardless of the data (#362).
+    tip.scale.range <- y.scale.range
+    if (identical(tip.length.ref, "axis")) {
+      axis.limits <- scales$y$get_limits()
+      if (length(axis.limits) == 2 && all(is.finite(axis.limits))) {
+        tip.scale.range <- axis.limits[2] - axis.limits[1]
+      }
+    }
     bracket.shorten <- data$bracket.shorten / 2
     xmin <- data$xmin + bracket.shorten
     xmax <- data$xmax - bracket.shorten
@@ -29,8 +42,8 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
     data <- dplyr::bind_rows(data, data, data)
     data$x <- c(xmin, xmin, xmax)
     data$xend <- c(xmin, xmax, xmax)
-    data$y <- c(y.position - y.scale.range * tip.length[seq_along(tip.length) %% 2 == 1], y.position, y.position)
-    data$yend <- c(y.position, y.position, y.position - y.scale.range * tip.length[seq_along(tip.length) %% 2 == 0])
+    data$y <- c(y.position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 1], y.position, y.position)
+    data$yend <- c(y.position, y.position, y.position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 0])
     data$annotation <- rep(label, 3)
     data
   }
@@ -63,8 +76,21 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
 #'   of bracket.
 #' @param step.group.by a variable name for grouping brackets before adding
 #'   step.increase. Useful to group bracket by facet panel.
-#' @param tip.length numeric vector with the fraction of total height that the
-#'   bar goes down to indicate the precise column
+#' @param tip.length numeric vector with the fraction that the bracket tips go
+#'   down to indicate the precise column. Interpreted relative to the reference
+#'   set by \code{tip.length.ref}. Default is 0.03. Can be of the same length as
+#'   the number of brackets to adjust each tip specifically, e.g.
+#'   \code{tip.length = c(0.01, 0.03)}. If too short it is recycled.
+#' @param tip.length.ref character string specifying what \code{tip.length} is a
+#'   fraction of. Allowed values are: \itemize{ \item \code{"data"} (default):
+#'   fraction of the trained data range. Tips scale with the data, so plots with
+#'   different data ranges get different absolute tip lengths (historical
+#'   behavior; keeps existing plots unchanged). \item \code{"axis"}: fraction of
+#'   the y-axis range (the limits set via \code{ylim}/\code{scale_y_*}). This
+#'   renders at the same physical fraction across plots and therefore gives
+#'   visually constant tip lengths regardless of the data - useful to keep tips
+#'   consistent across facets or across separate plots with different scales
+#'   (#362).}
 #' @param na.rm If \code{FALSE} (the default), removes missing values with a
 #'   warning.  If \code{TRUE} silently removes missing values.
 #' @param coord.flip logical. If \code{TRUE}, flip x and y coordinates so that
@@ -140,6 +166,7 @@ stat_bracket <- function(mapping = NULL, data = NULL,
                          inherit.aes = TRUE,
                          label = NULL, type = c("text", "expression"), y.position = NULL, xmin = NULL, xmax = NULL,
                          step.increase = 0, step.group.by = NULL, tip.length = 0.03,
+                         tip.length.ref = c("data", "axis"),
                          bracket.nudge.y = 0, bracket.shorten = 0,
                          size = 0.3, linewidth = size, label.size = 3.88, family = "", vjust = 0,
                          ...) {
@@ -148,6 +175,7 @@ stat_bracket <- function(mapping = NULL, data = NULL,
     if (!"y" %in% names(data)) mapping$y <- 1
   }
   type <- match.arg(type)
+  tip.length.ref <- match.arg(tip.length.ref)
   ggplot2::layer(
     stat = StatBracket, data = data, mapping = mapping, geom = "bracket",
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
@@ -156,7 +184,8 @@ stat_bracket <- function(mapping = NULL, data = NULL,
       y.position = y.position, xmin = xmin, xmax = xmax,
       step.increase = step.increase, bracket.nudge.y = bracket.nudge.y,
       bracket.shorten = bracket.shorten, step.group.by = step.group.by,
-      tip.length = tip.length, size = linewidth, label.size = label.size,
+      tip.length = tip.length, tip.length.ref = tip.length.ref,
+      size = linewidth, label.size = label.size,
       family = family, vjust = vjust, na.rm = na.rm, ...
     )
   )
@@ -228,11 +257,13 @@ geom_bracket <- function(mapping = NULL, data = NULL, stat = "bracket",
                          inherit.aes = TRUE,
                          label = NULL, type = c("text", "expression"), y.position = NULL, xmin = NULL, xmax = NULL,
                          step.increase = 0, step.group.by = NULL, tip.length = 0.03,
+                         tip.length.ref = c("data", "axis"),
                          bracket.nudge.y = 0, bracket.shorten = 0,
                          size = 0.3, linewidth = size, label.size = 3.88, family = "", vjust = 0,
                          coord.flip = FALSE,
                          ...) {
   type <- match.arg(type)
+  tip.length.ref <- match.arg(tip.length.ref)
   data <- build_signif_data(
     data = data, label = label, y.position = y.position,
     xmin = xmin, xmax = xmax, step.increase = step.increase,
@@ -245,7 +276,7 @@ geom_bracket <- function(mapping = NULL, data = NULL, stat = "bracket",
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(
       type = type,
-      tip.length = tip.length,
+      tip.length = tip.length, tip.length.ref = tip.length.ref,
       size = linewidth, label.size = label.size,
       family = family, na.rm = na.rm, coord.flip = coord.flip,
       ...

--- a/R/geom_exec.R
+++ b/R/geom_exec.R
@@ -64,7 +64,7 @@ geom_exec <- function(geomfunc = NULL, data = NULL,
     # stat_summary,
     "fun.data", "fun", "fun.min", "fun.max",
     # bracket
-    "y.position", "tip.length", "label.size", "step.increase",
+    "y.position", "tip.length", "tip.length.ref", "label.size", "step.increase",
     "bracket.nudge.y", "bracket.shorten", "coord.flip"
   )
 

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -80,7 +80,9 @@ NULL
 #'  with different scales get different tip lengths). To obtain visually constant
 #'  tip lengths across plots, compute the tests with \code{\link{compare_means}()}
 #'  and draw them with \code{\link{stat_pvalue_manual}(..., tip.length.ref = "axis")}
-#'  (which makes \code{tip.length} a fraction of the y-axis range).
+#'  (which makes \code{tip.length} a fraction of the y-axis range). Passing
+#'  \code{tip.length.ref} directly to \code{stat_compare_means()} has no effect
+#'  and emits an informative message.
 #' @param label.x,label.y \code{numeric} Coordinates (in data units) to be used
 #'  for absolute positioning of the label. If too short they will be recycled.
 #' @param bracket.size Width of the lines of the bracket.
@@ -191,6 +193,28 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
   )
 
   if (!is.null(comparisons)) {
+    # The `comparisons` path draws brackets via ggsignif::geom_signif(), whose
+    # tip length is always a fraction of the data range - ggpubr cannot alter it.
+    # `tip.length.ref` (supported by geom_bracket()/stat_pvalue_manual()) is not
+    # honored here, so warn once instead of silently ignoring it (#362).
+    if ("tip.length.ref" %in% names(list(...))) {
+      rlang::inform(
+        c(
+          paste0(
+            "`tip.length.ref` is not supported by `stat_compare_means(comparisons = )`; ",
+            "it is ignored here."
+          ),
+          i = paste0(
+            "Bracket tips are drawn by `ggsignif::geom_signif()` and are always a ",
+            "fraction of the data range. For tip lengths that stay constant across ",
+            "plots, compute the tests with `compare_means()` and draw them with ",
+            "`stat_pvalue_manual(..., tip.length.ref = \"axis\")`."
+          )
+        ),
+        .frequency = "once",
+        .frequency_id = "ggpubr_stat_compare_means_tip_length_ref"
+      )
+    }
     # The `comparisons` path draws each pairwise test independently (via
     # ggsignif::geom_signif) and shows UNADJUSTED p-values. Warn once per session
     # when there is more than one comparison, so users aren't misled into thinking

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -67,12 +67,20 @@ NULL
 #'  'middle') for x-axis; ii) and one of c( 'bottom', 'top', 'center', 'centre',
 #'  'middle') for y-axis.}
 #' @param vjust move the text up or down relative to the bracket.
-#' @param tip.length numeric vector with the fraction of total height that the
-#'  bar goes down to indicate the precise column. Default is 0.03. Can be of
+#' @param tip.length numeric vector with the fraction that the bracket tips go
+#'  down to indicate the precise column. Default is 0.03. Can be of
 #'  same length as the number of comparisons to adjust specifically the tip
 #'  lenth of each comparison. For example tip.length = c(0.01, 0.03).
 #'
 #'  If too short they will be recycled.
+#'
+#'  Note: when \code{comparisons} is set, brackets are drawn via
+#'  \code{ggsignif::geom_signif()} and \code{tip.length} is a fraction of the
+#'  trained data range, so the absolute tip length scales with your data (plots
+#'  with different scales get different tip lengths). To obtain visually constant
+#'  tip lengths across plots, compute the tests with \code{\link{compare_means}()}
+#'  and draw them with \code{\link{stat_pvalue_manual}(..., tip.length.ref = "axis")}
+#'  (which makes \code{tip.length} a fraction of the y-axis range).
 #' @param label.x,label.y \code{numeric} Coordinates (in data units) to be used
 #'  for absolute positioning of the label. If too short they will be recycled.
 #' @param bracket.size Width of the lines of the bracket.

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -40,8 +40,14 @@ NULL
 #' @param bracket.size Width of the lines of the bracket.
 #' @param color text and line color. Can be variable name in the data for coloring by groups.
 #' @param linetype linetype. Can be variable name in the data for changing linetype by groups.
-#' @param tip.length numeric vector with the fraction of total height that the
-#'  bar goes down to indicate the precise column. Default is 0.03.
+#' @param tip.length numeric vector with the fraction that the bracket tips go
+#'  down to indicate the precise column. Interpreted relative to the reference set
+#'  by \code{tip.length.ref}. Default is 0.03.
+#' @param tip.length.ref character string specifying what \code{tip.length} is a
+#'  fraction of. Either \code{"data"} (default): fraction of the trained data
+#'  range (tips scale with the data; existing plots unchanged); or \code{"axis"}:
+#'  fraction of the y-axis range (\code{ylim}/\code{scale_y_*}), giving visually
+#'  constant tip lengths across plots with different scales (#362).
 #' @param remove.bracket logical, if \code{TRUE}, brackets are removed from the
 #'  plot. Considered only in the situation, where comparisons are performed
 #'  against reference group or against "all".
@@ -132,9 +138,11 @@ stat_pvalue_manual <- function(
   size = 3.88, label.size = size, bracket.size = 0.3,
   bracket.nudge.y = 0, bracket.shorten = 0,
   color = "black", linetype = 1, tip.length = 0.03,
+  tip.length.ref = c("data", "axis"),
   remove.bracket = FALSE, step.increase = 0, step.group.by = NULL,
   hide.ns = FALSE, vjust = 0, coord.flip = FALSE, position = "identity", inherit.aes = FALSE, ...
 ) {
+  tip.length.ref <- match.arg(tip.length.ref)
   if (is.null(label)) {
     label <- guess_signif_label_column(data)
   }
@@ -241,6 +249,7 @@ stat_pvalue_manual <- function(
       data = data, xmin = "xmin", xmax = "xmax",
       label = "label", y.position = "y.position", vjust = "vjust",
       group = seq_len(nrow(data)), tip.length = tip.length,
+      tip.length.ref = tip.length.ref,
       label.size = label.size, size = bracket.size,
       bracket.nudge.y = bracket.nudge.y, bracket.shorten = bracket.shorten,
       color = color, linetype = linetype, step.increase = step.increase,

--- a/man/geom_bracket.Rd
+++ b/man/geom_bracket.Rd
@@ -20,6 +20,7 @@ stat_bracket(
   step.increase = 0,
   step.group.by = NULL,
   tip.length = 0.03,
+  tip.length.ref = c("data", "axis"),
   bracket.nudge.y = 0,
   bracket.shorten = 0,
   size = 0.3,
@@ -46,6 +47,7 @@ geom_bracket(
   step.increase = 0,
   step.group.by = NULL,
   tip.length = 0.03,
+  tip.length.ref = c("data", "axis"),
   bracket.nudge.y = 0,
   bracket.shorten = 0,
   size = 0.3,
@@ -128,8 +130,22 @@ height for every additional comparison to minimize overlap.}
 \item{step.group.by}{a variable name for grouping brackets before adding
 step.increase. Useful to group bracket by facet panel.}
 
-\item{tip.length}{numeric vector with the fraction of total height that the
-bar goes down to indicate the precise column}
+\item{tip.length}{numeric vector with the fraction that the bracket tips go
+down to indicate the precise column. Interpreted relative to the reference
+set by \code{tip.length.ref}. Default is 0.03. Can be of the same length as
+the number of brackets to adjust each tip specifically, e.g.
+\code{tip.length = c(0.01, 0.03)}. If too short it is recycled.}
+
+\item{tip.length.ref}{character string specifying what \code{tip.length} is a
+fraction of. Allowed values are: \itemize{ \item \code{"data"} (default):
+fraction of the trained data range. Tips scale with the data, so plots with
+different data ranges get different absolute tip lengths (historical
+behavior; keeps existing plots unchanged). \item \code{"axis"}: fraction of
+the y-axis range (the limits set via \code{ylim}/\code{scale_y_*}). This
+renders at the same physical fraction across plots and therefore gives
+visually constant tip lengths regardless of the data - useful to keep tips
+consistent across facets or across separate plots with different scales
+(#362).}}
 
 \item{bracket.nudge.y}{Vertical adjustment to nudge brackets by. Useful to
 move up or move down the bracket. If positive value, brackets will be moved

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -128,7 +128,9 @@ for absolute positioning of the label. If too short they will be recycled.}
  with different scales get different tip lengths). To obtain visually constant
  tip lengths across plots, compute the tests with \code{\link{compare_means}()}
  and draw them with \code{\link{stat_pvalue_manual}(..., tip.length.ref = "axis")}
- (which makes \code{tip.length} a fraction of the y-axis range).}
+ (which makes \code{tip.length} a fraction of the y-axis range). Passing
+ \code{tip.length.ref} directly to \code{stat_compare_means()} has no effect
+ and emits an informative message.}
 
 \item{bracket.size}{Width of the lines of the bracket.}
 

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -115,12 +115,20 @@ for absolute positioning of the label. If too short they will be recycled.}
 
 \item{vjust}{move the text up or down relative to the bracket.}
 
-\item{tip.length}{numeric vector with the fraction of total height that the
- bar goes down to indicate the precise column. Default is 0.03. Can be of
+\item{tip.length}{numeric vector with the fraction that the bracket tips go
+ down to indicate the precise column. Default is 0.03. Can be of
  same length as the number of comparisons to adjust specifically the tip
  lenth of each comparison. For example tip.length = c(0.01, 0.03).
 
- If too short they will be recycled.}
+ If too short they will be recycled.
+
+ Note: when \code{comparisons} is set, brackets are drawn via
+ \code{ggsignif::geom_signif()} and \code{tip.length} is a fraction of the
+ trained data range, so the absolute tip length scales with your data (plots
+ with different scales get different tip lengths). To obtain visually constant
+ tip lengths across plots, compute the tests with \code{\link{compare_means}()}
+ and draw them with \code{\link{stat_pvalue_manual}(..., tip.length.ref = "axis")}
+ (which makes \code{tip.length} a fraction of the y-axis range).}
 
 \item{bracket.size}{Width of the lines of the bracket.}
 

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -19,6 +19,7 @@ stat_pvalue_manual(
   color = "black",
   linetype = 1,
   tip.length = 0.03,
+  tip.length.ref = c("data", "axis"),
   remove.bracket = FALSE,
   step.increase = 0,
   step.group.by = NULL,
@@ -72,8 +73,15 @@ of bracket.}
 
 \item{linetype}{linetype. Can be variable name in the data for changing linetype by groups.}
 
-\item{tip.length}{numeric vector with the fraction of total height that the
-bar goes down to indicate the precise column. Default is 0.03.}
+\item{tip.length}{numeric vector with the fraction that the bracket tips go
+down to indicate the precise column. Interpreted relative to the reference set
+by \code{tip.length.ref}. Default is 0.03.}
+
+\item{tip.length.ref}{character string specifying what \code{tip.length} is a
+fraction of. Either \code{"data"} (default): fraction of the trained data
+range (tips scale with the data; existing plots unchanged); or \code{"axis"}:
+fraction of the y-axis range (\code{ylim}/\code{scale_y_*}), giving visually
+constant tip lengths across plots with different scales (#362).}
 
 \item{remove.bracket}{logical, if \code{TRUE}, brackets are removed from the
 plot. Considered only in the situation, where comparisons are performed

--- a/tests/testthat/test-compare-means-comparisons-note.R
+++ b/tests/testthat/test-compare-means-comparisons-note.R
@@ -34,3 +34,46 @@ test_that("stat_compare_means(comparisons=) still renders (no regression, #293)"
     stat_compare_means(comparisons = .cmp3)
   expect_no_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)))
 })
+
+# Regression tests for #362: tip.length.ref is not supported on the
+# stat_compare_means(comparisons=) path (delegates to ggsignif). Instead of
+# silently ignoring it, users are informed once and pointed to stat_pvalue_manual.
+
+test_that("stat_compare_means(comparisons=, tip.length.ref=) informs it is ignored (#362)", {
+  old <- options(rlib_message_verbosity = "verbose")
+  on.exit(options(old), add = TRUE)
+  expect_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = list(c("0.5", "1")), tip.length.ref = "axis"),
+    "tip.length.ref.*not supported|ignored"
+  )
+  expect_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = list(c("0.5", "1")), tip.length.ref = "axis"),
+    "stat_pvalue_manual"
+  )
+})
+
+test_that("stat_compare_means without tip.length.ref emits no such note (#362)", {
+  old <- options(rlib_message_verbosity = "verbose")
+  on.exit(options(old), add = TRUE)
+  expect_no_message(
+    ggboxplot(ToothGrowth, "dose", "len") +
+      stat_compare_means(comparisons = list(c("0.5", "1"))),
+    message = "tip.length.ref"
+  )
+})
+
+test_that("passing tip.length.ref to stat_compare_means does not change output (#362)", {
+  suppressMessages({
+    with_arg <- ggplot2::ggplot_build(
+      ggboxplot(ToothGrowth, "dose", "len") +
+        stat_compare_means(comparisons = list(c("0.5", "1")), tip.length.ref = "axis")
+    )
+    without <- ggplot2::ggplot_build(
+      ggboxplot(ToothGrowth, "dose", "len") +
+        stat_compare_means(comparisons = list(c("0.5", "1")))
+    )
+  })
+  expect_equal(with_arg$data, without$data)
+})

--- a/tests/testthat/test-stat_pvalue_manual.R
+++ b/tests/testthat/test-stat_pvalue_manual.R
@@ -25,3 +25,79 @@ test_that("fill aes works well by default", {
   expect_no_error(test_with_fill(inherit.aes = FALSE))
   expect_no_error(test_with_fill())
 })
+
+# tip.length.ref: "data" (default) vs "axis" (#362) -----------------------
+
+# Helper: absolute tip depth (in y data units) of the bracket in a built plot
+.bracket_tip_depth <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  for (d in b$data) {
+    if (all(c("y", "yend") %in% names(d)) && "annotation" %in% names(d)) {
+      return(max(c(d$y, d$yend)) - min(c(d$y, d$yend)))
+    }
+  }
+  NA_real_
+}
+
+.tip_plot <- function(values, ylim, y.position, ref = "data") {
+  d <- data.frame(
+    treatment = c("a", "a", "a", "b", "b", "b"),
+    value = values
+  )
+  stat <- data.frame(group1 = "a", group2 = "b", p = 0.01, y.position = y.position)
+  spm <- if (is.null(ref)) {
+    stat_pvalue_manual(stat, label = "p", tip.length = 0.2)  # rely on default arg
+  } else {
+    stat_pvalue_manual(stat, label = "p", tip.length = 0.2, tip.length.ref = ref)
+  }
+  ggbarplot(d, "treatment", "value") + spm + ggplot2::ylim(ylim)
+}
+
+test_that("tip.length.ref default 'data' is unchanged (tips scale with data range)", {
+  small <- .tip_plot(c(1, 2, 4, 3, 5, 6),        c(0, 10),  9,  "data")
+  big   <- .tip_plot(c(10, 20, 40, 30, 50, 60),  c(0, 100), 90, "data")
+  # Historical behavior: tip = tip.length * data range. big's inputs are exactly
+  # 10x small's, so its data-mode tip is exactly 10x as deep, and it is NOT a
+  # fixed fraction of the axis (that is what 'axis' mode adds).
+  tip_small <- .bracket_tip_depth(small)
+  tip_big   <- .bracket_tip_depth(big)
+  expect_equal(tip_big / tip_small, 10, tolerance = 1e-6)
+  expect_false(isTRUE(all.equal(tip_small, 0.2 * 10)))
+})
+
+test_that("tip.length.ref = 'data' (default) is byte-identical to omitting the arg", {
+  omitted  <- .tip_plot(c(1, 2, 4, 3, 5, 6), c(0, 10), 9, ref = NULL)
+  explicit <- .tip_plot(c(1, 2, 4, 3, 5, 6), c(0, 10), 9, ref = "data")
+  expect_equal(.bracket_tip_depth(omitted), .bracket_tip_depth(explicit),
+               tolerance = 1e-9)
+})
+
+test_that("tip.length.ref = 'axis' gives constant fraction of the y-axis range (#362)", {
+  small <- .tip_plot(c(1, 2, 4, 3, 5, 6),        c(0, 10),  9,  "axis")
+  big   <- .tip_plot(c(10, 20, 40, 30, 50, 60),  c(0, 100), 90, "axis")
+  # tip = 0.2 * axis range: 0.2*10 = 2 and 0.2*100 = 20 -> both 20% of their axis
+  expect_equal(.bracket_tip_depth(small), 0.2 * 10, tolerance = 1e-6)
+  expect_equal(.bracket_tip_depth(big),   0.2 * 100, tolerance = 1e-6)
+})
+
+test_that("geom_bracket honors tip.length.ref and validates it", {
+  d <- data.frame(
+    treatment = c("a", "a", "a", "b", "b", "b"),
+    value = c(1, 2, 4, 3, 5, 6)
+  )
+  p_data <- ggbarplot(d, "treatment", "value") +
+    geom_bracket(xmin = "a", xmax = "b", label = "x", y.position = 9,
+                 tip.length = 0.2, tip.length.ref = "data") +
+    ggplot2::ylim(0, 10)
+  p_axis <- ggbarplot(d, "treatment", "value") +
+    geom_bracket(xmin = "a", xmax = "b", label = "x", y.position = 9,
+                 tip.length = 0.2, tip.length.ref = "axis") +
+    ggplot2::ylim(0, 10)
+  # here data range (<10) < axis range (10), so axis tips are deeper than data tips
+  expect_gt(.bracket_tip_depth(p_axis), .bracket_tip_depth(p_data))
+  expect_equal(.bracket_tip_depth(p_axis), 0.2 * 10, tolerance = 1e-6)
+  expect_error(
+    geom_bracket(xmin = "a", xmax = "b", label = "x", y.position = 9,
+                 tip.length.ref = "bogus")
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #362. Bracket p-value "tips" (the short vertical drops at each bracket end) were always computed as a fraction of the **trained data range** (`scales$y$range$range`), so their absolute length scaled with the data. Plots with different data ranges got different tip lengths — making it impossible to keep tips visually consistent across facets or across separate plots with different scales. (The docs also incorrectly described `tip.length` as a "fraction of total height".)

## What changed

New opt-in argument **`tip.length.ref = c("data", "axis")`** on `geom_bracket()`, `stat_bracket()` and `stat_pvalue_manual()`:

- **`"data"` (default)** — fraction of the trained data range. **Unchanged behavior**; existing plots are byte-identical.
- **`"axis"`** — fraction of the **y-axis range** (`scales$y$get_limits()`, i.e. the `ylim`/`scale_y_*` limits). This renders at the same physical fraction across plots, giving **visually constant tip lengths** regardless of the data.

Only the tip normalization uses the new reference; `y.position` and `step.increase` are untouched.

`stat_compare_means(comparisons=)` delegates its tips to `ggsignif::geom_signif()` (whose tip math ggpubr cannot alter), so it is **documented** to point users at `stat_pvalue_manual(..., tip.length.ref = "axis")` for constant tips, together with `compare_means()`.

Also: added `"tip.length.ref"` to `geom_exec()`'s `allowed_options` (so it threads through `stat_pvalue_manual()`), and corrected the misleading `tip.length` docs in all three functions.

## Verification

- **No regression:** full suite `0 fail / 651 pass`; default (`"data"`) output byte-identical (omitted arg == explicit `"data"`), verified by two independent reviewers.
- **New behavior:** with `ylim(0, 20)` and different bar heights, default tips diverge (reporter's bug) while `tip.length.ref = "axis"` gives constant tips at depth `0.2 × 20 = 4` in both plots (visually confirmed by render).
- **Tests added:** regression (data-mode scales with data & is byte-identical to omitting the arg), axis-mode (constant fraction of axis), and `match.arg` validation.
- **Docs:** hand-edited `.Rd` (repo pins `RoxygenNote 7.3.3`; local roxygen is 8.0.0), `tools::checkRd()` clean on all three.

## Note for the maintainer

The reporter's literal call uses `stat_compare_means(comparisons=)`, which routes through `ggsignif` and so is doc-only here. Passing `tip.length.ref` to `stat_compare_means()` is currently silently ignored (flows into `...` → `ggsignif`); both reviewers flagged this as a minor UX nit covered by the docs. A small informative message there could be a follow-up if you'd like.
