### PR TITLE
Expose ggviolin(drop=) to keep sparse violins aligned with other geoms (#381)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,14 @@
   from which ggpubr's correlation/regression label-positioning logic was
   originally adapted; this is acknowledged via `@seealso` in `?stat_cor`.
 
+- `ggviolin()` gains a `drop` argument (passed to `ggplot2::geom_violin()`),
+  default `TRUE` (unchanged behavior). Previously the argument was silently
+  dropped, so grouped violins where a sub-sample has too few points to draw a
+  density (which `geom_violin()` removes, including from the dodge position)
+  could not be kept aligned with added boxplots / dot plots. Setting
+  `drop = FALSE` together with `position = position_dodge(0.8, preserve = "single")`
+  now reserves the empty dodge lane so all geoms stay aligned (#381).
+
 ## Bug fixes
 
 - `ggboxplot()` now accepts a `position` argument (e.g.

--- a/R/geom_exec.R
+++ b/R/geom_exec.R
@@ -41,7 +41,7 @@ geom_exec <- function(geomfunc = NULL, data = NULL,
     "binwidth", "binaxis", "method", "binpositions",
     "stackdir", "stackratio", "dotsize",
     # Violin and density
-    "trim", "draw_quantiles", "quantiles", "quantile.linetype", "quantile.type",
+    "trim", "drop", "draw_quantiles", "quantiles", "quantile.linetype", "quantile.type",
     "quantile.alpha", "quantile.colour", "quantile.color", "quantile.linewidth",
     "quantile.size", "scale", "adjust", "bw",
     # error

--- a/R/ggviolin.R
+++ b/R/ggviolin.R
@@ -6,6 +6,16 @@ NULL
 #' data at different values.
 #' @inheritParams ggboxplot
 #' @param width violin width.
+#' @param drop logical, passed to \code{\link[ggplot2]{geom_violin}()}. When
+#'  \code{TRUE} (the default, unchanged behavior), grouped sub-samples with fewer
+#'  than two data points (for which no density can be computed) are dropped,
+#'  including from the dodge position, so the remaining violins re-center and no
+#'  longer line up with other layers (e.g. added boxplots or dot plots). Set
+#'  \code{drop = FALSE} \emph{together with} a "preserve single" dodge, i.e.
+#'  \code{position = position_dodge(0.8, preserve = "single")}, to reserve the
+#'  empty dodge lane so the violins stay aligned with the other geoms. Both are
+#'  needed: \code{drop = FALSE} keeps the sparse group and \code{preserve =
+#'  "single"} keeps its lane width (#381).
 #' @param alpha color transparency. Values should be between 0 and 1.
 #' @param linewidth constant value specifying the line width.
 #' @param quantiles numeric vector of quantiles to draw on the violin.
@@ -114,7 +124,7 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
                      color = "black", fill = "white", palette = NULL, alpha = 1,
                      title = NULL, xlab = NULL, ylab = NULL,
                      facet.by = NULL, panel.labs = NULL, short.panel.labs = TRUE,
-                     linetype = "solid", trim = FALSE, size = NULL, linewidth = NULL, width = 1,
+                     linetype = "solid", trim = FALSE, drop = TRUE, size = NULL, linewidth = NULL, width = 1,
                      quantiles = NULL, quantile.linetype = NULL, quantile.type = NULL,
                      quantile.alpha = NULL, quantile.colour = NULL, quantile.color = NULL,
                      quantile.linewidth = NULL, quantile.size = NULL,
@@ -133,7 +143,7 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
     color = color, fill = fill, palette = palette, alpha = alpha,
     title = title, xlab = xlab, ylab = ylab,
     facet.by = facet.by, panel.labs = panel.labs, short.panel.labs = short.panel.labs,
-    linetype = linetype, trim = trim, size = size, linewidth = linewidth, width = width,
+    linetype = linetype, trim = trim, drop = drop, size = size, linewidth = linewidth, width = width,
     quantiles = quantiles, quantile.linetype = quantile.linetype, quantile.type = quantile.type,
     quantile.alpha = quantile.alpha, quantile.colour = quantile.colour, quantile.color = quantile.color,
     quantile.linewidth = quantile.linewidth, quantile.size = quantile.size, draw_quantiles = draw_quantiles,
@@ -172,7 +182,7 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
 ggviolin_core <- function(data, x, y,
                           color = "black", fill = "white", palette = NULL, alpha = 1,
                           title = NULL, xlab = NULL, ylab = NULL,
-                          linetype = "solid", trim = FALSE, size = NULL, linewidth = NULL, width = 1,
+                          linetype = "solid", trim = FALSE, drop = TRUE, size = NULL, linewidth = NULL, width = 1,
                           quantiles = NULL, quantile.linetype = NULL, quantile.type = NULL,
                           quantile.alpha = NULL, quantile.colour = NULL, quantile.color = NULL,
                           quantile.linewidth = NULL, quantile.size = NULL,
@@ -228,7 +238,7 @@ ggviolin_core <- function(data, x, y,
     geom_exec(geom_violin,
       data = data,
       color = color, fill = fill, linetype = linetype,
-      trim = trim, size = linewidth, width = width, alpha = alpha,
+      trim = trim, drop = drop, size = linewidth, width = width, alpha = alpha,
       position = position, draw_quantiles = NULL, quantiles = quantiles,
       quantile.linetype = quantile.linetype, quantile.type = quantile.type,
       quantile.alpha = quantile.alpha, quantile.colour = quantile.colour,

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -22,6 +22,7 @@ ggviolin(
   short.panel.labs = TRUE,
   linetype = "solid",
   trim = FALSE,
+  drop = TRUE,
   size = NULL,
   linewidth = NULL,
   width = 1,
@@ -111,6 +112,17 @@ outlines.}
 \item{linewidth}{constant value specifying the line width.}
 
 \item{width}{violin width.}
+
+\item{drop}{logical, passed to \code{\link[ggplot2]{geom_violin}()}. When
+\code{TRUE} (the default, unchanged behavior), grouped sub-samples with fewer
+than two data points (for which no density can be computed) are dropped,
+including from the dodge position, so the remaining violins re-center and no
+longer line up with other layers (e.g. added boxplots or dot plots). Set
+\code{drop = FALSE} \emph{together with} a "preserve single" dodge, i.e.
+\code{position = position_dodge(0.8, preserve = "single")}, to reserve the
+empty dodge lane so the violins stay aligned with the other geoms. Both are
+needed: \code{drop = FALSE} keeps the sparse group and \code{preserve =
+"single"} keeps its lane width (#381).}
 
 \item{quantiles}{numeric vector of quantiles to draw on the violin.}
 

--- a/tests/testthat/test-ggviolin.R
+++ b/tests/testthat/test-ggviolin.R
@@ -57,3 +57,52 @@ test_that("ggviolin warns when quantiles are provided without linetype", {
     "quantile.linetype"
   )
 })
+
+# drop argument: keep sparse groups aligned with other geoms (#381) -----------
+
+# Data with a single-point sub-group at dose = 1 (OJ), which geom_violin drops.
+.viol_sparse <- rbind(
+  subset(ToothGrowth, dose == 0.5),
+  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "VC", ][1:6, ],
+  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "OJ", ][1, ],
+  subset(ToothGrowth, dose == 2)
+)
+.viol_sparse$dose <- factor(.viol_sparse$dose)
+
+.violin_lanes <- function(p, layer = 1) {
+  # geom_violin emits expected "fewer than two datapoints" warnings for the
+  # sparse group; they are incidental to what these tests assert.
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  d <- b$data[[layer]]
+  s <- d[abs(d$x - 2) < 0.45, ]           # dose = 1 is the 2nd x position
+  sort(unique(round(s$x, 3)))
+}
+
+test_that("ggviolin forwards drop to geom_violin", {
+  p <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot", drop = FALSE)
+  expect_false(p$layers[[1]]$stat_params$drop)
+  p2 <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot")
+  expect_true(p2$layers[[1]]$stat_params$drop)
+})
+
+test_that("ggviolin default (drop = TRUE) is byte-identical to omitting drop (#381)", {
+  omitted  <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot")
+  explicit <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot", drop = TRUE)
+  expect_equal(
+    suppressWarnings(ggplot2::ggplot_build(omitted))$data[[1]],
+    suppressWarnings(ggplot2::ggplot_build(explicit))$data[[1]]
+  )
+  # default drops the sparse group's lane -> violin is centered (single lane)
+  expect_length(.violin_lanes(omitted, 1), 1)
+})
+
+test_that("drop = FALSE + preserve = 'single' aligns violins with added boxplots (#381)", {
+  p <- ggviolin(
+    .viol_sparse, "dose", "len", color = "supp", add = "boxplot",
+    drop = FALSE, position = position_dodge(0.8, preserve = "single")
+  )
+  violin_x <- .violin_lanes(p, 1)
+  box_x    <- .violin_lanes(p, 2)
+  expect_length(violin_x, 2)          # empty lane reserved -> two lanes
+  expect_equal(violin_x, box_x, tolerance = 1e-6)  # violins line up with boxes
+})


### PR DESCRIPTION
## Summary

Addresses #381 (grouped violins drift out of alignment with added boxplots / dot plots). When a grouped sub-sample has too few points to compute a density, `ggplot2::geom_violin()` removes it — **including from the dodge position** — so the surviving violins re-center while the box/dot layers keep their lanes.

`ggviolin()` previously **silently swallowed** the `geom_violin()` `drop` argument (it was neither a formal nor in `geom_exec()`'s `allowed_options`), so users had no way to change this.

## What changed

- Add `"drop"` to `geom_exec()`'s `allowed_options`, and add a `drop = TRUE` formal to `ggviolin()` / `ggviolin_core()`, forwarded to the violin layer (mirroring how `trim`/`scale` are handled). Default `TRUE` = `geom_violin()`'s default, so existing output is byte-identical.

## How to keep sparse violins aligned

Both of these are required together (verified at coordinate level):

```r
ggviolin(df, "dose", "len", color = "supp", add = "boxplot",
         drop = FALSE,
         position = position_dodge(0.8, preserve = "single"))
```

- `drop = FALSE` keeps the sparse group so it isn't removed from the dodge;
- `preserve = "single"` keeps its lane width (needed because `ggviolin()` sets `width = 1`, which otherwise collapses the reserved lane).

`drop = FALSE` alone or `preserve = "single"` alone do **not** align — the docs/NEWS state this explicitly rather than over-claiming.

## Verification

- Two independent reviewers: both SAFE.
- Default output byte-identical (`drop = TRUE` == omitting `drop`) across basic / grouped / faceted / horizontal / add=box·dot·jitter·mean_se / combine·merge — confirmed via `ggplot_build()$data`.
- At the sparse x-position: default & `drop=FALSE`-alone → violin single lane (misaligned); `drop=FALSE` + `preserve="single"` → violin lanes == box lanes (aligned); builds and full gtable render cleanly, no stray artifact.
- Full suite 0 fail / 672 pass; `tools::checkRd()` clean; `RoxygenNote` unchanged.

## Note

`drop` is added to the global `geom_exec` whitelist, so — exactly like the existing `trim`/`scale` params — explicitly passing `drop=` to a non-violin high-level function (e.g. `ggboxplot(..., drop=FALSE)`) now produces ggplot2's harmless `Ignoring unknown parameters: drop` (output unchanged; it was silently ignored before). This is consistent with how every other geom-specific param already behaves.
