### PR TITLE
Add label.y.step to align stat_cor/stat_regline_equation labels across facets (#248)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,16 @@
   `stat_pvalue_manual(..., tip.length.ref = "axis")` instead of being silently
   ignored (#362).
 
+- `stat_cor()` and `stat_regline_equation()` gain a `label.y.step` argument giving
+  the vertical spacing (in text-line units) between the labels of successive
+  groups. Default is `1.4` (unchanged behavior). Setting `label.y.step = 0` stops
+  the per-group vertical shift so labels align across facet panels when a factor
+  is mapped to an aesthetic that also defines the facets (the long-standing
+  "labels climbing stairs across facets" behavior; #248). This control was
+  inspired by the `vstep` argument in the ggpmisc package (by Pedro J. Aphalo),
+  from which ggpubr's correlation/regression label-positioning logic was
+  originally adapted; this is acknowledged via `@seealso` in `?stat_cor`.
+
 ## Bug fixes
 
 - `ggboxplot()` now accepts a `position` argument (e.g.

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -28,6 +28,13 @@ NULL
 #'  If too short they will be recycled.
 #' @param label.x,label.y \code{numeric} Coordinates (in data units) to be used
 #'  for absolute positioning of the label. If too short they will be recycled.
+#' @param label.y.step numeric value giving the vertical spacing (in text-line
+#'  units) between the labels of successive groups when several groups are present.
+#'  Default is 1.4 (unchanged behavior). Set \code{label.y.step = 0} to stop the
+#'  per-group vertical shift, so that labels align across facet panels when a
+#'  factor is mapped to an aesthetic that also defines the facets. This places the
+#'  labels flush with the top of each panel; it is similar in spirit to the
+#'  \code{aes(group = 1)} workaround, which instead leaves them one text line lower.
 #' @param output.type character One of "expression", "latex", "tex" or "text".
 #' @param digits,r.digits,p.digits integer indicating the number of decimal
 #'  places (round) or significant digits (signif) to be used for the correlation
@@ -58,7 +65,10 @@ NULL
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
 #'  TRUE silently removes missing values.
-#' @seealso \code{\link{ggscatter}}
+#' @seealso \code{\link{ggscatter}}. For an alternative implementation with more
+#'  control over label positioning (native NPC coordinates, per-group vertical and
+#'  horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
+#'  the label-positioning logic in \code{stat_cor()} was originally adapted.
 #' @section Computed variables: \describe{ \item{r}{correlation coefficient}
 #'  \item{rr}{correlation coefficient squared} \item{r.label}{formatted label
 #'  for the correlation coefficient} \item{rr.label}{formatted label for the
@@ -111,7 +121,8 @@ stat_cor <- function(mapping = NULL, data = NULL,
                      method = "pearson", alternative = "two.sided",
                      cor.coef.name = c("R", "rho", "tau"), label.sep = ", ",
                      label.x.npc = "left", label.y.npc = "top",
-                     label.x = NULL, label.y = NULL, output.type = "expression",
+                     label.x = NULL, label.y = NULL, label.y.step = 1.4,
+                     output.type = "expression",
                      digits = 2, r.digits = digits, p.digits = digits,
                      r.accuracy = NULL, p.accuracy = NULL,
                      r.leading.zero = NULL,
@@ -126,7 +137,8 @@ stat_cor <- function(mapping = NULL, data = NULL,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y, label.sep = label.sep,
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step,
+      label.sep = label.sep,
       method = method, alternative = alternative, output.type = output.type, digits = digits,
       r.digits = r.digits, p.digits = p.digits, r.accuracy = r.accuracy,
       p.accuracy = p.accuracy, r.leading.zero = r.leading.zero,
@@ -143,7 +155,7 @@ StatCor <- ggproto("StatCor", Stat,
   required_aes = c("x", "y"),
   default_aes = aes(hjust = after_stat(hjust), vjust = after_stat(vjust)),
   compute_group = function(data, scales, method, alternative, label.x.npc, label.y.npc,
-                           label.x, label.y, label.sep, output.type, digits,
+                           label.x, label.y, label.y.step = 1.4, label.sep, output.type, digits,
                            r.digits, p.digits, r.accuracy, p.accuracy, r.leading.zero,
                            p.format.style, p.leading.zero, p.decimal.mark, cor.coef.name,
                            p.coef.name) {
@@ -167,7 +179,7 @@ StatCor <- ggproto("StatCor", Stat,
     .label.pms <- .label_params(
       data = data, scales = scales,
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step
     ) %>%
       mutate(hjust = 0)
     cbind(.test, .label.pms)

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -20,6 +20,10 @@ NULL
 #'  If too short they will be recycled.
 #' @param label.x,label.y \code{numeric} Coordinates (in data units) to be used
 #'  for absolute positioning of the label. If too short they will be recycled.
+#' @param label.y.step numeric value giving the vertical spacing (in text-line
+#'  units) between the labels of successive groups. Default is 1.4 (unchanged
+#'  behavior). Set \code{label.y.step = 0} to stop the per-group vertical shift so
+#'  labels align across facet panels.
 #' @param output.type character One of "expression", "latex" or "text".
 #' @param decreasing logical. If \code{TRUE} (the default), the equation is
 #'   formatted in standard mathematical convention with terms in decreasing
@@ -99,7 +103,8 @@ NULL
 stat_regline_equation <- function(
   mapping = NULL, data = NULL, formula = y ~ x,
   label.x.npc = "left", label.y.npc = "top",
-  label.x = NULL, label.y = NULL, output.type = "expression", decreasing = TRUE,
+  label.x = NULL, label.y = NULL, label.y.step = 1.4,
+  output.type = "expression", decreasing = TRUE,
   coef.digits = 2, rr.digits = 2,
   geom = "text", position = "identity", na.rm = FALSE, show.legend = NA,
   inherit.aes = TRUE, ...
@@ -113,7 +118,7 @@ stat_regline_equation <- function(
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
     params = list(
       formula = formula, label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y,
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step,
       output.type = output.type, decreasing = decreasing,
       coef.digits = coef.digits, rr.digits = rr.digits,
       parse = parse, na.rm = na.rm, ...
@@ -126,7 +131,7 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
   required_aes = c("x", "y"),
   default_aes = aes(label = after_stat(eq.label), hjust = after_stat(hjust), vjust = after_stat(vjust)),
   compute_group = function(data, scales, formula, label.x.npc, label.y.npc,
-                           label.x, label.y, output.type, decreasing,
+                           label.x, label.y, label.y.step = 1.4, output.type, decreasing,
                            coef.digits = 2, rr.digits = 2) {
     force(data)
 
@@ -140,7 +145,7 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
     .label.pms <- .label_params(
       data = data, scales = scales,
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step
     ) %>%
       mutate(hjust = 0)
     cbind(.test, .label.pms)

--- a/R/utilities_label.R
+++ b/R/utilities_label.R
@@ -8,7 +8,8 @@
 # Returns a data frame with x, y, hjust, vjust
 # group.id is the index position of the group in a boxplot for example
 .label_params <- function(data, scales, label.x.npc = "left", label.y.npc = "right",
-                          label.x = NULL, label.y = NULL, .by = c("group", "panel"),
+                          label.x = NULL, label.y = NULL, label.y.step = 1.4,
+                          .by = c("group", "panel"),
                           group.id = NULL, ...) {
   .by <- match.arg(.by)
   # Check label coordinates for each group
@@ -54,17 +55,17 @@
     if (is.numeric(label.y.npc)) {
       y <- scales$y$dimension()[1] + label.y.npc *
         diff(scales$y$dimension())
-      vjust <- 1.4 * group.id - (0.7 * length(group.id))
+      vjust <- label.y.step * group.id - (label.y.step / 2 * length(group.id))
     } else if (is.character(label.y.npc)) {
       if (label.y.npc == "bottom") {
         y <- scales$y$dimension()[1]
-        vjust <- -1.4 * group.id
+        vjust <- -label.y.step * group.id
       } else if (label.y.npc %in% c("center", "centre", "middle")) {
         y <- mean(scales$y$dimension())
-        vjust <- 1.4 * group.id - (0.7 * length(group.id))
+        vjust <- label.y.step * group.id - (label.y.step / 2 * length(group.id))
       } else if (label.y.npc == "top") {
         y <- scales$y$dimension()[2]
-        vjust <- 1.4 * group.id
+        vjust <- label.y.step * group.id
       }
     }
   }

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -15,6 +15,7 @@ stat_cor(
   label.y.npc = "top",
   label.x = NULL,
   label.y = NULL,
+  label.y.step = 1.4,
   output.type = "expression",
   digits = 2,
   r.digits = digits,
@@ -83,6 +84,14 @@ separate the correlation coefficient and the p.value.}
 
 \item{label.x, label.y}{\code{numeric} Coordinates (in data units) to be used
 for absolute positioning of the label. If too short they will be recycled.}
+
+\item{label.y.step}{numeric value giving the vertical spacing (in text-line
+units) between the labels of successive groups when several groups are present.
+Default is 1.4 (unchanged behavior). Set \code{label.y.step = 0} to stop the
+per-group vertical shift, so that labels align across facet panels when a
+factor is mapped to an aesthetic that also defines the facets. This places the
+labels flush with the top of each panel; it is similar in spirit to the
+\code{aes(group = 1)} workaround, which instead leaves them one text line lower.}
 
 \item{output.type}{character One of "expression", "latex", "tex" or "text".}
 
@@ -220,5 +229,8 @@ sp + stat_cor(aes(color = cyl), label.x = 3)
 
 }
 \seealso{
-\code{\link{ggscatter}}
+\code{\link{ggscatter}}. For an alternative implementation with more
+control over label positioning (native NPC coordinates, per-group vertical and
+horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
+the label-positioning logic in \code{stat_cor()} was originally adapted.
 }

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -12,6 +12,7 @@ stat_regline_equation(
   label.y.npc = "top",
   label.x = NULL,
   label.y = NULL,
+  label.y.step = 1.4,
   output.type = "expression",
   decreasing = TRUE,
   coef.digits = 2,
@@ -60,6 +61,11 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{label.x, label.y}{\code{numeric} Coordinates (in data units) to be used
 for absolute positioning of the label. If too short they will be recycled.}
+
+\item{label.y.step}{numeric value giving the vertical spacing (in text-line
+units) between the labels of successive groups. Default is 1.4 (unchanged
+behavior). Set \code{label.y.step = 0} to stop the per-group vertical shift so
+labels align across facet panels.}
 
 \item{output.type}{character One of "expression", "latex" or "text".}
 

--- a/tests/testthat/test-stat_cor.R
+++ b/tests/testthat/test-stat_cor.R
@@ -64,3 +64,71 @@ test_that("stat_cor new label options work with text output (#540/#541)", {
   expect_true(grepl("R = .20", lab, fixed = TRUE))
   expect_true(grepl("P = ", lab, fixed = TRUE))
 })
+
+# label.y.step: per-group vertical spacing / facet alignment (#248) -----------
+
+.cor_vjust <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  d <- b$data[[which(vapply(b$data, function(x) "label" %in% names(x), logical(1)))[1]]]
+  d$vjust
+}
+
+.facet_df <- transform(mtcars, cyl = factor(cyl))
+
+test_that("stat_cor label.y.step default keeps the per-group vjust shift (#248)", {
+  p <- ggplot2::ggplot(.facet_df, ggplot2::aes(mpg, hp)) +
+    ggplot2::geom_point() +
+    ggplot2::facet_wrap(~cyl, scales = "free_y") +
+    stat_cor(ggplot2::aes(color = cyl))
+  # historical behavior: vjust = 1.4 * group.id -> 1.4, 2.8, 4.2 (the "stairs")
+  expect_equal(sort(.cor_vjust(p)), c(1.4, 2.8, 4.2), tolerance = 1e-6)
+})
+
+test_that("stat_cor default equals explicitly passing label.y.step = 1.4 (byte-identical)", {
+  mk <- function(step) {
+    g <- ggplot2::ggplot(.facet_df, ggplot2::aes(mpg, hp)) +
+      ggplot2::geom_point() +
+      ggplot2::facet_wrap(~cyl, scales = "free_y")
+    if (is.null(step)) g + stat_cor(ggplot2::aes(color = cyl))
+    else g + stat_cor(ggplot2::aes(color = cyl), label.y.step = step)
+  }
+  expect_equal(sort(.cor_vjust(mk(NULL))), sort(.cor_vjust(mk(1.4))), tolerance = 1e-9)
+})
+
+test_that("stat_cor label.y.step = 0 aligns labels across facets (#248)", {
+  p <- ggplot2::ggplot(.facet_df, ggplot2::aes(mpg, hp)) +
+    ggplot2::geom_point() +
+    ggplot2::facet_wrap(~cyl, scales = "free_y") +
+    stat_cor(ggplot2::aes(color = cyl), label.y.step = 0)
+  vj <- .cor_vjust(p)
+  expect_equal(vj, rep(0, length(vj)), tolerance = 1e-9)
+})
+
+test_that("stat_regline_equation gains the same label.y.step control (#248)", {
+  base <- ggplot2::ggplot(.facet_df, ggplot2::aes(mpg, hp)) +
+    ggplot2::geom_point() +
+    ggplot2::facet_wrap(~cyl, scales = "free_y")
+  default <- .cor_vjust(base + stat_regline_equation(ggplot2::aes(color = cyl)))
+  aligned <- .cor_vjust(base + stat_regline_equation(ggplot2::aes(color = cyl), label.y.step = 0))
+  expect_equal(sort(default), c(1.4, 2.8, 4.2), tolerance = 1e-6)
+  expect_equal(aligned, rep(0, length(aligned)), tolerance = 1e-9)
+})
+
+test_that("label.y.step default is byte-identical for numeric and center npc branches (#248)", {
+  # These branches use the recentering term (label.y.step/2 * length(group.id)),
+  # which must reduce to the historical 0.7 at the default 1.4.
+  mk <- function(npc, step) {
+    g <- ggplot2::ggplot(.facet_df, ggplot2::aes(mpg, hp)) +
+      ggplot2::geom_point() +
+      ggplot2::facet_wrap(~cyl, scales = "free_y")
+    if (is.null(step)) g + stat_cor(ggplot2::aes(color = cyl), label.y.npc = npc)
+    else g + stat_cor(ggplot2::aes(color = cyl), label.y.npc = npc, label.y.step = step)
+  }
+  for (npc in list(0.5, "center", "bottom")) {
+    expect_equal(sort(.cor_vjust(mk(npc, NULL))), sort(.cor_vjust(mk(npc, 1.4))),
+                 tolerance = 1e-9, info = paste("npc =", npc))
+    # step = 0 collapses every branch to a single aligned value
+    expect_equal(.cor_vjust(mk(npc, 0)), rep(0, length(.cor_vjust(mk(npc, 0)))),
+                 tolerance = 1e-9, info = paste("npc =", npc))
+  }
+})


### PR DESCRIPTION
## Summary

Addresses the dominant cause in #248: `stat_cor()` / `stat_regline_equation()` labels "climb stairs" across facet panels. When a factor is mapped to an aesthetic (e.g. `color`) that also defines the facets, each panel holds a single group, but the per-group vertical shift in `.label_params()` uses the **global** `group.id`, so `vjust` grows panel-by-panel (1.4, 2.8, 4.2, …).

## What changed

New **`label.y.step`** argument on `stat_cor()` and `stat_regline_equation()` (and the shared `.label_params()` helper):

- **Default `1.4`** → byte-identical to previous behaviour.
- **`label.y.step = 0`** removes the per-group shift, so labels align across facet panels (the explicit equivalent of the community `aes(group = 1)` trick; it places labels flush with the top of each panel).

The literal `1.4` in the vjust formulas becomes `label.y.step`, and the `0.7` recentering term becomes `label.y.step / 2` (exactly `0.7` at the default, so no change).

## Attribution

ggpubr's correlation/regression label-positioning logic was originally adapted from **ggpmisc** (Pedro J. Aphalo). This control was inspired by ggpmisc's `vstep`. Added `@seealso ggpmisc::stat_correlation()` on `stat_cor()` and a NEWS acknowledgement.

## Scope

This fixes the **faceted per-group "stairs"** — the majority of the thread (ShanSabri, e-leib, Jeffrothschild, wbvguo, caparks2). The **OP's own case** (two separate `ggarrange`d plots where `geom_smooth` extends each panel's range differently, anchoring the label to the data range) is a *separate* cause that `label.y.step` does not address; the workaround is a common `ylim` / explicit `label.y`, and a native-NPC label engine is left for a focused follow-up. The issue stays open for that.

## Verification

- Full suite **0 fail / 660+ pass**; default output byte-identical (omit == explicit `1.4`), verified by two independent reviewers.
- `label.y.step = 0` → vjust `0/0/0` (aligned); default → `1.4/2.8/4.2` (unchanged stairs). Tests cover the top, numeric, center and bottom npc branches.
- `tools::checkRd()` clean on edited `.Rd`; `RoxygenNote` unchanged (hand-edited, local roxygen differs from the repo pin).
