### PR TITLE
Refresh documentation and ggplot2 linewidth handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
 Author: Alboukadel Kassambara [aut, cre], Laszlo Erdey [ctb] (Faculty of Economics and Business, University of Debrecen, Hungary)
 Maintainer: Alboukadel Kassambara <alboukadel.kassambara@gmail.com>
 Description: The 'ggplot2' package is excellent and flexible for elegant data
-    visualization in R. However the default generated plots requires some formatting
+    visualization in R. However the default generated plots require some formatting
     before we can send them for publication. Furthermore, to customize a 'ggplot',
     the syntax is opaque and this raises the level of difficulty for researchers
     with no advanced R programming skills. 'ggpubr' provides some easy-to-use

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@
 
 - Added compatibility updates for modern `ggplot2`, `dplyr`, and `tidyr`.
 - Updated legacy `size` usage to `linewidth` where required by recent `ggplot2`.
+- Completed the `size` -> `linewidth` migration for the remaining line layers that
+  still passed the deprecated `size` argument: the mean/median reference line added
+  by `gghistogram(add = ...)` and `ggdensity(add = ...)`, and the connector segments
+  of `ggdotchart(add = "segments")`. These no longer emit ggplot2's "`size` aesthetic
+  for lines was deprecated" or "Ignoring empty aesthetic: `size`" warnings, and the
+  requested line width is now applied via `linewidth`.
+- `ggmaplot()` no longer emits an "Ignoring empty aesthetic: `size`" warning on its
+  default call; the point layer sets `size` only when the user supplies a value.
 - Replaced deprecated tidyverse APIs in affected helper functions.
 - Added package startup lock-file checks and `clean_lock_files()` helper.
 - Relaxed minimum `ggrepel` dependency to `>= 0.9.2` to keep Ubuntu oldrel
@@ -335,7 +343,7 @@
 - `ggexport()`: support added for graphics device svg (#469)
 - `ggpie()` and `ggdonutchart()` now fully reacts to the option `lab.font` (#502)
 - Replacing deprecated `gather_()` in both internal (`.check_data()`) and exported functions (`compare_means()`) (#513)
-- `stat_compare_means()`: The dot-dot notation (`..p.signif..`) was deprecated in ggplot2 3.4.0; `after_stat(p.signif)` should be used; updated so that `..p.signif..` is automatically converted into `after_stat()` format without warning for bacward compatibility.
+- `stat_compare_means()`: The dot-dot notation (`..p.signif..`) was deprecated in ggplot2 3.4.0; `after_stat(p.signif)` should be used; updated so that `..p.signif..` is automatically converted into `after_stat()` format without warning for backward compatibility.
 - Enable faceting by column names with spaces (#391)
 - Licence changed to GPL (>= 2) (#482)
 - `desc_statby()` doc updated to clarify the difference between SD (standard deviation) and SE (standard error) (#492)
@@ -351,14 +359,14 @@
 - `ggmaplot()`: Suppressing ggmaplot warning: *Unlabeled data points (too many overlaps). Consider increasing max.overlaps* (#520)
 - `compare_means()`: works now when the grouping variable levels contain the key words group2 or group1 (#450)
 - `ggparagraph()` : fixing bug about minimum paragraph length (#408)
-- `ggexport()`: the verbose argument is now considered when specifyed by user (#474)
+- `ggexport()`: the verbose argument is now considered when specified by user (#474)
 
 # ggpubr 0.5.0
 
 
 ## New features
 
-- New functions `stat_anova_test()`, `stat_kruskal_test()`, `stat_welch_anova_test()`, `stat_friedman_test()` and `geom_pwc()` added. These are flexible functions to add p-values onto ggplot with more options. The function `geom_pwc()` is for adding pairwise comparisons p-values to a ggplot; supportted statistical methods include "wilcox_test", "t_test", "sign_test", "dunn_test", "emmeans_test", "tukey_hsd" and "games_howell_test".
+- New functions `stat_anova_test()`, `stat_kruskal_test()`, `stat_welch_anova_test()`, `stat_friedman_test()` and `geom_pwc()` added. These are flexible functions to add p-values onto ggplot with more options. The function `geom_pwc()` is for adding pairwise comparisons p-values to a ggplot; supported statistical methods include "wilcox_test", "t_test", "sign_test", "dunn_test", "emmeans_test", "tukey_hsd" and "games_howell_test".
 - New functions to convert character vector coordinates into NPC (normalized parent coordinates) and data coordinates: `as_npc()`, `npc_to_data_coordinates()` and `get_coord()`.
 - Global options:
     - New function `ggpubr_options()` to display allowed global options in ggpubr
@@ -422,7 +430,7 @@
 
 ## Minor changes
 
-- Now, when creating a box plot with error bars, color and fill argiments are taken into account in the errorbar function (#105).
+- Now, when creating a box plot with error bars, color and fill arguments are taken into account in the errorbar function (#105).
 - New argument `alternative` supported in `stat_cor()` (#276).
 - New argument `position` in `ggline()` to make position "dodged" (#52).
 - New argument `outlier.shape` in ggboxplot(). Default is 19. To hide outlier, specify outlier.shape = NA. When jitter is added, then outliers will be automatically hidden.
@@ -455,7 +463,7 @@
 - the argument `font.family` is now correctly handled by `ggscatter()` (#149)
 - `ggpar()` arguments are correctly applied using `ggpie()` (#277).
 - `ggscatter()`: When `conf.int = FALSE`, fill color is set to "lightgray" for the regression line confidence band ([@zhan6073, #111](https://github.com/kassambara/ggpubr/issues/111)).
-- Now, `gghistogram()` supports the paramter `yticks.by` ([@Chitanda-Satou, #258](https://github.com/kassambara/ggpubr/issues/258)).
+- Now, `gghistogram()` supports the parameter `yticks.by` ([@Chitanda-Satou, #258](https://github.com/kassambara/ggpubr/issues/258)).
 
 
 # ggpubr 0.3.0
@@ -521,7 +529,7 @@
 
 # ggpubr 0.2.2
 
-## New fatures
+## New features
 
 - New function `geom_bracket()` for adding brackets with label annotation to a ggplot. Helpers for adding p-value or significance levels to a plot.
 
@@ -575,7 +583,7 @@
 
 ## Bug fixes
 
-- The option `ref.group` was only considered when the grouping variable contains more than two levels. In that case, each level is compared against the specified reference group. Now, `ref.group` option is also considereded in two samples mean comparisons ([@OwenDonohoe, #118](https://github.com/kassambara/ggpubr/issues/118))
+- The option `ref.group` was only considered when the grouping variable contains more than two levels. In that case, each level is compared against the specified reference group. Now, `ref.group` option is also considered in two samples mean comparisons ([@OwenDonohoe, #118](https://github.com/kassambara/ggpubr/issues/118))
 
 - Now, `ggqqplot()` reacts to the argument `conf.int.level` ([@vsluydts, #123](https://github.com/kassambara/ggpubr/issues/123)
 - Added error bar color is now inherited from the main plot ([@JesseRop, #109](https://github.com/kassambara/ggpubr/issues/109)
@@ -587,7 +595,7 @@
 ## New features
 
 - New arguments `bxp.errorbar` added to `ggboxplot()` for adding error bars at the top of the box plots ([@j3ypi, #105](https://github.com/kassambara/ggpubr/issues/105).
-- New function `stat_pvalue_manual()` for adding p-values generated elswhere ([@achamess, #81](https://github.com/kassambara/ggpubr/issues/81), [@grst, #65](https://github.com/kassambara/ggpubr/issues/65)).
+- New function `stat_pvalue_manual()` for adding p-values generated elsewhere ([@achamess, #81](https://github.com/kassambara/ggpubr/issues/81), [@grst, #65](https://github.com/kassambara/ggpubr/issues/65)).
 
 
 ## Minor changes
@@ -649,7 +657,7 @@
 
 - New argument `lab.nb.digits` in `ggbarplot()`. Integer indicating the number of decimal places (round) to be used ([#28](https://github.com/kassambara/ggpubr/issues/28)). Example: lab.nb.digits = 2.
 
-- New argument `tip.length` in `stat_compare_means()`. Numeric vector with the fraction of total height that the bar goes down to indicate the precise column. Default is 0.03. Can be of same length as the number of comparisons to adjust specifically the tip lenth of each comparison. For example tip.length = c(0.01, 0.03).
+- New argument `tip.length` in `stat_compare_means()`. Numeric vector with the fraction of total height that the bar goes down to indicate the precise column. Default is 0.03. Can be of same length as the number of comparisons to adjust specifically the tip length of each comparison. For example tip.length = c(0.01, 0.03).
 
 
 ## Minor changes
@@ -774,7 +782,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 
 - New arguments in ggpubr functions, see `ggboxplot()`, `ggdotplot()`, `ggstripchart()`, `ggviolin()`, `ggbarplot()` and `ggline`:
     - `combine` added to combine multiple y variables on the same graph.
-    - `merge` to merge multiple y variables in the same ploting area.
+    - `merge` to merge multiple y variables in the same plotting area.
     - `select` to select which item to display.
     - `remove` to remove a specific item from a plot.
     - `order` to order plot items.
@@ -801,7 +809,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 
 - Now, `ggpar()` reacts to palette when length(palette) = 1 and palette is a color name [#3](https://github.com/kassambara/ggpubr/issues/3).
 
-- `ggmaplot()` now handles situations, where there is only upregulated, or downlegulated gnes.
+- `ggmaplot()` now handles situations, where there is only upregulated, or downregulated gnes.
 
 
 # ggpubr 0.1.2
@@ -809,7 +817,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 
 ## New features
 
-- New function `get_palette()` to generate a palette of k colors from ggsci palettes, RColorbrewer palettes and custom color palettes. Useful to extend RColorBrewer and ggsci to support more colors.
+- New function `get_palette()` to generate a palette of k colors from ggsci palettes, RColorBrewer palettes and custom color palettes. Useful to extend RColorBrewer and ggsci to support more colors.
 
 ## Minor changes
 
@@ -882,7 +890,7 @@ ggboxplot(iris$Sepal.Length)
 - ggscatter(): Scatter plot
 
 
-## Graphical paramters
+## Graphical parameters
 
 - ggpar(): Change graphical parameters
 - show_line_type(): Line types available in R

--- a/NEWS.md
+++ b/NEWS.md
@@ -308,7 +308,7 @@
   - Replaced deprecated `ggplot2::is.ggplot()` with `ggplot2::is_ggplot()` in `ggpar()`
   - Updated `.data$column` syntax to quoted column names in `geom_pwc()` for tidyselect 1.2.0+ compatibility
   - Added `all_of()` wrapper in `unnest()` utility function for tidyselect compatibility
-  - Replaced the option `size` by `linewidth` in ggplot2 element_line() and element_trect() functions.
+  - Replaced the option `size` by `linewidth` in ggplot2 element_line() and element_rect() functions.
 - Fixed deprecation warning in `stat_regline_equation()`  by automatically converting deprecated dot-dot notation (`..eq.label..`, `..adj.rr.label..`, `..p.signif..`, etc.) to `after_stat()` syntax for ggplot2 3.4.0+ compatibility (#623, @hinkyisme).
 -  Fixed deprecation warnings in `add_summary()` and `ggerrorplot()` for ggplot2 compatibility:
     - Updated internal `stat_summary()` parameters to use `fun`, `fun.min`, and `fun.max` instead of deprecated `fun.y`, `fun.ymin`, and `fun.ymax` (#587, @vlonde).
@@ -322,14 +322,14 @@
 
 - New function `ggadjust_pvalue()` added to adjust p-values produced by `geom_pwc()` on a ggplot (#522).
 - New data added: `gene_expression`
-- Global options: New available package options: `ggpubr.null_device`, which value should be a function that creates an appropriate null device. These include: `cowplot::pdf_null_device`, `cowplot::png_null_device`, `cowplot::cairo_null_device` and `cowplot::agg_null_device`. Default is `cowplot::pdf_null_device`. This is used in function like `as_ggplot()`, which needs to open a graphics device to render ggplot objects into grid graphics objects. This function is used to open null device for avoiding the display of unnecessary blank page when calling `ggarrange()` or `as_ggplot()` (#306 and #158).  The default option can be changed using, for example, `options(ggpubr.null_device = cowplot::png_null_device)`.
+- Global options: New available package options: `ggpubr.null_device`, whose value should be a function that creates an appropriate null device. These include: `cowplot::pdf_null_device`, `cowplot::png_null_device`, `cowplot::cairo_null_device` and `cowplot::agg_null_device`. Default is `cowplot::pdf_null_device`. This is used in functions like `as_ggplot()`, which need to open a graphics device to render ggplot objects into grid graphics objects. This function is used to open a null device to avoid displaying an unnecessary blank page when calling `ggarrange()` or `as_ggplot()` (#306 and #158).  The default option can be changed using, for example, `options(ggpubr.null_device = cowplot::png_null_device)`.
 
 
 ## Major changes
 
 - `gadd()`: Restoring back random state after setting seed when adding jittered points. To do so, the seed number is just passed to `position_jitter()` and `position_jitterdodge()`, which preserve the initial random state ( #177 and #349) .
-- `ggpubr` requires now a version of `ggrepel >= 0.9.2.9999`, which restores now the initial random state after set.seed(). see https://github.com/slowkow/ggrepel/issues/228
-- `ggpubr` requires now a version of `cowplot >= 1.1.1`
+- `ggpubr` now requires a version of `ggrepel >= 0.9.2.9999`, which now restores the initial random state after set.seed(). See https://github.com/slowkow/ggrepel/issues/228
+- `ggpubr` now requires a version of `cowplot >= 1.1.1`
 
 
 
@@ -370,7 +370,7 @@
 - New functions to convert character vector coordinates into NPC (normalized parent coordinates) and data coordinates: `as_npc()`, `npc_to_data_coordinates()` and `get_coord()`.
 - Global options:
     - New function `ggpubr_options()` to display allowed global options in ggpubr
-    - New available package options: `ggpubr.parse_aes`. logical indicating whether to parse or not the aesthetics variables names. Default is `TRUE`. For example, if you want ggpubr to handle non-standard column names, like A-A, without parsing, then set this option to FALSE using `options(ggpubr.parse_aes = FALSE)`.
+    - New available package options: `ggpubr.parse_aes`. Logical indicating whether to parse aesthetic variable names. Default is `TRUE`. For example, if you want ggpubr to handle non-standard column names, like A-A, without parsing, then set this option to FALSE using `options(ggpubr.parse_aes = FALSE)`.
 
 
 ## Minor changes
@@ -385,7 +385,7 @@
 - `create_aes()`:
     - Default is now to parse its input, which can be an expression (#348). If you want ggpubr to handle non-standard column names (#229), like A-A, without parsing, then set this option to FALSE using `options(ggpubr.parse_aes = FALSE)`.
     - Supports space in column names like "Dimension 1"
-    - Unittest added
+    - Unit tests added
 - Arguments (`digits` and `table.font.size`) added to `ggsummarystats()` for changing the summary table decimal place and text size (#341).
 - In `stat_pvalue_manual()` the argument `hide.ns` can be either a logical value (TRUE or FALSE) or a character value ("p" or "p.adj" for filtering out non significant by p-value or adjusted p-values).
 - Now, the x-axis tick label names correctly align with the corresponding ticks when the rotation angle of the texts is set to 90. This is automatically achieved by setting internally `vjust = 0.5` (#301).
@@ -417,7 +417,7 @@
 - New function `create_aes()` added to create aes mapping from a list. Makes programming easy with ggplot2 (#229).
 - New argument `coord.flip` added to support adding p-values onto horizontal ggplots (#179). When adding the p-values to a horizontal ggplot (generated using `coord_flip()`), you need to specify the option `coord.flip = TRUE`.
 - New errorbar functions - `median_hilow_()` and `median_q1q3()` -  added ([@davidlorenz, #209](https://github.com/kassambara/ggpubr/issues/209)):
-    - `median_hilow_()`: computes the sample median and a selected pair of outer quantiles having equal tail areas. This function is a reformatted version of `Hmisc::smedian.hilow()`. The confidence limits are computed as follow: `lower.limits = (1-ci)/2` percentiles; `upper.limits = (1+ci)/2` percentiles. By default (`ci = 0.95`), the 2.5th and the 97.5th percentiles are used as the lower and the upper confidence limits, respectively. If you want to use the 25th and the 75th percentiles as the confidence limits, then specify `ci = 0.5` or use the function `median_q1q3()`.
+    - `median_hilow_()`: computes the sample median and a selected pair of outer quantiles having equal tail areas. This function is a reformatted version of `Hmisc::smedian.hilow()`. The confidence limits are computed as follows: `lower.limits = (1-ci)/2` percentiles; `upper.limits = (1+ci)/2` percentiles. By default (`ci = 0.95`), the 2.5th and the 97.5th percentiles are used as the lower and the upper confidence limits, respectively. If you want to use the 25th and the 75th percentiles as the confidence limits, then specify `ci = 0.5` or use the function `median_q1q3()`.
     - `median_q1q3()`: computes the sample median and, the 25th and 75th percentiles. Wrapper around the function median_hilow_() using ci = 0.5.
 - New function `get_breaks()` added to easily create breaks for numeric axes. Can be used to increase the number of x and y ticks by specifying the option `n`. It's also possible to control axis breaks by specifying a step between ticks. For example, if by = 5, a tick mark is shown on every 5 ([@Chitanda-Satou, #258](https://github.com/kassambara/ggpubr/issues/258)).
 
@@ -472,8 +472,8 @@
 ## New features
 
 - New functions:
-    - `ggsummarystats()` to create  a GGPLOT with summary stats table under the plot ( [#251](https://github.com/kassambara/ggpubr/pull/251)).
-    - `clean_table_theme()` to clean the the theme of a table, such as those created by `ggsummarytable()`
+    - `ggsummarystats()` to create a GGPlot with summary stats table under the plot ( [#251](https://github.com/kassambara/ggpubr/pull/251)).
+    - `clean_table_theme()` to clean the theme of a table, such as those created by `ggsummarytable()`
 - `ggbarplot()` now supports stacked barplots with error bars ([#245](https://github.com/kassambara/ggpubr/pull/245)).
 
 
@@ -571,22 +571,22 @@
 
 ## Bug fixes
 
-- P-value for multiple comparisons by group (stat_compare_means()) are now correctly displayed ([@elisheva100, #135](https://github.com/kassambara/ggpubr/issues/135)).
+- P-values for multiple comparisons by group (stat_compare_means()) are now correctly displayed ([@elisheva100, #135](https://github.com/kassambara/ggpubr/issues/135)).
 
 
 # ggpubr 0.1.9
 
 ## Minor changes
 
-- ggsci palettes have been updated to add new palettes: nejm, jama, ucscgb, d3, locuszoom, igv, startrek, tron, futurama, simpsons ([@cbrueffer, #118](https://github.com/kassambara/ggpubr/pull/127)
+- ggsci palettes have been updated to add new palettes: nejm, jama, ucscgb, d3, locuszoom, igv, startrek, tron, futurama, simpsons ([@cbrueffer, #118](https://github.com/kassambara/ggpubr/pull/127))
 
 
 ## Bug fixes
 
 - The option `ref.group` was only considered when the grouping variable contains more than two levels. In that case, each level is compared against the specified reference group. Now, `ref.group` option is also considered in two samples mean comparisons ([@OwenDonohoe, #118](https://github.com/kassambara/ggpubr/issues/118))
 
-- Now, `ggqqplot()` reacts to the argument `conf.int.level` ([@vsluydts, #123](https://github.com/kassambara/ggpubr/issues/123)
-- Added error bar color is now inherited from the main plot ([@JesseRop, #109](https://github.com/kassambara/ggpubr/issues/109)
+- Now, `ggqqplot()` reacts to the argument `conf.int.level` ([@vsluydts, #123](https://github.com/kassambara/ggpubr/issues/123))
+- Added error bar color is now inherited from the main plot ([@JesseRop, #109](https://github.com/kassambara/ggpubr/issues/109))
 
 
 # ggpubr 0.1.8
@@ -600,7 +600,7 @@
 
 ## Minor changes
 
-- `alpha`option added to `ggviolin()` [@mtmatter, #77](https://github.com/kassambara/ggpubr/pull/77)
+- `alpha` option added to `ggviolin()` [@mtmatter, #77](https://github.com/kassambara/ggpubr/pull/77)
 - New argument `bracket.size` added to `stat_compare_means()` [@mtmatter, #43](https://github.com/kassambara/ggpubr/issues/43)
 - Now, the function `stat_cor()` supports R^2 as an option [@philament, #32](https://github.com/kassambara/ggpubr/issues/32)
 - New argument `position` added in `gghistogram()`. Allowed values include "identity", "stack", "dodge".
@@ -626,7 +626,7 @@
 ## Bug fixes
 
 - In `ggscatterhist()` the x variable was plotted two times, on both the plot x & y margins, instead of having, as expected, a) the x variable on the main plot x margin and 2) the y variable on the main plot y margin. This has been now fixed.
-- In previous version, `ggdotchart()` sorted automatically within groups when the `color` argument is specified, even when groups = NULL. This default behaviour has been now removed. Sorting withi groups is performed only when the argument `group` is specified ([@sfeds, #90](https://github.com/kassambara/ggpubr/issues/90)).
+- In previous version, `ggdotchart()` sorted automatically within groups when the `color` argument is specified, even when groups = NULL. This default behaviour has been now removed. Sorting within groups is performed only when the argument `group` is specified ([@sfeds, #90](https://github.com/kassambara/ggpubr/issues/90)).
 - Now, `yticks.by` and  `xticks.by` work with NAs ([@j3ypi, #89](https://github.com/kassambara/ggpubr/issues/89)).
 
 
@@ -703,7 +703,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 - `drawDetails.splitText()` exported so that the function `ggparagraph()` works properly.
 - Now, ggpubr functions accept expression for label text
 - In `ggbarplot()`, now labels correspond to the true size of bars ([@tdelhomme, #15](https://github.com/kassambara/ggpubr/issues/15)).
-- `stat_compare_means()` now keep the default order of factor levels ([@RoKant, #12](https://github.com/kassambara/ggpubr/issues/12)).
+- `stat_compare_means()` now keeps the default order of factor levels ([@RoKant, #12](https://github.com/kassambara/ggpubr/issues/12)).
 
 
 # ggpubr 0.1.4
@@ -711,10 +711,10 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 ## New features
 
 - New helper functions:
-    - `gradient_color()` and `gradient_color()`: change gradient color and fill palettes.
+    - `gradient_color()` and `gradient_fill()`: change gradient color and fill palettes.
     - `clean_theme()`: remove axis lines, ticks, texts and titles.
     - `get_legend()`: to extract the legend labels from a ggplot object.
-    - `as_ggplot()`: Transform the output of `gridExtra::arrangeGrob()` and `gridExtra::grid.arrange()` to a an object of class ggplot.
+    - `as_ggplot()`: Transform the output of `gridExtra::arrangeGrob()` and `gridExtra::grid.arrange()` to an object of class ggplot.
     - `ggtexttable()`: to draw a textual table.
     - `ggparagraph()`: to draw a paragraph of text.
     - fill_palette() and color_palette() to change the fill and color palette, respectively.
@@ -803,13 +803,13 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 ## Minor changes
 
 
-- Now, the argument `palette` Can be also a numeric vector of length(groups); in this case a basic color palette is created using the function `grDevices::palette()`.
+- Now, the argument `palette` can be also a numeric vector of length(groups); in this case a basic color palette is created using the function `grDevices::palette()`.
 
 ## Bug fixes
 
 - Now, `ggpar()` reacts to palette when length(palette) = 1 and palette is a color name [#3](https://github.com/kassambara/ggpubr/issues/3).
 
-- `ggmaplot()` now handles situations, where there is only upregulated, or downregulated gnes.
+- `ggmaplot()` now handles situations, where there is only upregulated, or downregulated genes.
 
 
 # ggpubr 0.1.2
@@ -829,7 +829,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 
 ## Bug fixed
 
-- The mean within group for `ggdensity` (`gghistogram`) are now shown if data have NA values [@chunkaowang, #1](https://github.com/kassambara/ggpubr/issues/1)
+- Group means for `ggdensity` (`gghistogram`) are now shown when data have NA values [@chunkaowang, #1](https://github.com/kassambara/ggpubr/issues/1)
 
 
 # ggpubr 0.1.1
@@ -839,7 +839,7 @@ ggscatter(mtcars, x = "mpg", y = "wt",
 
 - New function `ggtext()` for textual annotation.
 - New argument star.plot in `ggscatter()`. A logical value. If TRUE, a star plot is generated.
-- New helper function `geom_exec()`. A helper function used by ggpubr functions to execute any geom_xx functions in ggplot2. Useful only when you want to call a geom_xx function without carrying about the arguments to put in `ggplot2::aes()`.
+- New helper function `geom_exec()`. A helper function used by ggpubr functions to execute any geom_xx functions in ggplot2. Useful only when you want to call a geom_xx function without worrying about the arguments to put in `ggplot2::aes()`.
 - New arguments sort.val and top in `ggbarplot()`.
     - sort.val: a string specifying whether the value should be sorted. Allowed values are "none" (no sorting), "asc" (for ascending) or "desc" (for descending).
     - top: a numeric value specifying the number of top elements to be shown.

--- a/R/add_summary.R
+++ b/R/add_summary.R
@@ -239,7 +239,7 @@ median_iqr <- function(x, error.limit = "both") {
 #' @describeIn add_summary computes the sample median and a selected pair of
 #'   outer quantiles having equal tail areas. This function is a reformatted
 #'   version of \code{Hmisc::smedian.hilow()}. The confidence limits are computed
-#'   as follow: \code{lower.limits = (1-ci)/2} percentiles; \code{upper.limits =
+#'   as follows: \code{lower.limits = (1-ci)/2} percentiles; \code{upper.limits =
 #'   (1+ci)/2} percentiles. By default (\code{ci = 0.95}), the 2.5th and the
 #'   97.5th percentiles are used as the lower and the upper confidence limits,
 #'   respectively. If you want to use the 25th and the 75th percentiles as the

--- a/R/add_summary.R
+++ b/R/add_summary.R
@@ -12,7 +12,7 @@ NULL
 #'  "lower_errorbar", "upper_pointrange", "lower_pointrange", "upper_linerange",
 #'  "lower_linerange")}. Default value is "pointrange".
 #' @param color point or outline color.
-#' @param fill fill color. Used only whne \code{error.plot = "crossbar"}.
+#' @param fill fill color. Used only when \code{error.plot = "crossbar"}.
 #' @param group grouping variable. Allowed values are 1 (for one group) or a
 #'  character vector specifying the name of the grouping variable. Used only for
 #'  adding statistical summary per group.

--- a/R/as_ggplot.R
+++ b/R/as_ggplot.R
@@ -4,7 +4,7 @@ NULL
 #'
 #' @description Transform the output of
 #'  \code{\link[gridExtra:arrangeGrob]{arrangeGrob}()} and
-#'  \code{\link[gridExtra:arrangeGrob]{grid.arrange}()} to a an object of class
+#'  \code{\link[gridExtra:arrangeGrob]{grid.arrange}()} to an object of class
 #'  ggplot.
 #' @param x an object of class gtable or grob as returned by the functions
 #'  \code{\link[gridExtra:arrangeGrob]{arrangeGrob}()} and
@@ -12,7 +12,7 @@ NULL
 #' @return an object of class ggplot.
 #'
 #' @examples
-#' # Creat some plots
+#' # Create some plots
 #' bxp <- ggboxplot(iris, x = "Species", y = "Sepal.Length")
 #' vp <- ggviolin(iris,
 #'   x = "Species", y = "Sepal.Length",

--- a/R/as_npc.R
+++ b/R/as_npc.R
@@ -1,6 +1,6 @@
 #' Convert Character Coordinates into Normalized Parent Coordinates (NPC)
 #'
-#' Convert character coordinates to npc units and shift postions to avoid
+#' Convert character coordinates to npc units and shift positions to avoid
 #' overlaps when grouping is active. If numeric validate npc values.
 #'
 #' @param value numeric (in [0-1]) or character vector of coordinates. If

--- a/R/axis_scale.R
+++ b/R/axis_scale.R
@@ -7,7 +7,7 @@
 #' }
 #' @param .scale axis scale. Allowed values are one of c("none", "log2", "log10",
 #'  "sqrt", "percent", "dollar", "scientific"); e.g.: .scale="log2".
-#' @param .format ogical value. If TRUE, axis tick mark labels will be formatted
+#' @param .format logical value. If TRUE, axis tick mark labels will be formatted
 #'  when .scale  = "log2" or "log10".
 #'
 #'

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -77,7 +77,7 @@ NULL
 #'  show exact values. If provided, overrides the style default.
 #' @param p.decimal.mark character string to use as the decimal mark. If NULL,
 #'  uses \code{getOption("OutDec")}.
-#' @return return a data frame with the following columns:
+#' @return a data frame with the following columns:
 #' \itemize{
 #' \item \code{.y.}: the y variable used in the test.
 #' \item \code{group1,group2}: the compared groups in the pairwise tests.

--- a/R/facet.R
+++ b/R/facet.R
@@ -29,7 +29,7 @@ NULL
 #'  panel.labs.background = list(color = "blue", fill = "pink", linetype =
 #'  "dashed", linewidth = 0.5). Note: \code{size} is deprecated, use
 #'  \code{linewidth} instead.
-#' @param panel.labs.font a list of aestheics indicating the size (e.g.: 14), the
+#' @param panel.labs.font a list of aesthetics indicating the size (e.g.: 14), the
 #'  face/style (e.g.: "plain", "bold", "italic", "bold.italic") and the color
 #'  (e.g.: "red") and the orientation angle (e.g.: 45) of panel labels.
 #' @param panel.labs.font.x,panel.labs.font.y same as panel.labs.font but for

--- a/R/gene_expression.R
+++ b/R/gene_expression.R
@@ -9,7 +9,7 @@
 #' @docType data
 #' @usage data("gene_expression")
 #' @format A data frame with 1305 rows and 5 columns. \describe{
-#'  \item{\code{bcr_patient_barcode}}{sample ID} \item{\code{dataset}}{cance type} \item{\code{GATA3}}{GATA3 gene expression}
+#'  \item{\code{bcr_patient_barcode}}{sample ID} \item{\code{dataset}}{cancer type} \item{\code{GATA3}}{GATA3 gene expression}
 #'  \item{\code{PTEN}}{PTEN gene expression}\item{\code{XBP1}}{XBP1 gene expression.}}
 #'
 #' @examples

--- a/R/geom_exec.R
+++ b/R/geom_exec.R
@@ -98,8 +98,13 @@ geom_exec <- function(geomfunc = NULL, data = NULL,
     return(FALSE)
   }
 
-  # Auto-convert size to linewidth for line-based geoms
-  if (is_line_geom(geomfunc) && "size" %in% names(params) && !"linewidth" %in% names(params)) {
+  # Auto-convert size to linewidth for line-based geoms. A `linewidth` that was
+  # passed but is NULL must not block the conversion: callers forward
+  # `linewidth = <maybe-NULL>` alongside `size`, and a named NULL is dropped
+  # later anyway (see the NULL check in the loop below).
+  if (is_line_geom(geomfunc) && "size" %in% names(params) &&
+      (!"linewidth" %in% names(params) || is.null(params[["linewidth"]]))) {
+    params[["linewidth"]] <- NULL
     names(params)[names(params) == "size"] <- "linewidth"
   }
 

--- a/R/geom_exec.R
+++ b/R/geom_exec.R
@@ -1,15 +1,15 @@
 #' Execute ggplot2 functions
 #' @description A helper function used by ggpubr functions to execute any geom_*
 #'   functions in ggplot2. Useful only when you want to call a geom_* function
-#'   without carrying about the arguments to put in aes(). Basic users of ggpubr
+#'   without worrying about the arguments to put in aes(). Basic users of ggpubr
 #'   don't need this function.
 #' @param geomfunc a ggplot2 function (e.g.: geom_point)
 #' @param data a data frame to be used for mapping
 #' @param position Position adjustment, either as a string, or the result of a
 #'   call to a position adjustment function.
 #' @param ... arguments accepted by the function
-#' @return return a plot if geomfunc!=Null or a list(option, mapping) if
-#'   geomfunc = NULL.
+#' @return a plot if geomfunc != NULL or a list(option, mapping) if
+#'   geomfunc is NULL.
 #' @examples
 #' \dontrun{
 #' ggplot() +

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -153,8 +153,8 @@ NULL
 #' \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 #' \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 #' \itemize{
-#'   \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPLOT Facets}
-#'   \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPLOT Facets with Different Scales}
+#'   \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
+#'   \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPlot Facets with Different Scales}
 #' }
 #' }
 #' @inheritParams ggpubr-common-params

--- a/R/get_palette.R
+++ b/R/get_palette.R
@@ -1,6 +1,6 @@
 #' Generate Color Palettes
 #'
-#' @description Generate a palette of k colors from ggsci palettes, RColorbrewer
+#' @description Generate a palette of k colors from ggsci palettes, RColorBrewer
 #'  palettes and custom color palettes. Useful to extend RColorBrewer and ggsci to support more colors.
 #' @param palette Color palette. Allowed values include: \itemize{ \item
 #'  \strong{Grey color palettes}: "grey" or "gray"; \item \strong{RColorBrewer

--- a/R/ggadjust_pvalue.R
+++ b/R/ggadjust_pvalue.R
@@ -102,7 +102,7 @@ ggadjust_pvalue <- function(p, layer = NULL, p.adjust.method = "holm", label = "
     }
   }
   if (is.null(layer)) {
-    stop("Can't find any layer containing statiscal tests")
+    stop("Can't find any layer containing statistical tests")
   }
 
   stat_test <- .build$data[[layer]]

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -41,8 +41,8 @@ NULL
 #' @param legend.grob a legend grob as returned by the function
 #'   \code{\link{get_legend}()}. If provided, it will be used as the common
 #'   legend.
-#' @return return an object of class \code{ggarrange}, which is a ggplot or a
-#'   list of ggplot.
+#' @return an object of class \code{ggarrange}, which is a ggplot or a
+#'   list of ggplots.
 #' @author Laszlo Erdey \email{erdey.laszlo@@econ.unideb.hu}
 #' @seealso \code{\link{annotate_figure}()}
 #' @examples

--- a/R/ggballoonplot.R
+++ b/R/ggballoonplot.R
@@ -81,7 +81,7 @@
 #' ) +
 #'   gradient_fill(c("blue", "white", "red"))
 #'
-#' # Streched contingency table
+#' # Stretched contingency table
 #' # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 #'
 #' # Create an Example Data Frame Containing Car x Color data
@@ -158,7 +158,7 @@ ggballoonplot <- function(
   # case 2: x and y are not specified
   # - check if the data is stretched:
   #     If yes, then consider the first 3 columns as x, y and size values
-  #     If no, then strech the data and continu
+  #     If no, then stretch the data and continue
   else if (is.null(x) | is.null(y)) {
     if (.is_stretched(data)) {
       .cnames <- colnames(data)
@@ -171,7 +171,7 @@ ggballoonplot <- function(
       y.val <- dplyr::pull(data, 2)
       data[[2]] <- y.val %>% factor(levels = rev(.levels(y.val)))
     } else {
-      data <- .df_strech(data) # Strech the data into 3 columns: .row|.col|.value
+      data <- .df_stretch(data) # Stretch the data into 3 columns: .row|.col|.value
       x <- ".col"
       y <- ".row"
       if (missing(size)) size <- "value"
@@ -233,16 +233,16 @@ ggballoonplot <- function(
 }
 
 
-# strech a data frame with row names
+# Stretch a data frame with row names
 # returns a data frame with 3 columns .row, .col, value
-.df_strech <- function(data) {
+.df_stretch <- function(data) {
   .col.names <- colnames(data)
   .row.names <- rownames(data)
   data <- data %>%
     dplyr::mutate(.row = .row.names) %>%
     dplyr::select(.row, dplyr::everything())
 
-  # Sretch the data into three columns
+  # Stretch the data into three columns
   .col <- .row <- NULL
   data <- data %>%
     tidyr::pivot_longer(
@@ -284,7 +284,7 @@ ggballoonplot <- function(
   all(apply(x, 2, is.numeric))
 }
 
-# For tible data. The first column should be row names
+# For tibble data. The first column should be row names
 .is_correct_tbl <- function(x) {
   ok <- FALSE
   if (inherits(x, "tbl_df")) ok <- TRUE

--- a/R/ggballoonplot.R
+++ b/R/ggballoonplot.R
@@ -1,4 +1,4 @@
-#' Ballon plot
+#' Balloon plot
 #'
 #' @description Plot a graphical matrix where each cell contains a dot whose
 #'   size reflects the relative magnitude of the corresponding component. Useful
@@ -9,9 +9,9 @@
 #'   contingency table} formed by two categorical variables: a data frame with
 #'   row names and column names. The categories of the first variable are
 #'   columns and the categories of the second variable are rows. \item \bold{a
-#'   streched contingency table}: a data frame containing at least three columns
+#'   stretched contingency table}: a data frame containing at least three columns
 #'   corresponding, respectively, to (1) the categories of the first variable,
-#'   (2) the categories of the second varible, (3) the frequency value. In this
+#'   (2) the categories of the second variable, (3) the frequency value. In this
 #'   case, you should specify the argument x and y in the function
 #'   \code{ggballoonplot()}}.
 #' @param x,y the column names specifying, respectively, the first and the
@@ -20,7 +20,7 @@
 #' @param color point border line color.
 #' @param fill point fill color. Default is "lightgray". Considered only for
 #'   points 21 to 25.
-#' @param shape points shape. The default value is 21. Alternaive values include
+#' @param shape points shape. The default value is 21. Alternative values include
 #'   22, 23, 24, 25.
 #' @param size point size. By default, the points size reflects the relative
 #'   magnitude of the value of the corresponding cell (\code{size = "value"}).
@@ -37,7 +37,7 @@
 #'   the color (e.g.: "red") of point labels. For example font.label = c(14,
 #'   "bold", "red"). To specify only the size and the style, use font.label =
 #'   c(14, "plain").
-#' @param rotate.x.text logica. If TRUE (default), rotate the x axis text.
+#' @param rotate.x.text logical. If TRUE (default), rotate the x axis text.
 #' @param ... other arguments passed to the function \code{\link{ggpar}}
 #'
 #' @examples
@@ -143,7 +143,7 @@ ggballoonplot <- function(
   # ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
-  # case 1: x and y specified. we assume that the data is streched
+  # case 1: x and y specified. we assume that the data is stretched
   # if size not specified, then take the third column as size values
   # detect fill variable if misspecified
   if (!is.null(x) & !is.null(y)) {
@@ -156,11 +156,11 @@ ggballoonplot <- function(
 
 
   # case 2: x and y are not specified
-  # - check if the data is streched:
+  # - check if the data is stretched:
   #     If yes, then consider the first 3 columns as x, y and size values
   #     If no, then strech the data and continu
   else if (is.null(x) | is.null(y)) {
-    if (.is_streched(data)) {
+    if (.is_stretched(data)) {
       .cnames <- colnames(data)
       x <- .cnames[1]
       y <- .cnames[2]
@@ -258,17 +258,17 @@ ggballoonplot <- function(
 }
 
 
-# Check if the contingency table is in the streched format
-.is_streched <- function(data, x = NULL, y = NULL) {
-  streched <- TRUE
+# Check if the contingency table is in the stretched format
+.is_stretched <- function(data, x = NULL, y = NULL) {
+  stretched <- TRUE
   if (is.null(x) | is.null(y)) {
     if (.is_numeric_data(data)) {
-      streched <- FALSE
+      stretched <- FALSE
     } else {
       x <- dplyr::pull(data, 1)
       y <- dplyr::pull(data, 2)
       z <- dplyr::pull(data, 3)
-      streched <- (
+      stretched <- (
         (is.character(x) | is.factor(x)) &
           (is.character(y) | is.factor(y)) &
           is.numeric(z)
@@ -276,7 +276,7 @@ ggballoonplot <- function(
     }
   }
 
-  streched
+  stretched
 }
 
 # Check if a data matrix is numeric

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -17,7 +17,7 @@ NULL
 #'   categories. Ignored when \code{order} is set or \code{sort.val != "none"},
 #'   which require a discrete x axis.
 #' @param label specify whether to add labels on the bar plot. Allowed values
-#'   are: \itemize{ \item \strong{logical value}: If TRUE, y values is added as
+#'   are: \itemize{ \item \strong{logical value}: If TRUE, y values are added as
 #'   labels on the bar plot \item \strong{character vector}: Used as text
 #'   labels; must be the same length as y. }
 #' @param lab.col,lab.size text color and size for labels.

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -28,7 +28,7 @@ NULL
 #' @param size Numeric value (e.g.: size = 1). change the size of points and
 #'  outlines.
 #' @param linewidth constant value specifying the line width.
-#' @param width numeric value between 0 and 1 specifying box width.
+#' @param width numeric value between 0 and 1 specifying the width of the plot elements.
 #' @inheritParams ggplot2::geom_boxplot
 #' @param outlier.shape point shape of outlier. Default is 19. To hide outlier,
 #'  specify \code{outlier.shape = NA}. When jitter is added, then outliers will
@@ -60,9 +60,7 @@ NULL
 #'  the style, use font.label = list(size = 14, face = "plain").
 #' @param position position adjustment, either as a string, or the result of a
 #'  call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-#'  Used to control the spacing between boxes of grouped box plots. Applies to
-#'  the box and box-error-bar layers; layers added via \code{add} (e.g.
-#'  "jitter") keep their own default positioning.
+#'  Used to control the spacing between grouped elements.
 #' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr().
 #'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'  theme_minimal(), theme_classic(), theme_void(), ....

--- a/R/ggdotchart.R
+++ b/R/ggdotchart.R
@@ -227,12 +227,10 @@ ggdotchart_core <- function(data, x, y, group = NULL,
       option$linewidth <- add.params$size
     }
 
-    if ("linewidth" %in% names(formals(ggplot2::geom_linerange))) {
-      option$size <- NULL
-    } else {
-      if (is.null(option$size) && !is.null(option$linewidth)) option$size <- option$linewidth
-      option$linewidth <- NULL
-    }
+    # ggpubr requires ggplot2 (>= 3.5.2); geom_linerange takes `linewidth`, not the
+    # deprecated `size`. Migrate any size value to linewidth, then drop size.
+    if (is.null(option$linewidth) && !is.null(option$size)) option$linewidth <- option$size
+    option$size <- NULL
 
     option[["mapping"]] <- create_aes(mapping)
     p <- p + do.call(geom_linerange, option)

--- a/R/ggdotchart.R
+++ b/R/ggdotchart.R
@@ -227,10 +227,13 @@ ggdotchart_core <- function(data, x, y, group = NULL,
       option$linewidth <- add.params$size
     }
 
-    # ggpubr requires ggplot2 (>= 3.5.2); geom_linerange takes `linewidth`, not the
-    # deprecated `size`. Migrate any size value to linewidth, then drop size.
+    # geom_linerange takes `linewidth`, not the deprecated `size` (ggplot2 >= 3.4.0).
+    # Migrate any size to linewidth, then drop size -- for both the constant
+    # parameter (option$size) and a size mapped to a data column (mapping$size).
     if (is.null(option$linewidth) && !is.null(option$size)) option$linewidth <- option$size
     option$size <- NULL
+    if (is.null(mapping$linewidth) && !is.null(mapping$size)) mapping$linewidth <- mapping$size
+    mapping$size <- NULL
 
     option[["mapping"]] <- create_aes(mapping)
     p <- p + do.call(geom_linerange, option)

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -24,7 +24,7 @@ NULL
 #'
 #'  \itemize{ \item baseMean: the mean expression of genes in the two groups.
 #'  \item log2FoldChange: the log2 fold changes of group 2 compared to group 1
-#'  \item padj: the adjusted p-value of the used statiscal test. }
+#'  \item padj: the adjusted p-value of the used statistical test. }
 #' @param fdr Accepted false discovery rate for considering genes as
 #'  differentially expressed.
 #' @param fc the fold change threshold. Only genes with a fold change >= fc and
@@ -36,7 +36,7 @@ NULL
 #'  detection_call = c(1, 1, 0, 1, 0, 1). Default is NULL. If detection_call
 #'  column is available in data, it will be used.
 #' @param size points size.
-#' @param alpha numeric value betwenn 0 an 1 specifying point alpha for
+#' @param alpha numeric value between 0 and 1 specifying point alpha for
 #'  controlling transparency. For example, use alpha = 0.5.
 #' @param seed Random seed passed to \code{set.seed}. if
 #'  \code{NA}, set.seed will not be called. Default is 42 for reproducibility.
@@ -198,8 +198,14 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
 
   # Plot
   mean <- lfc <- sig <- name <- padj <- NULL
-  p <- ggplot(data, aes(x = mean, y = lfc)) +
-    geom_point(aes(color = sig), size = size, alpha = alpha)
+  # `size` defaults to NULL; passing it as an empty aesthetic warns, so only set
+  # it when the user supplied a value (NULL keeps ggplot2's default point size).
+  p <- ggplot(data, aes(x = mean, y = lfc))
+  if (is.null(size)) {
+    p <- p + geom_point(aes(color = sig), alpha = alpha)
+  } else {
+    p <- p + geom_point(aes(color = sig), size = size, alpha = alpha)
+  }
 
   max.overlaps <- getOption("ggrepel.max.overlaps", default = Inf)
 

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -55,7 +55,7 @@ NULL
 #' @param line.color color of the horizontal threshold lines (the central line
 #'   at 0 and the two fold-change cutoff lines). Default is "black".
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
-#' @return returns a ggplot.
+#' @return a ggplot.
 #' @examples
 #' data(diff_express)
 #'

--- a/R/ggpubr-package.R
+++ b/R/ggpubr-package.R
@@ -23,7 +23,7 @@
 #' @section Package options:
 #'
 #' \describe{
-#' \item{ggpubr.parse_aes}{logical indicating whether to parse or not aesthetics variables names.
+#' \item{ggpubr.parse_aes}{logical indicating whether to parse aesthetic variable names.
 #' Default is \code{TRUE}. For example, if you want \code{ggpubr} to handle non-standard column names, like \code{A-A},
 #' without parsing, then set this option to \code{FALSE} using \code{options(ggpubr.parse_aes = FALSE)}.}
 #' \item{ggpubr.null_device}{A function that creates an appropriate null device.
@@ -32,9 +32,9 @@
 #' \code{\link[cowplot:cairo_null_device]{cowplot::cairo_null_device}} and
 #' \code{\link[cowplot:agg_null_device]{cowplot::agg_null_device}}. Default is
 #' \code{\link[cowplot:pdf_null_device]{cowplot::pdf_null_device}}. This is used in
-#' function like \code{\link{as_ggplot}()}, which needs to open a graphics
+#' functions like \code{\link{as_ggplot}()}, which need to open a graphics
 #' device to render ggplot objects into grid graphics objects. This function is
-#' used to open null device for avoiding the display of unnecessary blank page
+#' used to open a null device to avoid displaying an unnecessary blank page
 #' when calling \code{\link{ggarrange}()} or \code{\link{as_ggplot}()}} }
 #'
 "_PACKAGE"

--- a/R/ggpubr_options.R
+++ b/R/ggpubr_options.R
@@ -1,4 +1,4 @@
-#' Global Options for GGPubr
+#' Global Options for ggpubr
 #' @description Displays allowed global options in ggpubr.
 #' @examples
 #'

--- a/R/ggscatter.R
+++ b/R/ggscatter.R
@@ -29,7 +29,7 @@ NULL
 #'  "euclid")} for plotting concentration ellipses.
 #'
 #'  \itemize{ \item \code{"convex"}: plot convex hull of a set o points. \item
-#'  \code{"confidence"}: plot confidence ellipses arround group mean points as
+#'  \code{"confidence"}: plot confidence ellipses around group mean points as
 #'  \code{FactoMineR::coord.ellipse()}. \item \code{"t"}:
 #'  assumes a multivariate t-distribution. \item \code{"norm"}: assumes a
 #'  multivariate normal distribution. \item \code{"euclid"}: draws a circle with

--- a/R/ggscatterhist.R
+++ b/R/ggscatterhist.R
@@ -24,7 +24,7 @@ NULL
 #'  \code{\link{theme_pubr}()}.
 #' @param print logical value. If \code{TRUE} (default), print the plot.
 #' @param ... other arguments passed to the function \code{\link{ggscatter}()}.
-#' @return an object of class \code{ggscatterhist}, which is list of ggplots,
+#' @return an object of class \code{ggscatterhist}, which is a list of ggplots,
 #'  including the following elements: \itemize{\item sp: main scatter plot;
 #'  \item xplot: marginal x-axis plot; \item yplot: marginal y-axis plot. }.
 #'
@@ -83,8 +83,8 @@ ggscatterhist <- function(
 ) {
   if (!has_cowplot_v0.9()) {
     warning("Install the latest developmental version of cowplot on github ",
-      "to fully use all the feature of ggscatterhist",
-      .call = FALSE
+      "to fully use all the features of ggscatterhist",
+      call. = FALSE
     )
     # margin.space = TRUE
   }
@@ -292,7 +292,7 @@ has_cowplot_v0.9 <- function() {
   )
 }
 
-.check_margin_params <- function(params, data, color = "black", fill = NA, linetype = "slid") {
+.check_margin_params <- function(params, data, color = "black", fill = NA, linetype = "solid") {
   if (is.null(params$color)) {
     if (color %in% colnames(data)) {
       col.val <- dplyr::pull(data, color)

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -1,7 +1,7 @@
 #' @include utilities.R ggpar.R
 #' @importFrom rstatix df_split_by get_summary_stats
 NULL
-#' GGPLOT with Summary Stats Table Under the Plot
+#' GGPlot with Summary Stats Table Under the Plot
 #'
 #' @description Create a ggplot with summary stats (n, median, mean, iqr) table
 #'   under the plot. Read more: \href{https://www.datanovia.com/en/blog/how-to-create-a-beautiful-plots-in-r-with-summary-statistics-labels/}{How to Create a Beautiful Plots in R with Summary Statistics Labels}.

--- a/R/ggtext.R
+++ b/R/ggtext.R
@@ -22,7 +22,7 @@ NULL
 #'   combination of the following components: \itemize{ \item \code{top.up} and
 #'   \code{top.down}: to display the labels  of the top up/down points. For
 #'   example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-#'   \code{criteria}: to filter, for example, by x and y variabes values, use
+#'   \code{criteria}: to filter, for example, by x and y variables values, use
 #'   this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 #'   c('A', 'B')")}. } }
 #' @param repel a logical value, whether to use ggrepel to avoid overplotting

--- a/R/ggtexttable.R
+++ b/R/ggtexttable.R
@@ -45,7 +45,7 @@ NULL
 #' @param alpha numeric value specifying fill color transparency.
 #' Value should be in [0, 1], where 0 is full transparency and 1 is no transparency.
 #' @param at.row a numeric vector of row indexes; for example \code{at.row = c(1, 2)}.
-#' @param row.side row side to which the horinzotal line should be added. Can be one of \code{c("bottom", "top")}.
+#' @param row.side row side to which the horizontal line should be added. Can be one of \code{c("bottom", "top")}.
 #' @param from.column integer indicating the column from which to start drawing the horizontal line.
 #' @param to.column integer indicating the column to which the horizontal line should end.
 #' @param linetype line type

--- a/R/stat_anova_test.R
+++ b/R/stat_anova_test.R
@@ -2,7 +2,7 @@
 NULL
 #' Add Anova Test P-values to a GGPlot
 #' @description Adds automatically one-way and two-way ANOVA test p-values to a
-#'  ggplot, such as box blots, dot plots and stripcharts.
+#'  ggplot, such as box plots, dot plots and stripcharts.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer
 #' @inheritParams stat_pvalue_manual

--- a/R/stat_anova_test.R
+++ b/R/stat_anova_test.R
@@ -23,7 +23,7 @@ NULL
 #'  1, 2 or 3. \code{type = 2} is the default because this will yield identical
 #'  ANOVA results as type = 1 when data are balanced but type = 2 will
 #'  additionally yield various assumption tests where appropriate. When the data
-#'  are unbalanced the \code{type = 3} is used by popular commercial softwares
+#'  are unbalanced the \code{type = 3} is used by popular commercial software
 #'  including SPSS.
 #' @param effect.size the effect size to compute and to show in the ANOVA
 #'  results. Allowed values can be either "ges" (generalized eta squared) or
@@ -36,7 +36,7 @@ NULL
 #'  the within-subject factors. Possible values are: \itemize{ \item{"GG"}:
 #'  applies Greenhouse-Geisser correction to all within-subjects factors even if
 #'  the assumption of sphericity is met (i.e., Mauchly's test is not
-#'  significant, p > 0.05). \item{"HF"}: applies Hyunh-Feldt correction to all
+#'  significant, p > 0.05). \item{"HF"}: applies Huynh-Feldt correction to all
 #'  within-subjects factors even if the assumption of sphericity is met,
 #'  \item{"none"}: returns the ANOVA table without any correction and
 #'  \item{"auto"}: apply automatically GG correction to only within-subjects
@@ -48,7 +48,7 @@ NULL
 #'  variables. Allowed values include "holm", "hochberg", "hommel",
 #'  "bonferroni", "BH", "BY", "fdr", "none". If you don't want to adjust the p
 #'  value (not recommended), use p.adjust.method = "none".
-#' @param significance a list of arguments specifying the signifcance cutpoints
+#' @param significance a list of arguments specifying the significance cutpoints
 #'  and symbols. For example, \code{significance <- list(cutpoints = c(0,
 #'  0.0001, 0.001, 0.01, 0.05, Inf), symbols = c("****", "***", "**", "*",
 #'  "ns"))}.
@@ -133,8 +133,8 @@ NULL
 #'  the option \code{effect.size = "pes"}. \item{F}:	F-value. \item{p}:	p-value.
 #'  \item{p.adj}: Adjusted p-values. \item{p.signif}: P-value significance.
 #'  \item{p.adj.signif}: Adjusted p-value significance. \item{p.format}:
-#'  Formated p-value. \item{p.format.signif}: Formated p-value with significance symbols.
-#'  \item{p.adj.format}: Formated adjusted p-value. \item{n}:
+#'  Formatted p-value. \item{p.format.signif}: Formatted p-value with significance symbols.
+#'  \item{p.adj.format}: Formatted adjusted p-value. \item{n}:
 #'  number of samples. }
 #'
 #' @examples

--- a/R/stat_central_tendency.R
+++ b/R/stat_central_tendency.R
@@ -1,16 +1,16 @@
 #' @include utilities.R
 NULL
-#' Add Central Tendency Measures to a GGPLot
+#' Add Central Tendency Measures to a GGPlot
 #'
 #' @description Add central tendency measures (mean, median, mode) to density
 #'   and histogram plots created using ggplots.
 #'
 #'   Note that, normally, the mode is used for categorical data where we wish to
-#'   know which is the most common category. Therefore, we can have have two or
+#'   know which is the most common category. Therefore, we can have two or
 #'   more values that share the highest frequency. This might be problematic for
-#'   continuous variable.
+#'   a continuous variable.
 #'
-#'   For continuous variable, we can consider using mean or median as the
+#'   For a continuous variable, we can consider using mean or median as the
 #'   measures of the central tendency.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -1,7 +1,7 @@
 #' @include utilities.R utilities_label.R utils_stat_test_label.R p_format_utils.R
 NULL
 #' Add Mean Comparison P-values to a ggplot
-#' @description Add mean comparison p-values to a ggplot, such as box blots, dot
+#' @description Add mean comparison p-values to a ggplot, such as box plots, dot
 #'  plots and stripcharts.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -70,7 +70,7 @@ NULL
 #' @param tip.length numeric vector with the fraction that the bracket tips go
 #'  down to indicate the precise column. Default is 0.03. Can be of
 #'  same length as the number of comparisons to adjust specifically the tip
-#'  lenth of each comparison. For example tip.length = c(0.01, 0.03).
+#'  length of each comparison. For example tip.length = c(0.01, 0.03).
 #'
 #'  If too short they will be recycled.
 #'

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -82,7 +82,7 @@ NULL
 #'  \item{rr}{correlation coefficient squared} \item{r.label}{formatted label
 #'  for the correlation coefficient} \item{rr.label}{formatted label for the
 #'  squared correlation coefficient} \item{p.label}{label for the p-value}
-#'  \item{label}{default labeldisplayed by \code{stat_cor()}} }
+#'  \item{label}{default label displayed by \code{stat_cor()}} }
 #'
 #' @examples
 #' # Load data

--- a/R/stat_friedman_test.R
+++ b/R/stat_friedman_test.R
@@ -15,9 +15,9 @@ NULL
 #'  \item{p.adj}: Adjusted p-values.
 #'  \item{p.signif}: P-value significance.
 #'  \item{p.adj.signif}: Adjusted p-value significance.
-#'  \item{p.format}: Formated p-value.
-#'  \item{p.format.signif}: Formated p-value with significance symbols.
-#'  \item{p.adj.format}: Formated adjusted p-value.
+#'  \item{p.format}: Formatted p-value.
+#'  \item{p.format.signif}: Formatted p-value with significance symbols.
+#'  \item{p.adj.format}: Formatted adjusted p-value.
 #'  \item{n}: number of samples.
 #'   }
 #'

--- a/R/stat_friedman_test.R
+++ b/R/stat_friedman_test.R
@@ -2,7 +2,7 @@
 NULL
 #' Add Friedman Test P-values to a GGPlot
 #' @description Add automatically Friedman test p-values to a ggplot, such as
-#'  box blots, dot plots and stripcharts.
+#'  box plots, dot plots and stripcharts.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer
 #' @inheritParams stat_pvalue_manual

--- a/R/stat_kruskal_test.R
+++ b/R/stat_kruskal_test.R
@@ -14,9 +14,9 @@ NULL
 #'  \item{p.adj}: Adjusted p-values.
 #'  \item{p.signif}: P-value significance.
 #'  \item{p.adj.signif}: Adjusted p-value significance.
-#'  \item{p.format}: Formated p-value.
-#'  \item{p.format.signif}: Formated p-value with significance symbols.
-#'  \item{p.adj.format}: Formated adjusted p-value.
+#'  \item{p.format}: Formatted p-value.
+#'  \item{p.format.signif}: Formatted p-value with significance symbols.
+#'  \item{p.adj.format}: Formatted adjusted p-value.
 #'  \item{n}: number of samples.
 #'   }
 #'

--- a/R/stat_kruskal_test.R
+++ b/R/stat_kruskal_test.R
@@ -2,7 +2,7 @@
 NULL
 #' Add Kruskal-Wallis Test P-values to a GGPlot
 #' @description Add Kruskal-Wallis test p-values to a ggplot, such as
-#'  box blots, dot plots and stripcharts.
+#'  box plots, dot plots and stripcharts.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer
 #' @inheritParams stat_pvalue_manual

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -2,18 +2,18 @@
 #' @importFrom dplyr pull
 #' @importFrom glue glue
 NULL
-#' Add Manually P-values to a ggplot
+#' Add P-values Manually to a ggplot
 #'
-#' @description Add manually p-values to a ggplot, such as box blots, dot plots
+#' @description Add p-values manually to a ggplot, such as box plots, dot plots
 #'  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
 #'  \itemize{
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPLOTS}
+#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPlots}
 #'  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-adjusted-p-values-to-a-multi-panel-ggplot/}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPLOT Facets}
-#'  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPLOT}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPLOT using the GGPUBR R Package}
+#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
+#'  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPlot}
+#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
 #'  \item \href{https://www.datanovia.com/en/blog/how-to-create-stacked-bar-plots-with-error-bars-and-p-values/}{How to Create Stacked Bar Plots with Error Bars and P-values}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPLOTS}
+#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPlots}
 #'  }
 #' @inheritParams geom_bracket
 #' @param data a data frame containing statistical test results. The expected
@@ -96,7 +96,7 @@ NULL
 #' )
 #' stat.test
 #'
-#' # Add manually p-values from stat.test data
+#' # Add p-values manually from stat.test data
 #' # First specify the y.position of each comparison
 #' stat.test <- stat.test %>%
 #'   mutate(y.position = c(29, 35, 39))

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -16,7 +16,7 @@ NULL
 #'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPLOTS}
 #'  }
 #' @inheritParams geom_bracket
-#' @param data a data frame containing statitistical test results. The expected
+#' @param data a data frame containing statistical test results. The expected
 #'  default format should contain the following columns: \code{group1 | group2 |
 #'  p | y.position | etc}. \code{group1} and \code{group2} are the groups that
 #'  have been compared. \code{p} is the resulting p-value. \code{y.position} is

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -7,7 +7,7 @@ NULL
 # by Pedro J. Aphalo. For an actively maintained version with additional features and
 # bug fixes, see the 'ggpmisc' package.
 
-#' Add Regression Line Equation and R-Square to a GGPLOT.
+#' Add Regression Line Equation and R-Square to a GGPlot.
 #' @description Add regression line equation and R^2 to a ggplot. Regression
 #'  model is fitted using the function \code{\link[stats]{lm}}.
 #' @inheritParams ggpubr-common-params

--- a/R/stat_welch_anova_test.R
+++ b/R/stat_welch_anova_test.R
@@ -16,9 +16,9 @@ NULL
 #'  \item{p.adj}: Adjusted p-values.
 #'  \item{p.signif}: P-value significance.
 #'  \item{p.adj.signif}: Adjusted p-value significance.
-#'  \item{p.format}: Formated p-value.
-#'  \item{p.format.signif}: Formated p-value with significance symbols.
-#'  \item{p.adj.format}: Formated adjusted p-value.
+#'  \item{p.format}: Formatted p-value.
+#'  \item{p.format.signif}: Formatted p-value with significance symbols.
+#'  \item{p.adj.format}: Formatted adjusted p-value.
 #'  \item{n}: number of samples.
 #'   }
 #'

--- a/R/stat_welch_anova_test.R
+++ b/R/stat_welch_anova_test.R
@@ -2,7 +2,7 @@
 NULL
 #' Add Welch One-Way ANOVA Test P-values to a GGPlot
 #' @description Add Welch one-way ANOVA test p-values to a ggplot, such as
-#'  box blots, dot plots and stripcharts.
+#'  box plots, dot plots and stripcharts.
 #' @inheritParams ggpubr-common-params
 #' @inheritParams ggplot2::layer
 #' @inheritParams stat_pvalue_manual

--- a/R/theme_pubr.R
+++ b/R/theme_pubr.R
@@ -9,7 +9,7 @@ NULL
 #'  plot labels to a publication ready style \item \strong{theme_classic2()}:
 #'  Create a classic theme with axis lines. \item \strong{clean_theme()}: Remove
 #'  axis lines, ticks, texts and titles. \item \strong{clean_table_theme()}:
-#'  Clean the the theme of a table, such as those created by
+#'  Clean the theme of a table, such as those created by
 #'  \code{\link{ggsummarytable}()}}.
 #' @details \code{theme_pubr()} sets \code{strip.clip = "off"} so that the facet
 #'  strip background border is drawn at its full width (with the ggplot2 default

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -78,7 +78,7 @@ keep_only_tbl_df_classes <- function(x) {
 # geomfunc : gem_*() functions
 # data data for mapping
 # ... argument accepeted by the function
-# return a plot if geomfunc!=Null or a list(option, mapping) if  geomfunc = NULL
+# return a plot if geomfunc != NULL or a list(option, mapping) if geomfunc is NULL
 .geom_exec <- function(geomfunc = NULL, data = NULL,
                        position = NULL, ...) {
   geom_exec(geomfunc = geomfunc, data = data, position = position, ...)
@@ -867,7 +867,7 @@ keep_only_tbl_df_classes <- function(x) {
   # Special case for density and histograms:
   # x are variables and y is ..count.. or ..density..
   # after merging ggpubr add a new column .y. which hold x variables
-  # User might want to color by x variables as follow color = ".x." and
+  # User might want to color by x variables as follows: color = ".x." and
   # he aren't aware that the column is ".y." --> so we should translate this (see from line 1055)
 
   user.add.color <- add.params$color

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1085,9 +1085,10 @@ keep_only_tbl_df_classes <- function(x) {
       mean(data[[x]], na.rm = TRUE),
       stats::median(data[[x]], na.rm = TRUE)
     )
-    line_width_arg <- if ("linewidth" %in% names(formals(ggplot2::geom_vline))) "linewidth" else "size"
-    width_opt <- list(size)
-    names(width_opt) <- line_width_arg
+    # ggpubr requires ggplot2 (>= 3.5.2); geom_vline takes `linewidth`, not the
+    # deprecated `size`. Only pass it when set, so the default width is used
+    # otherwise (avoids an "empty aesthetic" warning when no width is supplied).
+    width_opt <- if (!is.null(size)) list(linewidth = size) else list()
     p <- p + do.call(
       ggplot2::geom_vline,
       c(

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1085,9 +1085,9 @@ keep_only_tbl_df_classes <- function(x) {
       mean(data[[x]], na.rm = TRUE),
       stats::median(data[[x]], na.rm = TRUE)
     )
-    # ggpubr requires ggplot2 (>= 3.5.2); geom_vline takes `linewidth`, not the
-    # deprecated `size`. Only pass it when set, so the default width is used
-    # otherwise (avoids an "empty aesthetic" warning when no width is supplied).
+    # geom_vline takes `linewidth`, not the deprecated `size` (ggplot2 >= 3.4.0).
+    # Only pass it when set, so the default width is used otherwise (avoids an
+    # "empty aesthetic" warning when no width is supplied).
     width_opt <- if (!is.null(size)) list(linewidth = size) else list()
     p <- p + do.call(
       ggplot2::geom_vline,

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,9 +24,9 @@ knitr::opts_chunk$set(
 
 # ggpubr: 'ggplot2' Based Publication Ready Plots
 
-[ggplot2, by Hadley Wickham, ](https://ggplot2.tidyverse.org/) is an excellent and flexible package for elegant data visualization in R. However the default generated plots requires some formatting before we can send them for publication. Furthermore, to customize a ggplot, the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills.
+[ggplot2, by Hadley Wickham, ](https://ggplot2.tidyverse.org/) is an excellent and flexible package for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a ggplot, the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills.
 
-The 'ggpubr' package provides some easy-to-use functions for creating and customizing 'ggplot2'- based publication ready plots.
+The 'ggpubr' package provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots.
 
 
 Find out more at https://rpkgs.datanovia.com/ggpubr/.
@@ -41,7 +41,7 @@ Find out more at https://rpkgs.datanovia.com/ggpubr/.
 ## Installation and loading
 
 
-- Install from [CRAN](https://cran.r-project.org/package=ggpubr) as follow:
+- Install from [CRAN](https://cran.r-project.org/package=ggpubr) as follows:
 
 
 ```{r, eval = FALSE}
@@ -49,7 +49,7 @@ install.packages("ggpubr")
 ```
 
 
-- Or, install the latest version from [GitHub](https://github.com/kassambara/ggpubr) as follow:
+- Or, install the latest version from [GitHub](https://github.com/kassambara/ggpubr) as follows:
 
 
 ```{r, eval = FALSE}
@@ -162,8 +162,8 @@ Change the fill color by the grouping variable "cyl". Sorting will be done globa
 ggbarplot(dfm, x = "name", y = "mpg",
           fill = "cyl",               # change fill color by cyl
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
-          sort.val = "desc",          # Sort the value in dscending order
+          palette = "jco",            # jco journal color palette. see ?ggpar
+          sort.val = "desc",          # Sort the value in descending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90           # Rotate vertically x axis texts
           )
@@ -179,8 +179,8 @@ Sort bars inside each group. Use the argument **sort.by.groups = TRUE**.
 ggbarplot(dfm, x = "name", y = "mpg",
           fill = "cyl",               # change fill color by cyl
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
-          sort.val = "asc",           # Sort the value in dscending order
+          palette = "jco",            # jco journal color palette. see ?ggpar
+          sort.val = "asc",           # Sort the value in ascending order
           sort.by.groups = TRUE,      # Sort inside each group
           x.text.angle = 90           # Rotate vertically x axis texts
           )
@@ -212,7 +212,7 @@ Create an ordered barplot, colored according to the level of mpg:
 ggbarplot(dfm, x = "name", y = "mpg_z",
           fill = "mpg_grp",           # change fill color by mpg_level
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
+          palette = "jco",            # jco journal color palette. see ?ggpar
           sort.val = "asc",           # Sort the value in ascending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90,          # Rotate vertically x axis texts
@@ -231,7 +231,7 @@ Rotate the plot: use rotate = TRUE and sort.val = "desc"
 ggbarplot(dfm, x = "name", y = "mpg_z",
           fill = "mpg_grp",           # change fill color by mpg_level
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
+          palette = "jco",            # jco journal color palette. see ?ggpar
           sort.val = "desc",          # Sort the value in descending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90,          # Rotate vertically x axis texts
@@ -342,5 +342,3 @@ Find out more at https://rpkgs.datanovia.com/ggpubr/.
 ## Blog posts
 
 - A. Kassambara. [ggpubr R Package: ggplot2-Based Publication Ready Plots](https://www.sthda.com/english/articles/24-ggpubr-publication-ready-plots/)
-
-

--- a/README.Rmd
+++ b/README.Rmd
@@ -190,7 +190,7 @@ ggbarplot(dfm, x = "name", y = "mpg",
 
 ### Deviation graphs
 
-The deviation graph shows the deviation of quantitatives values to a reference value. In the R code below, we'll plot the mpg z-score from the mtcars dataset.
+The deviation graph shows the deviation of quantitative values to a reference value. In the R code below, we'll plot the mpg z-score from the mtcars dataset.
 
 
 Calculate the z-score of the mpg data:
@@ -264,7 +264,7 @@ ggdotchart(dfm, x = "name", y = "mpg",
 
 
 
-- Sort in decending order. **sorting = "descending"**.
+- Sort in descending order. **sorting = "descending"**.
 - Rotate the plot vertically, using **rotate = TRUE**.
 - Sort the mpg value inside each group by using **group = "cyl"**.
 - Set **dot.size** to 6.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Downloads](https://cranlogs.r-pkg.org/badges/grand-total/ggpubr?color=orange)](h
 
 [ggplot2, by Hadley Wickham,](https://ggplot2.tidyverse.org/) is an
 excellent and flexible package for elegant data visualization in R.
-However the default generated plots requires some formatting before we
+However the default generated plots require some formatting before we
 can send them for publication. Furthermore, to customize a ggplot, the
 syntax is opaque and this raises the level of difficulty for researchers
 with no advanced R programming skills.
 
 The 'ggpubr' package provides some easy-to-use functions for creating
-and customizing 'ggplot2'- based publication ready plots.
+and customizing 'ggplot2'-based publication ready plots.
 
 Find out more at <https://rpkgs.datanovia.com/ggpubr/>.
 
@@ -36,14 +36,14 @@ Find out more at <https://rpkgs.datanovia.com/ggpubr/>.
 ## Installation and loading
 
 - Install from [CRAN](https://cran.r-project.org/package=ggpubr) as
-  follow:
+  follows:
 
 ``` r
 install.packages("ggpubr")
 ```
 
 - Or, install the latest version from
-  [GitHub](https://github.com/kassambara/ggpubr) as follow:
+  [GitHub](https://github.com/kassambara/ggpubr) as follows:
 
 ``` r
 # Install
@@ -181,8 +181,8 @@ done globally, but not by groups.
 ggbarplot(dfm, x = "name", y = "mpg",
           fill = "cyl",               # change fill color by cyl
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
-          sort.val = "desc",          # Sort the value in dscending order
+          palette = "jco",            # jco journal color palette. see ?ggpar
+          sort.val = "desc",          # Sort the value in descending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90           # Rotate vertically x axis texts
           )
@@ -196,8 +196,8 @@ Sort bars inside each group. Use the argument **sort.by.groups = TRUE**.
 ggbarplot(dfm, x = "name", y = "mpg",
           fill = "cyl",               # change fill color by cyl
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
-          sort.val = "asc",           # Sort the value in dscending order
+          palette = "jco",            # jco journal color palette. see ?ggpar
+          sort.val = "asc",           # Sort the value in ascending order
           sort.by.groups = TRUE,      # Sort inside each group
           x.text.angle = 90           # Rotate vertically x axis texts
           )
@@ -235,7 +235,7 @@ Create an ordered barplot, colored according to the level of mpg:
 ggbarplot(dfm, x = "name", y = "mpg_z",
           fill = "mpg_grp",           # change fill color by mpg_level
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
+          palette = "jco",            # jco journal color palette. see ?ggpar
           sort.val = "asc",           # Sort the value in ascending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90,          # Rotate vertically x axis texts
@@ -253,7 +253,7 @@ Rotate the plot: use rotate = TRUE and sort.val = "desc"
 ggbarplot(dfm, x = "name", y = "mpg_z",
           fill = "mpg_grp",           # change fill color by mpg_level
           color = "white",            # Set bar border colors to white
-          palette = "jco",            # jco journal color palett. see ?ggpar
+          palette = "jco",            # jco journal color palette. see ?ggpar
           sort.val = "desc",          # Sort the value in descending order
           sort.by.groups = FALSE,     # Don't sort inside each group
           x.text.angle = 90,          # Rotate vertically x axis texts

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ggbarplot(dfm, x = "name", y = "mpg",
 
 ### Deviation graphs
 
-The deviation graph shows the deviation of quantitatives values to a
+The deviation graph shows the deviation of quantitative values to a
 reference value. In the R code below, we'll plot the mpg z-score from
 the mtcars dataset.
 
@@ -287,7 +287,7 @@ ggdotchart(dfm, x = "name", y = "mpg",
 
 ![](tools/README-lollipop-chart-1.png)<!-- -->
 
-- Sort in decending order. **sorting = "descending"**.
+- Sort in descending order. **sorting = "descending"**.
 - Rotate the plot vertically, using **rotate = TRUE**.
 - Sort the mpg value inside each group by using **group = "cyl"**.
 - Set **dot.size** to 6.

--- a/man/add_summary.Rd
+++ b/man/add_summary.Rd
@@ -64,7 +64,7 @@ frame with variables ymin, y, and ymax. Allowed values are one of: "mean",
 
 \item{color}{point or outline color.}
 
-\item{fill}{fill color. Used only whne \code{error.plot = "crossbar"}.}
+\item{fill}{fill color. Used only when \code{error.plot = "crossbar"}.}
 
 \item{group}{grouping variable. Allowed values are 1 (for one group) or a
 character vector specifying the name of the grouping variable. Used only for

--- a/man/add_summary.Rd
+++ b/man/add_summary.Rd
@@ -129,7 +129,7 @@ defined by the \code{interquartile range}.
 \item \code{median_hilow_()}: computes the sample median and a selected pair of
 outer quantiles having equal tail areas. This function is a reformatted
 version of \code{Hmisc::smedian.hilow()}. The confidence limits are computed
-as follow: \code{lower.limits = (1-ci)/2} percentiles; \code{upper.limits =
+as follows: \code{lower.limits = (1-ci)/2} percentiles; \code{upper.limits =
 (1+ci)/2} percentiles. By default (\code{ci = 0.95}), the 2.5th and the
 97.5th percentiles are used as the lower and the upper confidence limits,
 respectively. If you want to use the 25th and the 75th percentiles as the

--- a/man/as_ggplot.Rd
+++ b/man/as_ggplot.Rd
@@ -17,11 +17,11 @@ an object of class ggplot.
 \description{
 Transform the output of
  \code{\link[gridExtra:arrangeGrob]{arrangeGrob}()} and
- \code{\link[gridExtra:arrangeGrob]{grid.arrange}()} to a an object of class
+ \code{\link[gridExtra:arrangeGrob]{grid.arrange}()} to an object of class
  ggplot.
 }
 \examples{
-# Creat some plots
+# Create some plots
 bxp <- ggboxplot(iris, x = "Species", y = "Sepal.Length")
 vp <- ggviolin(iris,
   x = "Species", y = "Sepal.Length",

--- a/man/as_npc.Rd
+++ b/man/as_npc.Rd
@@ -40,7 +40,7 @@ A numeric vector with values in the range [0-1] representing npc
   coordinates.
 }
 \description{
-Convert character coordinates to npc units and shift postions to avoid
+Convert character coordinates to npc units and shift positions to avoid
 overlaps when grouping is active. If numeric validate npc values.
 }
 \details{

--- a/man/axis_scale.Rd
+++ b/man/axis_scale.Rd
@@ -14,7 +14,7 @@ yscale(.scale, .format = FALSE)
 \item{.scale}{axis scale. Allowed values are one of c("none", "log2", "log10",
 "sqrt", "percent", "dollar", "scientific"); e.g.: .scale="log2".}
 
-\item{.format}{ogical value. If TRUE, axis tick mark labels will be formatted
+\item{.format}{logical value. If TRUE, axis tick mark labels will be formatted
 when .scale  = "log2" or "log10".}
 }
 \description{

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -121,7 +121,7 @@ allows four stars (****) for the most significant level when
 \item{...}{Other arguments to be passed to the test function.}
 }
 \value{
-return a data frame with the following columns:
+a data frame with the following columns:
 \itemize{
 \item \code{.y.}: the y variable used in the test.
 \item \code{group1,group2}: the compared groups in the pairwise tests.

--- a/man/facet.Rd
+++ b/man/facet.Rd
@@ -56,7 +56,7 @@ panel.labs.background = list(color = "blue", fill = "pink", linetype =
 "dashed", linewidth = 0.5). Note: \code{size} is deprecated, use
 \code{linewidth} instead.}
 
-\item{panel.labs.font}{a list of aestheics indicating the size (e.g.: 14), the
+\item{panel.labs.font}{a list of aesthetics indicating the size (e.g.: 14), the
 face/style (e.g.: "plain", "bold", "italic", "bold.italic") and the color
 (e.g.: "red") and the orientation angle (e.g.: 45) of panel labels.}
 

--- a/man/gene_expression.Rd
+++ b/man/gene_expression.Rd
@@ -6,7 +6,7 @@
 \title{Gene Expression Data}
 \format{
 A data frame with 1305 rows and 5 columns. \describe{
- \item{\code{bcr_patient_barcode}}{sample ID} \item{\code{dataset}}{cance type} \item{\code{GATA3}}{GATA3 gene expression}
+ \item{\code{bcr_patient_barcode}}{sample ID} \item{\code{dataset}}{cancer type} \item{\code{GATA3}}{GATA3 gene expression}
  \item{\code{PTEN}}{PTEN gene expression}\item{\code{XBP1}}{XBP1 gene expression.}}
 }
 \usage{

--- a/man/geom_exec.Rd
+++ b/man/geom_exec.Rd
@@ -17,13 +17,13 @@ call to a position adjustment function.}
 \item{...}{arguments accepted by the function}
 }
 \value{
-return a plot if geomfunc!=Null or a list(option, mapping) if
-  geomfunc = NULL.
+a plot if geomfunc != NULL or a list(option, mapping) if
+  geomfunc is NULL.
 }
 \description{
 A helper function used by ggpubr functions to execute any geom_*
   functions in ggplot2. Useful only when you want to call a geom_* function
-  without carrying about the arguments to put in aes(). Basic users of ggpubr
+  without worrying about the arguments to put in aes(). Basic users of ggpubr
   don't need this function.
 }
 \examples{

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -340,8 +340,8 @@ One might want to adjust the p-values of all the facet panels together. There ar
 \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 \itemize{
-  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPLOT Facets}
-  \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPLOT Facets with Different Scales}
+  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
+  \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPlot Facets with Different Scales}
 }
 }
 }

--- a/man/get_palette.Rd
+++ b/man/get_palette.Rd
@@ -22,7 +22,7 @@ e.g.: "npg", "aaas", "lancet", "jco", "ucscgb", "uchicago", "simpsons" and
 Returns a vector of color palettes.
 }
 \description{
-Generate a palette of k colors from ggsci palettes, RColorbrewer
+Generate a palette of k colors from ggsci palettes, RColorBrewer
  palettes and custom color palettes. Useful to extend RColorBrewer and ggsci to support more colors.
 }
 \details{

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -34,10 +34,6 @@ either ggplot2 plot objects or arbitrary gtables.}
 
 \item{nrow}{(optional) number of rows in the plot grid.}
 
-\item{byrow}{logical. If \code{TRUE} (default), the plots are filled into the
-grid by row; set to \code{FALSE} to fill by column. Passed to
-\code{\link[cowplot]{plot_grid}()}.}
-
 \item{labels}{(optional) list of labels to be added to the plots. You can
 also set labels="AUTO" to auto-generate upper-case labels or labels="auto"
 to auto-generate lower-case labels.}
@@ -71,6 +67,10 @@ example, in a two-column grid, widths = c(2, 1) would make the first column
 twice as wide as the second column.}
 
 \item{heights}{same as \code{widths} but for column heights.}
+
+\item{byrow}{logical. If \code{TRUE} (default), the plots are filled into the
+grid by row; set to \code{FALSE} to fill by column. Passed to
+\code{\link[cowplot]{plot_grid}()}.}
 
 \item{legend}{character specifying legend position. Allowed values are one of
 c("top", "bottom", "left", "right", "none"). To remove the legend use

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -84,8 +84,8 @@ unique legend will be created for arranged plots.}
 legend.}
 }
 \value{
-return an object of class \code{ggarrange}, which is a ggplot or a
-  list of ggplot.
+an object of class \code{ggarrange}, which is a ggplot or a
+  list of ggplots.
 }
 \description{
 Arrange multiple ggplots on the same page. Wrapper around

--- a/man/ggballoonplot.Rd
+++ b/man/ggballoonplot.Rd
@@ -118,7 +118,7 @@ ggballoonplot(data,
 ) +
   gradient_fill(c("blue", "white", "red"))
 
-# Streched contingency table
+# Stretched contingency table
 # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 # Create an Example Data Frame Containing Car x Color data

--- a/man/ggballoonplot.Rd
+++ b/man/ggballoonplot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ggballoonplot.R
 \name{ggballoonplot}
 \alias{ggballoonplot}
-\title{Ballon plot}
+\title{Balloon plot}
 \usage{
 ggballoonplot(
   data,
@@ -26,9 +26,9 @@ ggballoonplot(
 contingency table} formed by two categorical variables: a data frame with
 row names and column names. The categories of the first variable are
 columns and the categories of the second variable are rows. \item \bold{a
-streched contingency table}: a data frame containing at least three columns
+stretched contingency table}: a data frame containing at least three columns
 corresponding, respectively, to (1) the categories of the first variable,
-(2) the categories of the second varible, (3) the frequency value. In this
+(2) the categories of the second variable, (3) the frequency value. In this
 case, you should specify the argument x and y in the function
 \code{ggballoonplot()}}.}
 
@@ -47,7 +47,7 @@ faceting the plot into multiple panels. Should be in the data.}
 maximum size of the plotting symbol. Default values are \code{size.range =
 c(1, 10)}.}
 
-\item{shape}{points shape. The default value is 21. Alternaive values include
+\item{shape}{points shape. The default value is 21. Alternative values include
 22, 23, 24, 25.}
 
 \item{color}{point border line color.}
@@ -64,7 +64,7 @@ the color (e.g.: "red") of point labels. For example font.label = c(14,
 "bold", "red"). To specify only the size and the style, use font.label =
 c(14, "plain").}
 
-\item{rotate.x.text}{logica. If TRUE (default), rotate the x axis text.}
+\item{rotate.x.text}{logical. If TRUE (default), rotate the x axis text.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -69,7 +69,7 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}
 
-\item{width}{numeric value between 0 and 1 specifying box width.}
+\item{width}{numeric value between 0 and 1 specifying the width of the plot elements.}
 
 \item{title}{plot main title.}
 
@@ -144,9 +144,7 @@ Used only when sort.val != "none".}
 
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-Used to control the spacing between boxes of grouped box plots. Applies to
-the box and box-error-bar layers; layers added via \code{add} (e.g.
-"jitter") keep their own default positioning.}
+Used to control the spacing between grouped elements.}
 
 \item{numeric.x.axis}{logical. If TRUE, x axis will be treated as numeric.
 Default is FALSE. Useful, for example, to plot bars at their numeric x

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -116,7 +116,7 @@ when add != "none" and add contains one "mean_*" or "med_*" where "*" = sd,
 se, ....}
 
 \item{label}{specify whether to add labels on the bar plot. Allowed values
-are: \itemize{ \item \strong{logical value}: If TRUE, y values is added as
+are: \itemize{ \item \strong{logical value}: If TRUE, y values are added as
 labels on the bar plot \item \strong{character vector}: Used as text
 labels; must be the same length as y. }}
 
@@ -142,24 +142,17 @@ Used only when sort.val != "none".}
 
 \item{top}{a numeric value specifying the number of top elements to be shown.}
 
+\item{position}{position adjustment, either as a string, or the result of a
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+Used to control the spacing between boxes of grouped box plots. Applies to
+the box and box-error-bar layers; layers added via \code{add} (e.g.
+"jitter") keep their own default positioning.}
+
 \item{numeric.x.axis}{logical. If TRUE, x axis will be treated as numeric.
 Default is FALSE. Useful, for example, to plot bars at their numeric x
 positions (e.g. a time axis) instead of at equally-spaced discrete
 categories. Ignored when \code{order} is set or \code{sort.val != "none"},
 which require a discrete x axis.}
-
-\item{position}{A position adjustment to use on the data for this layer. This
-can be used in various ways, including to prevent overplotting and
-improving the display. The \code{position} argument accepts the following:
-\itemize{
-\item The result of calling a position function, such as \code{position_jitter()}.
-This method allows for passing extra arguments to the position.
-\item A string naming the position adjustment. To give the position as a
-string, strip the function name of the \code{position_} prefix. For example,
-to use \code{position_jitter()}, give the position as \code{"jitter"}.
-\item For more information and other ways to specify the position, see the
-\link[ggplot2:layer_positions]{layer position} documentation.
-}}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -104,7 +104,7 @@ outlines.}
 
 \item{linewidth}{constant value specifying the line width.}
 
-\item{width}{numeric value between 0 and 1 specifying box width.}
+\item{width}{numeric value between 0 and 1 specifying the width of the plot elements.}
 
 \item{notch}{If \code{FALSE} (default) make a standard box plot. If
 \code{TRUE}, make a notched box plot. Notches are used to compare groups;
@@ -171,9 +171,7 @@ text, making it easier to read.}
 
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-Used to control the spacing between boxes of grouped box plots. Applies to
-the box and box-error-bar layers; layers added via \code{add} (e.g.
-"jitter") keep their own default positioning.}
+Used to control the spacing between grouped elements.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -159,7 +159,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 
@@ -170,10 +170,10 @@ text labels or not.}
 text, making it easier to read.}
 
 \item{position}{position adjustment, either as a string, or the result of a
-call to a position adjustment function (e.g. \code{position_dodge(0.8)}). Used
-to control the spacing between boxes of grouped box plots. Applies to the box
-and box-error-bar layers; layers added via \code{add} (e.g. "jitter") keep
-their own default positioning.}
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+Used to control the spacing between boxes of grouped box plots. Applies to
+the box and box-error-bar layers; layers added via \code{add} (e.g.
+"jitter") keep their own default positioning.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggdensity.Rd
+++ b/man/ggdensity.Rd
@@ -115,7 +115,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggdotchart.Rd
+++ b/man/ggdotchart.Rd
@@ -127,7 +127,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggdotplot.Rd
+++ b/man/ggdotplot.Rd
@@ -127,7 +127,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggerrorplot.Rd
+++ b/man/ggerrorplot.Rd
@@ -115,18 +115,11 @@ se, ....}
 
 \item{ci}{the percent range of the confidence interval (default is 0.95).}
 
-\item{position}{A position adjustment to use on the data for this layer. This
-can be used in various ways, including to prevent overplotting and
-improving the display. The \code{position} argument accepts the following:
-\itemize{
-\item The result of calling a position function, such as \code{position_jitter()}.
-This method allows for passing extra arguments to the position.
-\item A string naming the position adjustment. To give the position as a
-string, strip the function name of the \code{position_} prefix. For example,
-to use \code{position_jitter()}, give the position as \code{"jitter"}.
-\item For more information and other ways to specify the position, see the
-\link[ggplot2:layer_positions]{layer position} documentation.
-}}
+\item{position}{position adjustment, either as a string, or the result of a
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+Used to control the spacing between boxes of grouped box plots. Applies to
+the box and box-error-bar layers; layers added via \code{add} (e.g.
+"jitter") keep their own default positioning.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggerrorplot.Rd
+++ b/man/ggerrorplot.Rd
@@ -67,7 +67,7 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}
 
-\item{width}{numeric value between 0 and 1 specifying box width.}
+\item{width}{numeric value between 0 and 1 specifying the width of the plot elements.}
 
 \item{title}{plot main title.}
 
@@ -117,9 +117,7 @@ se, ....}
 
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-Used to control the spacing between boxes of grouped box plots. Applies to
-the box and box-error-bar layers; layers added via \code{add} (e.g.
-"jitter") keep their own default positioning.}
+Used to control the spacing between grouped elements.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/gghistogram.Rd
+++ b/man/gghistogram.Rd
@@ -127,7 +127,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggline.Rd
+++ b/man/ggline.Rd
@@ -164,9 +164,7 @@ text, making it easier to read.}
 
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-Used to control the spacing between boxes of grouped box plots. Applies to
-the box and box-error-bar layers; layers added via \code{add} (e.g.
-"jitter") keep their own default positioning.}
+Used to control the spacing between grouped elements.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggline.Rd
+++ b/man/ggline.Rd
@@ -150,7 +150,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 
@@ -162,18 +162,11 @@ text, making it easier to read.}
 
 \item{show.line.label}{logical value. If TRUE, shows line labels.}
 
-\item{position}{A position adjustment to use on the data for this layer. This
-can be used in various ways, including to prevent overplotting and
-improving the display. The \code{position} argument accepts the following:
-\itemize{
-\item The result of calling a position function, such as \code{position_jitter()}.
-This method allows for passing extra arguments to the position.
-\item A string naming the position adjustment. To give the position as a
-string, strip the function name of the \code{position_} prefix. For example,
-to use \code{position_jitter()}, give the position as \code{"jitter"}.
-\item For more information and other ways to specify the position, see the
-\link[ggplot2:layer_positions]{layer position} documentation.
-}}
+\item{position}{position adjustment, either as a string, or the result of a
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+Used to control the spacing between boxes of grouped box plots. Applies to
+the box and box-error-bar layers; layers added via \code{add} (e.g.
+"jitter") keep their own default positioning.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -110,7 +110,7 @@ theme_minimal(), theme_classic(), theme_void(), ....}
 \item{...}{other arguments to be passed to \code{\link{ggpar}}.}
 }
 \value{
-returns a ggplot.
+a ggplot.
 }
 \description{
 Make MA-plot which is a scatter plot of log2 fold changes (M, on

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -45,7 +45,7 @@ ggmaplot(
 
  \itemize{ \item baseMean: the mean expression of genes in the two groups.
  \item log2FoldChange: the log2 fold changes of group 2 compared to group 1
- \item padj: the adjusted p-value of the used statiscal test. }}
+ \item padj: the adjusted p-value of the used statistical test. }}
 
 \item{fdr}{Accepted false discovery rate for considering genes as
 differentially expressed.}
@@ -63,7 +63,7 @@ column is available in data, it will be used.}
 
 \item{size}{points size.}
 
-\item{alpha}{numeric value betwenn 0 an 1 specifying point alpha for
+\item{alpha}{numeric value between 0 and 1 specifying point alpha for
 controlling transparency. For example, use alpha = 0.5.}
 
 \item{seed}{Random seed passed to \code{set.seed}. if

--- a/man/ggpaired.Rd
+++ b/man/ggpaired.Rd
@@ -103,7 +103,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggpubr-package.Rd
+++ b/man/ggpubr-package.Rd
@@ -6,7 +6,7 @@
 \alias{ggpubr-package}
 \title{ggpubr: 'ggplot2' Based Publication Ready Plots}
 \description{
-The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots requires some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
+The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
 }
 \details{
 General resources:
@@ -33,7 +33,7 @@ See \code{\link{list_p_format_styles}()} for details on each style.
 
 
 \describe{
-\item{ggpubr.parse_aes}{logical indicating whether to parse or not aesthetics variables names.
+\item{ggpubr.parse_aes}{logical indicating whether to parse aesthetic variable names.
 Default is \code{TRUE}. For example, if you want \code{ggpubr} to handle non-standard column names, like \code{A-A},
 without parsing, then set this option to \code{FALSE} using \code{options(ggpubr.parse_aes = FALSE)}.}
 \item{ggpubr.null_device}{A function that creates an appropriate null device.
@@ -42,9 +42,9 @@ These include: \code{\link[cowplot:pdf_null_device]{cowplot::pdf_null_device}},
 \code{\link[cowplot:cairo_null_device]{cowplot::cairo_null_device}} and
 \code{\link[cowplot:agg_null_device]{cowplot::agg_null_device}}. Default is
 \code{\link[cowplot:pdf_null_device]{cowplot::pdf_null_device}}. This is used in
-function like \code{\link{as_ggplot}()}, which needs to open a graphics
+functions like \code{\link{as_ggplot}()}, which need to open a graphics
 device to render ggplot objects into grid graphics objects. This function is
-used to open null device for avoiding the display of unnecessary blank page
+used to open a null device to avoid displaying an unnecessary blank page
 when calling \code{\link{ggarrange}()} or \code{\link{as_ggplot}()}} }
 }
 

--- a/man/ggpubr_options.Rd
+++ b/man/ggpubr_options.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ggpubr_options.R
 \name{ggpubr_options}
 \alias{ggpubr_options}
-\title{Global Options for GGPubr}
+\title{Global Options for ggpubr}
 \usage{
 ggpubr_options()
 }

--- a/man/ggscatter.Rd
+++ b/man/ggscatter.Rd
@@ -136,7 +136,7 @@ probability.}
  "euclid")} for plotting concentration ellipses.
 
  \itemize{ \item \code{"convex"}: plot convex hull of a set o points. \item
- \code{"confidence"}: plot confidence ellipses arround group mean points as
+ \code{"confidence"}: plot confidence ellipses around group mean points as
  \code{FactoMineR::coord.ellipse()}. \item \code{"t"}:
  assumes a multivariate t-distribution. \item \code{"norm"}: assumes a
  multivariate normal distribution. \item \code{"euclid"}: draws a circle with

--- a/man/ggscatterhist.Rd
+++ b/man/ggscatterhist.Rd
@@ -104,7 +104,7 @@ hide ylab.}
 \item{...}{other arguments passed to the function \code{\link{ggscatter}()}.}
 }
 \value{
-an object of class \code{ggscatterhist}, which is list of ggplots,
+an object of class \code{ggscatterhist}, which is a list of ggplots,
  including the following elements: \itemize{\item sp: main scatter plot;
  \item xplot: marginal x-axis plot; \item yplot: marginal y-axis plot. }.
 

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -128,7 +128,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggsummarystats.Rd
+++ b/man/ggsummarystats.Rd
@@ -5,7 +5,7 @@
 \alias{ggsummarystats}
 \alias{print.ggsummarystats}
 \alias{print.ggsummarystats_list}
-\title{GGPLOT with Summary Stats Table Under the Plot}
+\title{GGPlot with Summary Stats Table Under the Plot}
 \usage{
 ggsummarytable(
   data,

--- a/man/ggtext.Rd
+++ b/man/ggtext.Rd
@@ -58,7 +58,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 

--- a/man/ggtexttable.Rd
+++ b/man/ggtexttable.Rd
@@ -247,7 +247,7 @@ Value should be in [0, 1], where 0 is full transparency and 1 is no transparency
 
 \item{at.row}{a numeric vector of row indexes; for example \code{at.row = c(1, 2)}.}
 
-\item{row.side}{row side to which the horinzotal line should be added. Can be one of \code{c("bottom", "top")}.}
+\item{row.side}{row side to which the horizontal line should be added. Can be one of \code{c("bottom", "top")}.}
 
 \item{from.column}{integer indicating the column from which to start drawing the horizontal line.}
 

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -185,9 +185,7 @@ text, making it easier to read.}
 
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
-Used to control the spacing between boxes of grouped box plots. Applies to
-the box and box-error-bar layers; layers added via \code{add} (e.g.
-"jitter") keep their own default positioning.}
+Used to control the spacing between grouped elements.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -106,13 +106,6 @@ labelled only by variable grouping levels.}
 \item{trim}{If \code{TRUE} (default), trim the tails of the violins
 to the range of the data. If \code{FALSE}, don't trim the tails.}
 
-\item{size}{Numeric value (e.g.: size = 1). change the size of points and
-outlines.}
-
-\item{linewidth}{constant value specifying the line width.}
-
-\item{width}{violin width.}
-
 \item{drop}{logical, passed to \code{\link[ggplot2]{geom_violin}()}. When
 \code{TRUE} (the default, unchanged behavior), grouped sub-samples with fewer
 than two data points (for which no density can be computed) are dropped,
@@ -123,6 +116,13 @@ longer line up with other layers (e.g. added boxplots or dot plots). Set
 empty dodge lane so the violins stay aligned with the other geoms. Both are
 needed: \code{drop = FALSE} keeps the sparse group and \code{preserve =
 "single"} keeps its lane width (#381).}
+
+\item{size}{Numeric value (e.g.: size = 1). change the size of points and
+outlines.}
+
+\item{linewidth}{constant value specifying the line width.}
+
+\item{width}{violin width.}
 
 \item{quantiles}{numeric vector of quantiles to draw on the violin.}
 
@@ -173,7 +173,7 @@ specifying some labels to show. \item a list containing one or the
 combination of the following components: \itemize{ \item \code{top.up} and
 \code{top.down}: to display the labels  of the top up/down points. For
 example, \code{label.select = list(top.up = 10, top.down = 4)}. \item
-\code{criteria}: to filter, for example, by x and y variabes values, use
+\code{criteria}: to filter, for example, by x and y variables values, use
 this: \code{label.select = list(criteria = "`y` > 2 & `y` < 5 & `x` \%in\%
 c('A', 'B')")}. } }}
 
@@ -183,18 +183,11 @@ text labels or not.}
 \item{label.rectangle}{logical value. If TRUE, add rectangle underneath the
 text, making it easier to read.}
 
-\item{position}{A position adjustment to use on the data for this layer. This
-can be used in various ways, including to prevent overplotting and
-improving the display. The \code{position} argument accepts the following:
-\itemize{
-\item The result of calling a position function, such as \code{position_jitter()}.
-This method allows for passing extra arguments to the position.
-\item A string naming the position adjustment. To give the position as a
-string, strip the function name of the \code{position_} prefix. For example,
-to use \code{position_jitter()}, give the position as \code{"jitter"}.
-\item For more information and other ways to specify the position, see the
-\link[ggplot2:layer_positions]{layer position} documentation.
-}}
+\item{position}{position adjustment, either as a string, or the result of a
+call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
+Used to control the spacing between boxes of grouped box plots. Applies to
+the box and box-error-bar layers; layers added via \code{add} (e.g.
+"jitter") keep their own default positioning.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/stat_anova_test.Rd
+++ b/man/stat_anova_test.Rd
@@ -82,7 +82,7 @@ test is performed between the x-groups for each legend level. }}
 1, 2 or 3. \code{type = 2} is the default because this will yield identical
 ANOVA results as type = 1 when data are balanced but type = 2 will
 additionally yield various assumption tests where appropriate. When the data
-are unbalanced the \code{type = 3} is used by popular commercial softwares
+are unbalanced the \code{type = 3} is used by popular commercial software
 including SPSS.}
 
 \item{effect.size}{the effect size to compute and to show in the ANOVA
@@ -98,7 +98,7 @@ specify which correction of the degrees of freedom should be reported for
 the within-subject factors. Possible values are: \itemize{ \item{"GG"}:
 applies Greenhouse-Geisser correction to all within-subjects factors even if
 the assumption of sphericity is met (i.e., Mauchly's test is not
-significant, p > 0.05). \item{"HF"}: applies Hyunh-Feldt correction to all
+significant, p > 0.05). \item{"HF"}: applies Huynh-Feldt correction to all
 within-subjects factors even if the assumption of sphericity is met,
 \item{"none"}: returns the ANOVA table without any correction and
 \item{"auto"}: apply automatically GG correction to only within-subjects
@@ -144,7 +144,7 @@ variables. Allowed values include "holm", "hochberg", "hommel",
 "bonferroni", "BH", "BY", "fdr", "none". If you don't want to adjust the p
 value (not recommended), use p.adjust.method = "none".}
 
-\item{significance}{a list of arguments specifying the signifcance cutpoints
+\item{significance}{a list of arguments specifying the significance cutpoints
  and symbols. For example, \code{significance <- list(cutpoints = c(0,
  0.0001, 0.001, 0.01, 0.05, Inf), symbols = c("****", "***", "**", "*",
  "ns"))}.
@@ -258,8 +258,8 @@ Adds automatically one-way and two-way ANOVA test p-values to a
  the option \code{effect.size = "pes"}. \item{F}:	F-value. \item{p}:	p-value.
  \item{p.adj}: Adjusted p-values. \item{p.signif}: P-value significance.
  \item{p.adj.signif}: Adjusted p-value significance. \item{p.format}:
- Formated p-value. \item{p.format.signif}: Formated p-value with significance symbols.
- \item{p.adj.format}: Formated adjusted p-value. \item{n}:
+ Formatted p-value. \item{p.format.signif}: Formatted p-value with significance symbols.
+ \item{p.adj.format}: Formatted adjusted p-value. \item{n}:
  number of samples. }
 }
 

--- a/man/stat_anova_test.Rd
+++ b/man/stat_anova_test.Rd
@@ -247,7 +247,7 @@ text up or down. }}
 }
 \description{
 Adds automatically one-way and two-way ANOVA test p-values to a
- ggplot, such as box blots, dot plots and stripcharts.
+ggplot, such as box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{ \item{DFn}: Degrees of Freedom in the

--- a/man/stat_central_tendency.Rd
+++ b/man/stat_central_tendency.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/stat_central_tendency.R
 \name{stat_central_tendency}
 \alias{stat_central_tendency}
-\title{Add Central Tendency Measures to a GGPLot}
+\title{Add Central Tendency Measures to a GGPlot}
 \usage{
 stat_central_tendency(
   mapping = NULL,
@@ -90,11 +90,11 @@ Add central tendency measures (mean, median, mode) to density
   and histogram plots created using ggplots.
 
   Note that, normally, the mode is used for categorical data where we wish to
-  know which is the most common category. Therefore, we can have have two or
+  know which is the most common category. Therefore, we can have two or
   more values that share the highest frequency. This might be problematic for
-  continuous variable.
+  a continuous variable.
 
-  For continuous variable, we can consider using mean or median as the
+  For a continuous variable, we can consider using mean or median as the
   measures of the central tendency.
 }
 \examples{

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -236,7 +236,7 @@ shouldn't inherit behaviour from the default plot specification. Set to
 \code{\link[ggplot2:geom_text]{geom_label}}.}
 }
 \description{
-Add mean comparison p-values to a ggplot, such as box blots, dot
+Add mean comparison p-values to a ggplot, such as box plots, dot
  plots and stripcharts.
 }
 \details{

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -81,14 +81,14 @@ for wilcoxon test.}
  grouping variable levels is compared to all (i.e. basemean).}
 
 \item{comparisons}{A list of length-2 vectors. The entries in the vector are
-either the names of 2 values on the x-axis or the 2 integers that correspond
-to the index of the groups of interest, to be compared.
+ either the names of 2 values on the x-axis or the 2 integers that correspond
+ to the index of the groups of interest, to be compared.
 
-Note: when \code{comparisons} is specified, each pairwise test is computed
-independently and the displayed p-values are \strong{not} adjusted for
-multiple comparisons. For p-values corrected for multiple testing, use
-\code{\link{geom_pwc}()}, or \code{\link{stat_pvalue_manual}()} together with
-\code{\link{compare_means}(..., p.adjust.method = )}.}
+ Note: when \code{comparisons} is specified, each pairwise test is computed
+ independently and the displayed p-values are \strong{not} adjusted for
+ multiple comparisons. For p-values corrected for multiple testing, use
+ \code{\link{geom_pwc}()}, or \code{\link{stat_pvalue_manual}()} together with
+ \code{\link{compare_means}(..., p.adjust.method = )}.}
 
 \item{hide.ns}{logical value. If TRUE, hide ns symbol when displaying
 significance levels.}
@@ -118,7 +118,7 @@ for absolute positioning of the label. If too short they will be recycled.}
 \item{tip.length}{numeric vector with the fraction that the bracket tips go
  down to indicate the precise column. Default is 0.03. Can be of
  same length as the number of comparisons to adjust specifically the tip
- lenth of each comparison. For example tip.length = c(0.01, 0.03).
+ length of each comparison. For example tip.length = c(0.01, 0.03).
 
  If too short they will be recycled.
 

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -113,11 +113,6 @@ decimal point in the correlation coefficient (e.g., \code{"0.73"} vs
 \code{".73"}). Default (NULL) keeps the leading zero; set to \code{FALSE}
 for APA-style reporting.}
 
-\item{p.coef.name}{character. Symbol used for the p-value label. Default is
-\code{"p"}; use \code{"P"} for an uppercase p-value label. For
-\code{output.type = "expression"} this should be a single valid plotmath
-symbol (e.g. \code{"P"}), since it is parsed as an expression.}
-
 \item{p.format.style}{character specifying the p-value formatting style.
 One of "default", "apa", "nejm", "lancet", "ama", "graphpad", "scientific".
 Default is "default" for backward compatibility.}
@@ -127,6 +122,11 @@ point (e.g., "0.05" vs ".05"). If NULL, uses the style's default setting.}
 
 \item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
 uses \code{getOption("OutDec")}.}
+
+\item{p.coef.name}{character. Symbol used for the p-value label. Default is
+\code{"p"}; use \code{"P"} for an uppercase p-value label. For
+\code{output.type = "expression"} this should be a single valid plotmath
+symbol (e.g. \code{"P"}), since it is parsed as an expression.}
 
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
@@ -183,7 +183,7 @@ Add correlation coefficients with p-values to a scatter plot. Can
  \item{rr}{correlation coefficient squared} \item{r.label}{formatted label
  for the correlation coefficient} \item{rr.label}{formatted label for the
  squared correlation coefficient} \item{p.label}{label for the p-value}
- \item{label}{default labeldisplayed by \code{stat_cor()}} }
+ \item{label}{default label displayed by \code{stat_cor()}} }
 }
 
 \examples{
@@ -230,13 +230,13 @@ sp + stat_cor(aes(color = cyl), label.x = 3)
 }
 \references{
 \code{stat_cor()}'s label-positioning logic was adapted from
-\code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
-Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
-see \code{ggpmisc::stat_correlation()}.
+ \code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
+ Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
+ see \code{ggpmisc::stat_correlation()}.
 }
 \seealso{
 \code{\link{ggscatter}}. For an alternative implementation with more
-control over label positioning (native NPC coordinates, per-group vertical and
-horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
-the label-positioning logic in \code{stat_cor()} was originally adapted.
+ control over label positioning (native NPC coordinates, per-group vertical and
+ horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
+ the label-positioning logic in \code{stat_cor()} was originally adapted.
 }

--- a/man/stat_friedman_test.Rd
+++ b/man/stat_friedman_test.Rd
@@ -176,7 +176,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add automatically Friedman test p-values to a ggplot, such as
- box blots, dot plots and stripcharts.
+box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_friedman_test.Rd
+++ b/man/stat_friedman_test.Rd
@@ -92,7 +92,7 @@ variables. Allowed values include "holm", "hochberg", "hommel",
 "bonferroni", "BH", "BY", "fdr", "none". If you don't want to adjust the p
 value (not recommended), use p.adjust.method = "none".}
 
-\item{significance}{a list of arguments specifying the signifcance cutpoints
+\item{significance}{a list of arguments specifying the significance cutpoints
  and symbols. For example, \code{significance <- list(cutpoints = c(0,
  0.0001, 0.001, 0.01, 0.05, Inf), symbols = c("****", "***", "**", "*",
  "ns"))}.
@@ -186,9 +186,9 @@ Add automatically Friedman test p-values to a ggplot, such as
  \item{p.adj}: Adjusted p-values.
  \item{p.signif}: P-value significance.
  \item{p.adj.signif}: Adjusted p-value significance.
- \item{p.format}: Formated p-value.
- \item{p.format.signif}: Formated p-value with significance symbols.
- \item{p.adj.format}: Formated adjusted p-value.
+ \item{p.format}: Formatted p-value.
+ \item{p.format.signif}: Formatted p-value with significance symbols.
+ \item{p.adj.format}: Formatted adjusted p-value.
  \item{n}: number of samples.
   }
 }

--- a/man/stat_kruskal_test.Rd
+++ b/man/stat_kruskal_test.Rd
@@ -87,7 +87,7 @@ variables. Allowed values include "holm", "hochberg", "hommel",
 "bonferroni", "BH", "BY", "fdr", "none". If you don't want to adjust the p
 value (not recommended), use p.adjust.method = "none".}
 
-\item{significance}{a list of arguments specifying the signifcance cutpoints
+\item{significance}{a list of arguments specifying the significance cutpoints
  and symbols. For example, \code{significance <- list(cutpoints = c(0,
  0.0001, 0.001, 0.01, 0.05, Inf), symbols = c("****", "***", "**", "*",
  "ns"))}.
@@ -180,9 +180,9 @@ Add Kruskal-Wallis test p-values to a ggplot, such as
  \item{p.adj}: Adjusted p-values.
  \item{p.signif}: P-value significance.
  \item{p.adj.signif}: Adjusted p-value significance.
- \item{p.format}: Formated p-value.
- \item{p.format.signif}: Formated p-value with significance symbols.
- \item{p.adj.format}: Formated adjusted p-value.
+ \item{p.format}: Formatted p-value.
+ \item{p.format.signif}: Formatted p-value with significance symbols.
+ \item{p.adj.format}: Formatted adjusted p-value.
  \item{n}: number of samples.
   }
 }

--- a/man/stat_kruskal_test.Rd
+++ b/man/stat_kruskal_test.Rd
@@ -171,7 +171,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add Kruskal-Wallis test p-values to a ggplot, such as
- box blots, dot plots and stripcharts.
+box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -32,7 +32,7 @@ stat_pvalue_manual(
 )
 }
 \arguments{
-\item{data}{a data frame containing statitistical test results. The expected
+\item{data}{a data frame containing statistical test results. The expected
 default format should contain the following columns: \code{group1 | group2 |
 p | y.position | etc}. \code{group1} and \code{group2} are the groups that
 have been compared. \code{p} is the resulting p-value. \code{y.position} is

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/stat_pvalue_manual.R
 \name{stat_pvalue_manual}
 \alias{stat_pvalue_manual}
-\title{Add Manually P-values to a ggplot}
+\title{Add P-values Manually to a ggplot}
 \usage{
 stat_pvalue_manual(
   data,
@@ -126,16 +126,16 @@ its own data with different column names than the parent plot data, so
 \code{geom_text()}}
 }
 \description{
-Add manually p-values to a ggplot, such as box blots, dot plots
+Add p-values manually to a ggplot, such as box plots, dot plots
  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
  \itemize{
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPLOTS}
+ \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPlots}
  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-adjusted-p-values-to-a-multi-panel-ggplot/}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPLOT Facets}
- \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPLOT}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPLOT using the GGPUBR R Package}
+ \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
+ \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPlot}
+ \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
  \item \href{https://www.datanovia.com/en/blog/how-to-create-stacked-bar-plots-with-error-bars-and-p-values/}{How to Create Stacked Bar Plots with Error Bars and P-values}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPLOTS}
+ \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPlots}
  }
 }
 \examples{
@@ -160,7 +160,7 @@ stat.test <- compare_means(
 )
 stat.test
 
-# Add manually p-values from stat.test data
+# Add p-values manually from stat.test data
 # First specify the y.position of each comparison
 stat.test <- stat.test \%>\%
   mutate(y.position = c(29, 35, 39))

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -193,9 +193,9 @@ ggpar(p, palette = "jco")
 }
 \references{
 \code{stat_regline_equation()} was adapted from the source code of
-\code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
-maintained version of this statistic, with additional features and bug fixes, see
-\code{ggpmisc::stat_poly_eq()}.
+ \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
+ maintained version of this statistic, with additional features and bug fixes, see
+ \code{ggpmisc::stat_poly_eq()}.
 }
 \seealso{
 \code{\link{ggscatter}}

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/stat_regline_equation.R
 \name{stat_regline_equation}
 \alias{stat_regline_equation}
-\title{Add Regression Line Equation and R-Square to a GGPLOT.}
+\title{Add Regression Line Equation and R-Square to a GGPlot.}
 \usage{
 stat_regline_equation(
   mapping = NULL,

--- a/man/stat_welch_anova_test.Rd
+++ b/man/stat_welch_anova_test.Rd
@@ -171,7 +171,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add Welch one-way ANOVA test p-values to a ggplot, such as
- box blots, dot plots and stripcharts.
+box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_welch_anova_test.Rd
+++ b/man/stat_welch_anova_test.Rd
@@ -87,7 +87,7 @@ variables. Allowed values include "holm", "hochberg", "hommel",
 "bonferroni", "BH", "BY", "fdr", "none". If you don't want to adjust the p
 value (not recommended), use p.adjust.method = "none".}
 
-\item{significance}{a list of arguments specifying the signifcance cutpoints
+\item{significance}{a list of arguments specifying the significance cutpoints
  and symbols. For example, \code{significance <- list(cutpoints = c(0,
  0.0001, 0.001, 0.01, 0.05, Inf), symbols = c("****", "***", "**", "*",
  "ns"))}.
@@ -182,9 +182,9 @@ Add Welch one-way ANOVA test p-values to a ggplot, such as
  \item{p.adj}: Adjusted p-values.
  \item{p.signif}: P-value significance.
  \item{p.adj.signif}: Adjusted p-value significance.
- \item{p.format}: Formated p-value.
- \item{p.format.signif}: Formated p-value with significance symbols.
- \item{p.adj.format}: Formated adjusted p-value.
+ \item{p.format}: Formatted p-value.
+ \item{p.format.signif}: Formatted p-value with significance symbols.
+ \item{p.adj.format}: Formatted adjusted p-value.
  \item{n}: number of samples.
   }
 }

--- a/man/theme_pubr.Rd
+++ b/man/theme_pubr.Rd
@@ -64,12 +64,12 @@ axis.}
 }
 \details{
 \code{theme_pubr()} sets \code{strip.clip = "off"} so that the facet
-strip background border is drawn at its full width (with the ggplot2 default
-\code{strip.clip = "on"} the border is clipped to the strip area and renders
-thinner than requested). As a side effect, a facet label that is wider than
-its panel will overflow the strip instead of being truncated; if that is a
-problem for very long labels, restore clipping with
-\code{+ theme(strip.clip = "on")}.
+ strip background border is drawn at its full width (with the ggplot2 default
+ \code{strip.clip = "on"} the border is clipped to the strip area and renders
+ thinner than requested). As a side effect, a facet label that is wider than
+ its panel will overflow the strip instead of being truncated; if that is a
+ problem for very long labels, restore clipping with
+ \code{+ theme(strip.clip = "on")}.
 }
 \examples{
 p <- ggplot(mtcars, aes(x = wt, y = mpg)) +

--- a/man/theme_pubr.Rd
+++ b/man/theme_pubr.Rd
@@ -59,7 +59,7 @@ axis.}
  plot labels to a publication ready style \item \strong{theme_classic2()}:
  Create a classic theme with axis lines. \item \strong{clean_theme()}: Remove
  axis lines, ticks, texts and titles. \item \strong{clean_table_theme()}:
- Clean the the theme of a table, such as those created by
+ Clean the theme of a table, such as those created by
  \code{\link{ggsummarytable}()}}.
 }
 \details{

--- a/tests/testthat/test-geom-exec-linewidth.R
+++ b/tests/testthat/test-geom-exec-linewidth.R
@@ -9,3 +9,13 @@ test_that("geom_exec keeps size for non-linewidth geoms", {
   layer <- geom_exec(ggplot2::geom_point, data = df, x = "x", y = "y", size = 2)
   expect_equal(layer[["aes_params"]][["size"]], 2)
 })
+
+test_that("geom_exec converts size to linewidth when linewidth is passed as NULL", {
+  df <- data.frame(x = 1, y = 1)
+  layer <- geom_exec(ggplot2::geom_col,
+    data = df, x = "x", y = "y",
+    size = 0.6, linewidth = NULL
+  )
+  expect_equal(layer[["aes_params"]][["linewidth"]], 0.6)
+  expect_null(layer[["aes_params"]][["size"]])
+})

--- a/tests/testthat/test-ggscatterhist.R
+++ b/tests/testthat/test-ggscatterhist.R
@@ -54,6 +54,20 @@ test_that("ggscatterhist default still renders and margins align (#220/#420)", {
   expect_no_error(print(res))
 })
 
+test_that("ggscatterhist old-cowplot warning does not append the call flag", {
+  local_mocked_bindings(has_cowplot_v0.9 = function() FALSE)
+  warning_message <- NULL
+  withCallingHandlers(
+    res <- ggscatterhist(iris, x = "Sepal.Length", y = "Sepal.Width", print = FALSE),
+    warning = function(w) {
+      warning_message <<- conditionMessage(w)
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_s3_class(res, "ggscatterhist")
+  expect_match(warning_message, "features of ggscatterhist$")
+})
+
 test_that("ggscatterhist does NOT force a transformed (log) scatter range onto the raw-data margin (#220/#420)", {
   # A log-scaled scatter axis lives in different units than the raw-data margin.
   # The margin must stay in linear data units (visible), NOT be forced to the


### PR DESCRIPTION
Hi, you did an amazing job in the last couple of days. I wanted to make a tiny polishing contribution. Please check.

Cheers,
Laszlo

## Summary
- Refresh package documentation, examples, NEWS entries, README text, and manual pages for spelling, grammar, link, and wording correctness.
- Complete ggplot2 linewidth handling for line-based geoms while preserving user-supplied point sizes and mapped segment widths.
- Clarify inherited positioning and width docs, fix warning-call behavior, and add regression coverage for linewidth and warning edge cases.

## Validation
- R CMD build: passed
- R CMD check --no-manual: passed
- R CMD check --as-cran --no-manual: 0 errors, 0 warnings, 1 NOTE (Date field is over a month old)
- testthat: 269 test blocks, 0 failures
- Examples: passed in the package check
- Targeted probes for ggdotchart mapped linewidth, gghistogram density linewidth, ggmaplot point size, and geom_exec linewidth fallback passed