### PR TITLE
Credit ggpmisc (Pedro J. Aphalo) in stat_regline_equation and stat_cor docs/source (#419)

### DIFF
--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -1,5 +1,10 @@
 #' @include utilities.R utilities_label.R p_format_utils.R
 NULL
+
+# stat_cor()'s label-positioning logic was adapted from ggpmisc::stat_correlation() /
+# stat_poly_eq() by Pedro J. Aphalo (package 'ggpmisc', GPL-2). For an actively maintained
+# correlation statistic with more features, see the 'ggpmisc' package. See ggpubr issue #419.
+
 #' Add Correlation Coefficients with P-values to a Scatter Plot
 #' @description Add correlation coefficients with p-values to a scatter plot. Can
 #'  be also used to add `R2`.
@@ -65,6 +70,10 @@ NULL
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
 #'  TRUE silently removes missing values.
+#' @references \code{stat_cor()}'s label-positioning logic was adapted from
+#'  \code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
+#'  Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
+#'  see \code{ggpmisc::stat_correlation()}.
 #' @seealso \code{\link{ggscatter}}. For an alternative implementation with more
 #'  control over label positioning (native NPC coordinates, per-group vertical and
 #'  horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -2,6 +2,11 @@
 #' @importFrom dplyr everything
 #' @importFrom dplyr select
 NULL
+
+# stat_regline_equation() was adapted from the source code of ggpmisc::stat_poly_eq()
+# by Pedro J. Aphalo (package 'ggpmisc', GPL-2). For an actively maintained version with
+# additional features and bug fixes, see the 'ggpmisc' package. See ggpubr issue #419.
+
 #' Add Regression Line Equation and R-Square to a GGPLOT.
 #' @description Add regression line equation and R^2 to a ggplot. Regression
 #'  model is fitted using the function \code{\link[stats]{lm}}.
@@ -38,9 +43,10 @@ NULL
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
 #'  TRUE silently removes missing values.
 #' @seealso \code{\link{ggscatter}}
-#' @references the source code of the function \code{stat_regline_equation()} is
-#'  inspired from the code of the function \code{stat_poly_eq()} (in ggpmisc
-#'  package).
+#' @references \code{stat_regline_equation()} was adapted from the source code of
+#'  \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
+#'  maintained version of this statistic, with additional features and bug fixes, see
+#'  \code{ggpmisc::stat_poly_eq()}.
 #'
 #' @section Computed variables:
 #'   \describe{ \item{x}{x position for left edge}

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -228,6 +228,12 @@ sp <- ggscatter(df,
 sp + stat_cor(aes(color = cyl), label.x = 3)
 
 }
+\references{
+\code{stat_cor()}'s label-positioning logic was adapted from
+\code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
+Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
+see \code{ggpmisc::stat_correlation()}.
+}
 \seealso{
 \code{\link{ggscatter}}. For an alternative implementation with more
 control over label positioning (native NPC coordinates, per-group vertical and

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -192,9 +192,10 @@ ggpar(p, palette = "jco")
 
 }
 \references{
-the source code of the function \code{stat_regline_equation()} is
- inspired from the code of the function \code{stat_poly_eq()} (in ggpmisc
- package).
+\code{stat_regline_equation()} was adapted from the source code of
+\code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
+maintained version of this statistic, with additional features and bug fixes, see
+\code{ggpmisc::stat_poly_eq()}.
 }
 \seealso{
 \code{\link{ggscatter}}


### PR DESCRIPTION
## Summary

Addresses #419. Strengthens the acknowledgment that `stat_regline_equation()` — and the label-positioning logic in `stat_cor()` — were **adapted from** the ggpmisc package (`stat_poly_eq()` / `stat_correlation()`) by Pedro J. Aphalo.

- Reworded the `@references` from *"inspired from"* to *"adapted from"*, and added a pointer directing users to the actively maintained **ggpmisc** version (more features, bug fixes).
- Added an explicit acknowledgment **comment in the source** of `R/stat_regline_equation.R` and `R/stat_cor.R` (the "in the source code" part of the request).
- Added `@references` to `stat_cor` (previously only `@seealso`).

## Scope

Attribution text only — no functional change; default output byte-identical. No `DESCRIPTION`/`NAMESPACE` change. Full suite 0 fail / 677 pass; `checkRd` clean; `RoxygenNote` unchanged (hand-edited `.Rd`).

Fixes-adjacent: keeps #419 open until the reporter confirms the wording is satisfactory.
