### PR TITLE
geom_bracket: place y.position correctly on transformed (log) y scales (#342)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,13 @@
 
 ## Bug fixes
 
+- `geom_bracket()` and `stat_pvalue_manual()` now place brackets correctly on a
+  transformed y axis (e.g. `scale_y_log10()`). `y.position` is given in data units
+  but was previously used directly in the scale's transformed space, so brackets
+  landed far off (e.g. at `10^30`) and squashed the plot. The bracket `y.position`
+  is now run through the scale's transformation; on an untransformed (identity)
+  scale this is a no-op, so existing plots are unchanged (#342).
+
 - `ggboxplot()` now accepts a `position` argument (e.g.
   `position = position_dodge(0.9)`), like `ggviolin()`/`ggdotplot()` already do.
   Previously passing `position` errored (`formal argument "position" matched by

--- a/R/geom_bracket.R
+++ b/R/geom_bracket.R
@@ -1,6 +1,23 @@
 #' @include utilities.R
 NULL
 
+# Return the y-scale transformation function (e.g. log10) in a way that is robust
+# across ggplot2 versions, or NULL if unavailable. Used to place brackets in the
+# transformed space of the scale (#342). For an identity scale this is the
+# identity function, so applying it leaves positions unchanged.
+.stat_bracket_y_transform <- function(scale) {
+  trans <- NULL
+  # ggplot2 >= 3.5: get_transformation() method / transformation field
+  if (is.function(scale$get_transformation)) {
+    trans <- tryCatch(scale$get_transformation(), error = function(e) NULL)
+  }
+  if (is.null(trans)) trans <- scale$transformation
+  # ggplot2 < 3.5: trans field
+  if (is.null(trans)) trans <- scale$trans
+  if (is.null(trans) || !is.function(trans$transform)) return(NULL)
+  trans$transform
+}
+
 StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
   required_aes = c("x", "y", "group"),
   setup_params = function(data, params) {
@@ -23,6 +40,14 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
       if (length(axis.limits) == 2 && all(is.finite(axis.limits))) {
         tip.scale.range <- axis.limits[2] - axis.limits[1]
       }
+    }
+    # Place the bracket in the transformed space of the y scale, so a user-supplied
+    # y.position given in data units lands correctly on e.g. scale_y_log10(). The
+    # trained range/tips above are already in transformed units. For an identity
+    # scale the transform is a no-op, so default output is unchanged (#342).
+    y.transform <- .stat_bracket_y_transform(scales$y)
+    if (!is.null(y.transform)) {
+      data$y.position <- y.transform(data$y.position)
     }
     bracket.shorten <- data$bracket.shorten / 2
     xmin <- data$xmin + bracket.shorten

--- a/tests/testthat/test-stat_pvalue_manual.R
+++ b/tests/testthat/test-stat_pvalue_manual.R
@@ -101,3 +101,46 @@ test_that("geom_bracket honors tip.length.ref and validates it", {
                  tip.length.ref = "bogus")
   )
 })
+
+# geom_bracket on a transformed (log) y scale (#342) --------------------------
+
+.bracket_y_range <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  for (d in b$data) {
+    if ("annotation" %in% names(d)) return(range(c(d$y, d$yend)))
+  }
+  NA_real_
+}
+
+test_that("geom_bracket places y.position in the scale's transformed space on log axes (#342)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  p_log <- ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "p") +
+    ggplot2::scale_y_log10()
+  yr <- .bracket_y_range(p_log)
+  # y = 30 in data units must map to log10(30) ~ 1.477, not stay at 30
+  expect_equal(max(yr), log10(30), tolerance = 1e-6)
+  expect_lt(max(yr), 2)  # sanity: within the log panel, not at 30
+  # full render succeeds (draw-time, not just build)
+  expect_no_error(ggplot2::ggplot_gtable(p_log %>% ggplot2::ggplot_build()))
+})
+
+test_that("geom_bracket on a linear (identity) y scale is unchanged (#342 no-regression)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  p_lin <- ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "p")
+  yr <- .bracket_y_range(p_lin)
+  expect_equal(max(yr), 30, tolerance = 1e-9)  # y.position untouched on identity scale
+})
+
+test_that("stat_pvalue_manual brackets also respect a log y scale (#342)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  stat <- data.frame(group1 = "0.5", group2 = "1", p.signif = "*", y.position = 30)
+  p <- ggboxplot(df, "dose", "len") +
+    stat_pvalue_manual(stat, label = "p.signif") +
+    ggplot2::scale_y_log10()
+  expect_equal(max(.bracket_y_range(p)), log10(30), tolerance = 1e-6)
+})


### PR DESCRIPTION
## Summary

Fixes #342. `geom_bracket()` / `stat_pvalue_manual()` ignored a transformed y axis: `y.position` is given in **data units**, but `StatBracket$compute_group()` used it directly in the scale's **transformed** coordinate space. So on `scale_y_log10()`, a bracket at `y.position = 30` was drawn at `10^30`, squashing the plot.

## Fix

Transform `y.position` through the y scale's transformation before computing bracket geometry (the trained range and tip math are already in transformed units). Robust across ggplot2 versions via a small internal helper (`get_transformation()` → `$transformation` → `$trans`).

On an **identity** (untransformed) scale the transform is a no-op, so linear-axis output is **byte-identical**. Affects `geom_bracket()` and `stat_pvalue_manual()` (both via `StatBracket`); `geom_pwc()` uses its own `StatPwc` and is unaffected.

## Verification

- Two independent reviewers: both SAFE (one verified at pixel level via a rendered PNG).
- Reporter's example: bracket now at `log10(30) = 1.477` (data y = 30), renders correctly, boxplots not squashed.
- `log2` / `sqrt` / `reverse` / `trans="log"` all place correctly (transform applied once); `coord_trans(y=)` neutral (no double-shift).
- Linear axis **byte-identical** (`identity$transform` is an exact no-op — verified), across single/multi bracket, `step.increase`, `tip.length.ref`, `coord.flip`, faceted, real `rstatix add_xy_position`.
- Full suite 0 fail / 677 pass; internal helper only → no `.Rd`/RoxygenNote change.

## Note

Users who previously worked around this by passing an already-log-transformed `y.position` (e.g. `log10(30)`) will need to switch back to data units — the old placement was objectively wrong. Documented in NEWS.
