### PR TITLE
ggtheme = NULL now skips applying a ggpubr theme (#561)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,13 @@
 
 ## New features
 
+- Passing `ggtheme = NULL` to the plotting functions (e.g. `ggscatter()`,
+  `ggboxplot()`, `ggline()`, `gghistogram()`, ...) now skips applying a ggpubr
+  theme, so the plot keeps ggplot2's default theme or the theme set globally with
+  `theme_set()`. Previously an explicit `ggtheme = NULL` was treated like an unset
+  argument and `theme_pubr()` was still applied. Calls that omit `ggtheme` or pass
+  a specific theme are unchanged (#561).
+
 - `ggarrange()` gains a `spacing` argument to increase the gap between the
   arranged plots (a long-requested option). It adds a uniform margin, in
   text-line units, around each plot. Default is `0` (no extra space; each plot

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -236,6 +236,10 @@ ggbarplot <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -61,7 +61,7 @@ NULL
 #' @param position position adjustment, either as a string, or the result of a
 #'  call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 #'  Used to control the spacing between grouped elements.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr().
+#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 #'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'  theme_minimal(), theme_classic(), theme_void(), ....
 #' @param ... other arguments to be passed to
@@ -206,6 +206,10 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggdensity.R
+++ b/R/ggdensity.R
@@ -119,6 +119,10 @@ ggdensity <- function(data, x, y = "density", combine = FALSE, merge = FALSE,
   }
   if (missing(y)) .opts$y <- y
   if (missing(add.params)) .opts$add.params <- add.params
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggdotchart.R
+++ b/R/ggdotchart.R
@@ -128,6 +128,11 @@ ggdotchart <- function(data, x, y, group = NULL,
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
 
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
+
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggdotplot.R
+++ b/R/ggdotplot.R
@@ -115,6 +115,10 @@ ggdotplot <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggecdf.R
+++ b/R/ggecdf.R
@@ -75,6 +75,10 @@ ggecdf <- function(data, x, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggerrorplot.R
+++ b/R/ggerrorplot.R
@@ -129,6 +129,10 @@ ggerrorplot <- function(data, x, y, desc_stat = "mean_se",
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/gghistogram.R
+++ b/R/gghistogram.R
@@ -128,6 +128,10 @@ gghistogram <- function(data, x, y = "count", combine = FALSE, merge = FALSE,
   }
   if (missing(y)) .opts$y <- y
   if (missing(add.params)) .opts$add.params <- add.params
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggline.R
+++ b/R/ggline.R
@@ -203,6 +203,10 @@ ggline <- function(data, x, y, group = 1,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggpaired.R
+++ b/R/ggpaired.R
@@ -102,6 +102,10 @@ ggpaired <- function(data, cond1, cond2, x = NULL, y = NULL, id = NULL,
   if (missing(ggtheme) & (!is.null(facet.by))) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -67,7 +67,7 @@ NULL
 #'   orientation to horizontal.
 #' @param orientation change the orientation of the plot. Allowed values are one
 #'   of c( "vertical", "horizontal", "reverse"). Partial match is allowed.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr().
+#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 #'   Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'   theme_minimal(), theme_classic(), theme_void(), ....
 #' @param ... not used

--- a/R/ggpubr_args.R
+++ b/R/ggpubr_args.R
@@ -47,7 +47,7 @@
 #'   = FALSE to hide xlab.
 #' @param ylab character vector specifying y axis labels. Use ylab = FALSE to
 #'   hide ylab.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr().
+#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 #'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'  theme_minimal(), theme_classic(), theme_void(), ....
 #' @name ggpubr_args

--- a/R/ggqqplot.R
+++ b/R/ggqqplot.R
@@ -86,6 +86,10 @@ ggqqplot <- function(data, x, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggscatter.R
+++ b/R/ggscatter.R
@@ -216,6 +216,10 @@ ggscatter <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
   if (.is_list(p) & length(p) == 1) p <- p[[1]]
   return(p)

--- a/R/ggstripchart.R
+++ b/R/ggstripchart.R
@@ -152,6 +152,10 @@ ggstripchart <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (missing(ggtheme) & (!is.null(facet.by) | combine)) {
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/R/ggviolin.R
+++ b/R/ggviolin.R
@@ -172,6 +172,11 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
     .opts$ggtheme <- theme_pubr(border = TRUE)
   }
 
+  # Honor an explicit `ggtheme = NULL` (skip theming). The NULL-filter loop above
+  # drops it like an unset argument, so restore any explicitly passed value here,
+  # keeping an explicit NULL intact via single-bracket list assignment (#561).
+  if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
+
   p <- do.call(.plotter, .opts)
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]

--- a/man/ggballoonplot.Rd
+++ b/man/ggballoonplot.Rd
@@ -66,7 +66,7 @@ c(14, "plain").}
 
 \item{rotate.x.text}{logical. If TRUE (default), rotate the x axis text.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -152,7 +152,7 @@ positions (e.g. a time axis) instead of at equally-spaced discrete
 categories. Ignored when \code{order} is set or \code{sort.val != "none"},
 which require a discrete x axis.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -173,7 +173,7 @@ text, making it easier to read.}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggdensity.Rd
+++ b/man/ggdensity.Rd
@@ -125,7 +125,7 @@ text labels or not.}
 \item{label.rectangle}{logical value. If TRUE, add rectangle underneath the
 text, making it easier to read.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggdonutchart.Rd
+++ b/man/ggdonutchart.Rd
@@ -51,7 +51,7 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggdotchart.Rd
+++ b/man/ggdotchart.Rd
@@ -140,7 +140,7 @@ text, making it easier to read.}
 \item{position}{Position adjustment, either as a string, or the result of a
 call to a position adjustment function.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggdotplot.Rd
+++ b/man/ggdotplot.Rd
@@ -137,7 +137,7 @@ text labels or not.}
 \item{label.rectangle}{logical value. If TRUE, add rectangle underneath the
 text, making it easier to read.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggecdf.Rd
+++ b/man/ggecdf.Rd
@@ -71,7 +71,7 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggerrorplot.Rd
+++ b/man/ggerrorplot.Rd
@@ -119,7 +119,7 @@ se, ....}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/gghistogram.Rd
+++ b/man/gghistogram.Rd
@@ -141,7 +141,7 @@ text, making it easier to read.}
 call to a position adjustment function. Allowed values include "identity",
 "stack", "dodge".}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggline.Rd
+++ b/man/ggline.Rd
@@ -166,7 +166,7 @@ text, making it easier to read.}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -103,7 +103,7 @@ hide ylab.}
 \item{line.color}{color of the horizontal threshold lines (the central line
 at 0 and the two fold-change cutoff lines). Default is "black".}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpaired.Rd
+++ b/man/ggpaired.Rd
@@ -113,7 +113,7 @@ text labels or not.}
 \item{label.rectangle}{logical value. If TRUE, add rectangle underneath the
 text, making it easier to read.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpar.Rd
+++ b/man/ggpar.Rd
@@ -141,7 +141,7 @@ orientation to horizontal.}
 \item{orientation}{change the orientation of the plot. Allowed values are one
 of c( "vertical", "horizontal", "reverse"). Partial match is allowed.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpie.Rd
+++ b/man/ggpie.Rd
@@ -51,7 +51,7 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpubr_args.Rd
+++ b/man/ggpubr_args.Rd
@@ -71,7 +71,7 @@ list(size = 14, face = "plain").}
 \item{ylab}{character vector specifying y axis labels. Use ylab = FALSE to
 hide ylab.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 }

--- a/man/ggqqplot.Rd
+++ b/man/ggqqplot.Rd
@@ -85,7 +85,7 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggscatter.Rd
+++ b/man/ggscatter.Rd
@@ -203,7 +203,7 @@ coordinates of the correlation coefficient. Default values are NULL.}
 the default, includes if any aesthetics are mapped. FALSE never includes,
 and TRUE always includes.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -144,7 +144,7 @@ text, making it easier to read.}
 call to a position adjustment function. Used to adjust position for
 multiple groups.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggsummarystats.Rd
+++ b/man/ggsummarystats.Rd
@@ -81,7 +81,7 @@ call to a position adjustment function.}
 \item{angle}{numeric value specifying the rotation angle (in degrees) of the
 summary table text. Default is 0.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggtext.Rd
+++ b/man/ggtext.Rd
@@ -79,7 +79,7 @@ call to a position adjustment function.}
 
 \item{ggp}{a ggplot. If not NULL, points are added to an existing plot.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -187,7 +187,7 @@ text, making it easier to read.}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/tests/testthat/test-ggtheme-null.R
+++ b/tests/testthat/test-ggtheme-null.R
@@ -1,0 +1,55 @@
+context("test-ggtheme-null")
+
+# #561: `ggtheme = NULL` should skip applying a ggpubr theme, so the plot keeps
+# ggplot2's default theme (or the theme set globally with theme_set()). Passing
+# nothing or a real theme must stay byte-identical (no-regression).
+
+# helper: is a *complete* theme attached to the plot?
+.has_complete_theme <- function(p) isTRUE(attr(p$theme, "complete"))
+
+test_that("default (ggtheme unset) still applies theme_pubr (#561 no-regression)", {
+  p <- ggscatter(mtcars, "wt", "mpg")
+  expect_true(.has_complete_theme(p))
+  # theme_pubr panel background is white
+  expect_equal(ggplot2::calc_element("panel.background", p$theme)$fill, "white")
+})
+
+test_that("explicit ggtheme = NULL skips theming across wrappers (#561)", {
+  wrappers <- list(
+    ggscatter(mtcars, "wt", "mpg", ggtheme = NULL),
+    ggboxplot(ToothGrowth, "dose", "len", ggtheme = NULL),
+    ggline(ToothGrowth, "dose", "len", ggtheme = NULL),
+    gghistogram(ToothGrowth, "len", ggtheme = NULL),
+    ggbarplot(ToothGrowth[1:6, ], "supp", "len", ggtheme = NULL)
+  )
+  for (p in wrappers) {
+    # no complete ggpubr theme attached -> ggplot2 default governs at draw time
+    expect_false(.has_complete_theme(p))
+    # and it still renders without error
+    expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+  }
+})
+
+test_that("explicit ggtheme = theme_bw() is honored and unchanged (#561 no-regression)", {
+  p <- ggscatter(mtcars, "wt", "mpg", ggtheme = ggplot2::theme_bw())
+  expect_true(.has_complete_theme(p))
+  # theme_bw has a black axis-less panel border and grey grid; distinguishable
+  # from theme_pubr by the panel.grid.major being drawn (grey), not blank
+  expect_false(inherits(ggplot2::calc_element("panel.grid.major", p$theme), "element_blank"))
+})
+
+test_that("faceted default still gets the bordered theme_pubr (#561 no-regression)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len", facet.by = "supp")
+  expect_true(.has_complete_theme(p))
+  expect_equal(ggplot2::calc_element("panel.background", p$theme)$fill, "white")
+})
+
+test_that("ggtheme = NULL lets a session-global theme govern (#561)", {
+  old <- ggplot2::theme_set(ggplot2::theme_minimal())
+  on.exit(ggplot2::theme_set(old), add = TRUE)
+  # NULL means 'no ggpubr theme' -> the global theme (theme_minimal) is used at
+  # draw time; the plot itself carries no competing complete theme.
+  p <- ggscatter(mtcars, "wt", "mpg", ggtheme = NULL)
+  expect_false(.has_complete_theme(p))
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+})


### PR DESCRIPTION
Passing `ggtheme = NULL` to the plotting functions now skips applying a ggpubr theme, so the plot keeps ggplot2's default theme — or the theme set globally with `theme_set()`. This is the behaviour requested in #561.

Previously an explicit `ggtheme = NULL` was treated the same as *not passing the argument at all*, so `theme_pubr()` was still applied and users could not opt out of the ggpubr theme.

```r
library(ggpubr)

# Default (unchanged) — theme_pubr()
ggscatter(mtcars, "wt", "mpg", color = "cyl")

# Opt out of the ggpubr theme — keeps ggplot2's default theme
ggscatter(mtcars, "wt", "mpg", color = "cyl", ggtheme = NULL)

# Or let a session-global theme govern the plot
theme_set(theme_minimal())
ggscatter(mtcars, "wt", "mpg", color = "cyl", ggtheme = NULL)
```

Calls that omit `ggtheme` or pass a specific theme are unchanged. Includes tests and updated documentation. Closes #561.
