### PR TITLE
Tidy ggpmisc attribution source comments (#419)

### DIFF
--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -2,8 +2,8 @@
 NULL
 
 # stat_cor()'s label-positioning logic was adapted from ggpmisc::stat_correlation() /
-# stat_poly_eq() by Pedro J. Aphalo (package 'ggpmisc', GPL-2). For an actively maintained
-# correlation statistic with more features, see the 'ggpmisc' package. See ggpubr issue #419.
+# stat_poly_eq() by Pedro J. Aphalo. For an actively maintained correlation statistic
+# with more features, see the 'ggpmisc' package.
 
 #' Add Correlation Coefficients with P-values to a Scatter Plot
 #' @description Add correlation coefficients with p-values to a scatter plot. Can

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -4,8 +4,8 @@
 NULL
 
 # stat_regline_equation() was adapted from the source code of ggpmisc::stat_poly_eq()
-# by Pedro J. Aphalo (package 'ggpmisc', GPL-2). For an actively maintained version with
-# additional features and bug fixes, see the 'ggpmisc' package. See ggpubr issue #419.
+# by Pedro J. Aphalo. For an actively maintained version with additional features and
+# bug fixes, see the 'ggpmisc' package.
 
 #' Add Regression Line Equation and R-Square to a GGPLOT.
 #' @description Add regression line equation and R^2 to a ggplot. Regression


### PR DESCRIPTION
Comment-only cleanup: drop the `GPL-2` and `See ggpubr issue #419` fragments from the ggpmisc acknowledgment comments in `stat_regline_equation.R` and `stat_cor.R`, keeping the clean "adapted from … by Pedro J. Aphalo … see the ggpmisc package" wording. No functional or documentation change.