### PR TITLE
ggarrange(): add a spacing argument to control the gap between plots (#151)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,11 @@
 
 ## New features
 
+- `ggarrange()` gains a `spacing` argument to increase the gap between the
+  arranged plots (a long-requested option). It adds a uniform margin, in
+  text-line units, around each plot. Default is `0` (no extra space; each plot
+  keeps its own margins, so existing arrangements are unchanged) (#151).
+
 - `ggbarplot()` gains a `numeric.x.axis` argument (already available in
   `ggline()` and `ggerrorplot()`). With `numeric.x.axis = TRUE` the x variable
   is kept numeric instead of being coerced to a discrete factor, so bars are

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -41,6 +41,12 @@ NULL
 #' @param legend.grob a legend grob as returned by the function
 #'   \code{\link{get_legend}()}. If provided, it will be used as the common
 #'   legend.
+#' @param spacing numeric value giving the margin, in text-line units, set
+#'   uniformly around each plot to increase the gap between the arranged plots.
+#'   Default is 0, which leaves each plot's own margins untouched (existing
+#'   arrangements are unchanged). A positive value sets a uniform margin of that
+#'   many lines around every plot, replacing the plots' default margin; e.g.
+#'   \code{spacing = 1} puts a one-line margin around each plot.
 #' @return an object of class \code{ggarrange}, which is a ggplot or a
 #'   list of ggplots.
 #' @author Laszlo Erdey \email{erdey.laszlo@@econ.unideb.hu}
@@ -77,7 +83,8 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
                       font.label = list(size = 14, color = "black", face = "bold", family = NULL),
                       align = c("none", "h", "v", "hv"),
                       widths = 1, heights = 1, byrow = TRUE,
-                      legend = NULL, common.legend = FALSE, legend.grob = NULL) {
+                      legend = NULL, common.legend = FALSE, legend.grob = NULL,
+                      spacing = 0) {
   # Open null device to avoid blank page before plot------
   # see cowplot:::as_grob.ggplot
   null_device <- base::getOption("ggpubr.null_device", default = cowplot::pdf_null_device)
@@ -92,6 +99,7 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
 
 
   plots <- c(list(...), plotlist)
+  plots <- .add_plot_spacing(plots, spacing)
   align <- match.arg(align)
   nb.plots <- length(plots)
   page.layout <- .get_layout(ncol, nrow, nb.plots)
@@ -182,6 +190,26 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   }
 }
 
+
+# Increase the space between arranged plots by adding a uniform margin (in
+# text-line units) around each ggplot. spacing = 0 (default) leaves the plots
+# untouched, so the arrangement is unchanged (#151). Non-ggplot entries (NULL
+# spacers, grobs) are returned as-is.
+.add_plot_spacing <- function(plots, spacing = 0) {
+  if (is.null(spacing)) {
+    return(plots)
+  }
+  if (!is.numeric(spacing) || anyNA(spacing)) {
+    stop("`spacing` must be a single non-missing numeric value.", call. = FALSE)
+  }
+  if (all(spacing == 0)) {
+    return(plots)
+  }
+  margin <- grid::unit(rep(spacing[1], 4), "lines")
+  purrr::map(plots, function(x) {
+    if (inherits(x, "ggplot")) x + ggplot2::theme(plot.margin = margin) else x
+  })
+}
 
 .plot_grid <- function(plotlist, legend = "top", common.legend.grob = NULL, ...) {
   res <- cowplot::plot_grid(plotlist = plotlist, ...)

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -21,7 +21,8 @@ ggarrange(
   byrow = TRUE,
   legend = NULL,
   common.legend = FALSE,
-  legend.grob = NULL
+  legend.grob = NULL,
+  spacing = 0
 )
 }
 \arguments{
@@ -82,6 +83,13 @@ unique legend will be created for arranged plots.}
 \item{legend.grob}{a legend grob as returned by the function
 \code{\link{get_legend}()}. If provided, it will be used as the common
 legend.}
+
+\item{spacing}{numeric value giving the margin, in text-line units, set
+uniformly around each plot to increase the gap between the arranged plots.
+Default is 0, which leaves each plot's own margins untouched (existing
+arrangements are unchanged). A positive value sets a uniform margin of that
+many lines around every plot, replacing the plots' default margin; e.g.
+\code{spacing = 1} puts a one-line margin around each plot.}
 }
 \value{
 an object of class \code{ggarrange}, which is a ggplot or a

--- a/tests/testthat/test-ggarrange-spacing.R
+++ b/tests/testthat/test-ggarrange-spacing.R
@@ -1,0 +1,44 @@
+context("test-ggarrange-spacing")
+
+.p1 <- ggscatter(mtcars, "wt", "mpg")
+.p2 <- ggboxplot(ToothGrowth, "dose", "len")
+
+test_that("spacing = 0 (default) leaves the plots untouched (#151 no-regression)", {
+  plots <- list(.p1, .p2)
+  expect_identical(ggpubr:::.add_plot_spacing(plots, 0), plots)
+  expect_identical(ggpubr:::.add_plot_spacing(plots, spacing = 0), plots)
+  # NULL spacing also a no-op
+  expect_identical(ggpubr:::.add_plot_spacing(plots, NULL), plots)
+})
+
+test_that("spacing > 0 adds a uniform plot.margin (in lines) to each ggplot (#151)", {
+  out <- ggpubr:::.add_plot_spacing(list(.p1, .p2), spacing = 1)
+  m1 <- out[[1]]$theme$plot.margin
+  expect_true(inherits(m1, "unit"))
+  expect_equal(as.numeric(m1), rep(1, 4))
+  expect_true(all(grid::unitType(m1) == "lines"))
+  # both plots get it
+  expect_equal(as.numeric(out[[2]]$theme$plot.margin), rep(1, 4))
+})
+
+test_that("spacing passes non-ggplot entries (NULL spacers) through unchanged (#151)", {
+  plots <- list(.p1, NULL, .p2)
+  out <- ggpubr:::.add_plot_spacing(plots, spacing = 2)
+  expect_null(out[[2]])
+  expect_equal(as.numeric(out[[1]]$theme$plot.margin), rep(2, 4))
+})
+
+test_that("ggarrange gains a spacing argument that renders (#151)", {
+  expect_error(ggarrange(.p1, .p2, ncol = 2, spacing = 2), NA)
+  # default call still works and returns a ggarrange object
+  g <- ggarrange(.p1, .p2, ncol = 2)
+  expect_s3_class(g, "ggarrange")
+  g2 <- ggarrange(.p1, .p2, ncol = 2, spacing = 1.5)
+  expect_s3_class(g2, "ggarrange")
+})
+
+test_that("spacing rejects non-numeric / NA input cleanly (#151)", {
+  expect_error(ggpubr:::.add_plot_spacing(list(.p1), spacing = "a"), "numeric")
+  expect_error(ggpubr:::.add_plot_spacing(list(.p1), spacing = NA), "numeric|non-missing")
+  expect_error(ggarrange(.p1, .p2, spacing = "big"), "numeric")
+})


### PR DESCRIPTION
Adds a `spacing` argument to `ggarrange()` so users can widen the gap between the arranged plots without editing each plot's theme.

- `spacing = 0` (default) leaves every plot untouched — existing arrangements render exactly as before.
- A positive value sets a uniform margin (in text-line units) around each plot, e.g. `spacing = 1` puts a one-line margin around each plot.

Non-ggplot entries (NULL spacers, raw grobs) pass through unchanged. Invalid input (non-numeric or `NA`) raises a clear error.

Includes tests and a NEWS entry. Closes #151.
