### PR TITLE
geom_pwc(): keep valid comparisons when one explicit pair is untestable (#542)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,10 @@
   subsets were skipped and why (e.g., missing `ref.group` or insufficient levels).
 - Added regression tests for mixed comparable/non-comparable subsets and fully sparse
   subsets.
+- `geom_pwc()` with an explicit list of `comparisons` no longer drops a whole facet/panel
+  when a single requested pair cannot be tested (e.g. a group that is entirely `NA` or has
+  fewer than two observations). The untestable comparison is skipped (with a message) and
+  the remaining valid comparisons are still drawn (#542).
 - `geom_pwc()` now detects an absent `ref.group` in a grouped subset via the
   `rstatix_missing_ref_group` condition class raised by recent `rstatix`
   (walking the parent chain with `rlang::cnd_inherits()`), in addition to

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -414,7 +414,55 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
           stop(e)
         }
         if (!is.grouped.plots) {
-          return(data.frame())
+          # Non-grouped panel: when the user supplies an explicit list of
+          # comparisons, a single untestable pair (e.g. a group that is entirely
+          # NA, or has < 2 observations) makes the batched rstatix call abort the
+          # WHOLE panel, dropping the valid comparisons too (#542). Retry each
+          # requested comparison on its own and keep the ones that succeed, so
+          # only the untestable pair is dropped. This runs ONLY on the error
+          # path, so panels whose batched test succeeds are unaffected.
+          comparisons <- method.args$comparisons
+          if (is.null(comparisons)) {
+            return(data.frame())
+          }
+          run_one_comparison <- function(pair) {
+            args.one <- method.args
+            args.one$comparisons <- list(pair)
+            tryCatch(do.call(method, args.one), error = function(e) NULL)
+          }
+          per.comparison <- lapply(comparisons, run_one_comparison)
+          kept <- !vapply(per.comparison, is.null, logical(1))
+          if (!any(kept)) {
+            return(data.frame())
+          }
+          if (any(!kept)) {
+            skipped.desc <- vapply(
+              comparisons[!kept],
+              function(p) paste(as.character(p), collapse = " vs "),
+              character(1)
+            )
+            message(
+              "geom_pwc(): skipped ", sum(!kept),
+              " untestable comparison(s): ",
+              paste(skipped.desc, collapse = ", ")
+            )
+          }
+          survivors <- per.comparison[kept]
+          combined <- dplyr::bind_rows(survivors)
+          # bind_rows() drops the rstatix attributes/classes that downstream
+          # steps (get_description(), add_x_position(), ...) rely on; restore
+          # them from the first surviving single-comparison result.
+          first.survivor <- survivors[[1]]
+          attr(combined, "args") <- attr(first.survivor, "args")
+          class(combined) <- class(first.survivor)
+          # Each survivor was tested in its OWN rstatix call, so its p.adj is
+          # just its raw p (multiplicity correction over a single value = none).
+          # Drop it so the downstream adjustment re-computes p.adj across the
+          # surviving set, matching what a single test of only those comparisons
+          # would report (otherwise survivors would show under-adjusted p.adj /
+          # p.adj.signif under the default p.adjust.by = "group").
+          combined$p.adj <- NULL
+          return(combined)
         }
 
         # Retry using only grouped subsets with at least two comparison levels.

--- a/tests/testthat/test-geom_pwc.R
+++ b/tests/testthat/test-geom_pwc.R
@@ -386,6 +386,99 @@ test_that("geom_pwc skips grouped subsets missing ref.group and keeps valid ones
   expect_gte(nrow(b$data[[2]]), 1)
 })
 
+# Per-comparison survival with explicit comparisons (#542) ----------------
+test_that("geom_pwc keeps valid explicit comparisons when one pair is untestable (#542)", {
+  set.seed(1)
+  # Group D is entirely NA and B has a single finite value, so the B-D
+  # comparison cannot be tested; A-C and C-E remain valid and must survive.
+  dat <- data.frame(
+    Cond = factor(rep(c("A", "B", "C", "D", "E"), each = 3)),
+    Value = c(runif(3, 10, 12), c(NA, 11, NA), runif(3, 8, 13),
+              c(NA, NA, NA), runif(3, 10, 15))
+  )
+  p <- ggboxplot(dat, x = "Cond", y = "Value") +
+    geom_pwc(
+      method = "t_test",
+      method.args = list(comparisons = list(c(1, 3), c(3, 5), c(2, 4)))
+    )
+  expect_message(
+    b <- ggplot2::ggplot_build(p),
+    "geom_pwc\\(\\): skipped 1 untestable comparison\\(s\\): 2 vs 4"
+  )
+  stat.test <- b$data[[2]]
+  # only the two valid comparisons survive (A-C at x 1-3, C-E at x 3-5)
+  surviving <- unique(stat.test[, c("xmin", "xmax", "p", "p.adj")])
+  expect_equal(nrow(surviving), 2)
+  expect_true(all(paste(surviving$xmin, surviving$xmax) %in% c("1 3", "3 5")))
+  expect_false(any(paste(surviving$xmin, surviving$xmax) == "2 4"))
+
+  # The surviving comparisons must be multiplicity-corrected TOGETHER, exactly as
+  # if only those two comparisons had been requested (not left with the raw,
+  # unadjusted p as p.adj). Otherwise p.adj / p.adj.signif would be wrong (#542).
+  clean <- ggboxplot(dat, x = "Cond", y = "Value") +
+    geom_pwc(
+      method = "t_test",
+      method.args = list(comparisons = list(c(1, 3), c(3, 5)))
+    )
+  clean.test <- suppressMessages(ggplot2::ggplot_build(clean))$data[[2]]
+  key <- function(d) paste(d$xmin, d$xmax)
+  ord.s <- order(key(surviving))
+  ord.c <- order(key(unique(clean.test[, c("xmin", "xmax", "p", "p.adj")])))
+  clean.u <- unique(clean.test[, c("xmin", "xmax", "p", "p.adj")])
+  expect_equal(surviving$p[ord.s], clean.u$p[ord.c])
+  expect_equal(surviving$p.adj[ord.s], clean.u$p.adj[ord.c])
+})
+
+test_that("geom_pwc drops only the untestable pair per facet, keeping valid ones (#542 faceted)", {
+  set.seed(1)
+  # Reporter's scenario: two facets; in Sample2 group D is all-NA and B has a
+  # single value, so B-D is untestable there but A-C / C-E are valid. Sample1 is
+  # fully testable. Each facet must keep its own valid comparisons.
+  dataset <- data.frame(
+    Sample = rep(c("Sample1", "Sample2"), each = 15),
+    Cond = factor(rep(rep(c("A", "B", "C", "D", "E"), each = 3), 2)),
+    Value = c(runif(3, 10, 12), runif(3, 11, 14), runif(3, 8, 13),
+              runif(3, 7, 10), runif(3, 10, 15),
+              runif(3, 10, 12), c(NA, 11, NA), runif(3, 8, 13),
+              c(NA, NA, NA), runif(3, 10, 15))
+  )
+  p <- ggplot2::ggplot(dataset, ggplot2::aes(Cond, Value)) +
+    ggplot2::geom_jitter(width = 0.2) +
+    ggplot2::facet_wrap(~Sample) +
+    geom_pwc(
+      method = "t_test",
+      method.args = list(comparisons = list(c(1, 3), c(3, 5), c(2, 4)))
+    )
+  expect_message(
+    b <- ggplot2::ggplot_build(p),
+    "geom_pwc\\(\\): skipped 1 untestable comparison\\(s\\): 2 vs 4"
+  )
+  stat.test <- b$data[[2]]
+  by.panel <- split(stat.test, stat.test$PANEL)
+  pair.set <- function(d) sort(unique(paste(d$xmin, d$xmax)))
+  # Sample1 (PANEL 1): all three comparisons; Sample2 (PANEL 2): 2 vs 4 dropped.
+  expect_equal(pair.set(by.panel[["1"]]), c("1 3", "2 4", "3 5"))
+  expect_equal(pair.set(by.panel[["2"]]), c("1 3", "3 5"))
+})
+
+test_that("geom_pwc explicit comparisons are unchanged when all pairs are testable (#542 no-regression)", {
+  # Same call but on data with no untestable pair: no skip message, and all
+  # three requested comparisons are drawn (byte-identical to previous behavior).
+  df2 <- ToothGrowth
+  df2$dose <- as.factor(df2$dose)
+  p <- ggboxplot(df2, x = "dose", y = "len") +
+    geom_pwc(
+      method = "t_test",
+      method.args = list(comparisons = list(c(1, 2), c(2, 3), c(1, 3)))
+    )
+  expect_no_message(
+    b <- ggplot2::ggplot_build(p),
+    message = "geom_pwc\\(\\): skipped"
+  )
+  stat.test <- b$data[[2]]
+  expect_equal(nrow(unique(stat.test[, c("xmin", "xmax")])), 3)
+})
+
 # All-NA group placement (#575) -----------------------------------
 test_that("geom_pwc places brackets over the correct groups when a group is all-NA (#575)", {
   # Group "a" is entirely NA; its rows are dropped before the stat runs, so the


### PR DESCRIPTION
When `geom_pwc()` is given an explicit list of `comparisons`, a single pair that cannot be tested — for example a group that is entirely `NA`, or has fewer than two observations — used to abort the whole facet/panel, so the valid comparisons in that panel were dropped too (#542).

Now, only the untestable comparison is skipped (with an informative message) and the remaining valid comparisons are still drawn.

```r
library(ggpubr)
set.seed(1)
dataset <- tibble::tibble(
  Sample = rep(c("Sample1", "Sample2"), each = 15),
  Cond   = rep(rep(c("A", "B", "C", "D", "E"), each = 3), 2),
  Value  = c(runif(3, 10, 12), runif(3, 11, 14), runif(3, 8, 13), runif(3, 7, 10), runif(3, 10, 15),
             runif(3, 10, 12), c(NA, 11, NA), runif(3, 8, 13), c(NA, NA, NA), runif(3, 10, 15))
)

ggplot(dataset, aes(Cond, Value)) +
  geom_jitter(aes(colour = Cond), width = 0.2, alpha = 0.4) +
  facet_wrap(~Sample) +
  geom_pwc(method = "t_test",
           method.args = list(comparisons = list(c(1, 3), c(3, 5), c(2, 4))))
#> In Sample2, group D is all-NA so the B-D comparison can't be tested; A-C and
#> C-E are still drawn (previously the whole Sample2 panel lost its brackets).
```

Only the error path changes: panels whose test succeeds are unaffected, so existing output is unchanged. Includes a regression test and a no-regression test. Closes #542.
