### PR TITLE
stat_pvalue_manual(): add p.digits to format numeric p-value labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,13 @@
   - `p.min.threshold`
   - `p.decimal.mark`
 - Added `p.format.signif` support and related label handling paths.
+- `stat_pvalue_manual()` gains a `p.digits` argument (default `3`) that formats
+  **numeric** p-value label columns for display (e.g. `label = "p"` or
+  `label = "p.adj"`), using the same `format_p_value()` engine as
+  `stat_anova_test()`. This restores clean labels (e.g. `0.0156` instead of
+  `0.015625`) with rstatix `>= 1.0.0`, which now returns full-precision pairwise
+  p-values. Character labels (significance symbols, pre-formatted strings, glue
+  expressions) are unaffected. Set `p.digits = NULL` to print the raw value.
 - `stat_cor()` gains two label-formatting arguments:
   - `r.leading.zero` — set to `FALSE` to drop the leading zero of the
     correlation coefficient (e.g. `.73` instead of `0.73`), completing

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -44,8 +44,9 @@ NULL
 #'  raw value without rounding. All other labels are left unchanged: other
 #'  numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
 #'  significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
-#'  already-formatted strings, and \code{\link[glue]{glue}} expressions. Uses the
-#'  same formatting engine (\code{\link{format_p_value}()}) as
+#'  already-formatted strings, and \code{\link[glue]{glue}} expressions. A
+#'  p-named column whose values fall outside \code{[0, 1]} is also left as-is.
+#'  Uses the same formatting engine (\code{\link{format_p_value}()}) as
 #'  \code{\link{stat_anova_test}()} for consistency across layers.
 #' @param bracket.size Width of the lines of the bracket.
 #' @param color text and line color. Can be variable name in the data for coloring by groups.
@@ -211,13 +212,18 @@ stat_pvalue_manual <- function(
   # Round recognized numeric p-value label columns for display (e.g.
   # label = "p"/"p.adj"). Restricted to known p-value column names so that other
   # numeric label columns (e.g. "statistic", "n", effect sizes, fold changes) are
-  # left untouched -- format_p_value() only accepts values in [0, 1]. Character
+  # left untouched. The extra range check leaves the column as-is unless the
+  # values actually look like probabilities in [0, 1] -- format_p_value() rejects
+  # out-of-range values (NA + warning), so a numeric column merely *named* like a
+  # p-value but holding other quantities passes through unchanged. Character
   # labels (significance symbols, pre-formatted strings, glue output) also pass
   # through unchanged. Opt out with p.digits = NULL.
   .p_value_label_columns <- c("p", "p.adj", "p.value", "p.val", "pval", "padj")
+  .label_values <- data[[label]]
   if (!is.null(p.digits) && label %in% .p_value_label_columns &&
-      is.numeric(data[[label]])) {
-    data[[label]] <- format_p_value(data[[label]], digits = p.digits)
+      is.numeric(.label_values) &&
+      all(.label_values >= 0 & .label_values <= 1, na.rm = TRUE)) {
+    data[[label]] <- format_p_value(.label_values, digits = p.digits)
   }
 
   y.position <- .valide_y_position(y.position, data)

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -37,6 +37,16 @@ NULL
 #' @param x x position of the p-value. Should be used only when you want plot the
 #'  p-value as text (without brackets).
 #' @param size,label.size size of label text.
+#' @param p.digits integer indicating the number of significant digits used to
+#'  format recognized \strong{numeric} p-value label columns (\code{label} is one
+#'  of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
+#'  \code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
+#'  raw value without rounding. All other labels are left unchanged: other
+#'  numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
+#'  significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
+#'  already-formatted strings, and \code{\link[glue]{glue}} expressions. Uses the
+#'  same formatting engine (\code{\link{format_p_value}()}) as
+#'  \code{\link{stat_anova_test}()} for consistency across layers.
 #' @param bracket.size Width of the lines of the bracket.
 #' @param color text and line color. Can be variable name in the data for coloring by groups.
 #' @param linetype linetype. Can be variable name in the data for changing linetype by groups.
@@ -135,7 +145,7 @@ NULL
 stat_pvalue_manual <- function(
   data, label = NULL, y.position = "y.position",
   xmin = "group1", xmax = "group2", x = NULL,
-  size = 3.88, label.size = size, bracket.size = 0.3,
+  size = 3.88, label.size = size, p.digits = 3, bracket.size = 0.3,
   bracket.nudge.y = 0, bracket.shorten = 0,
   color = "black", linetype = 1, tip.length = 0.03,
   tip.length.ref = c("data", "axis"),
@@ -196,6 +206,18 @@ stat_pvalue_manual <- function(
   }
   if (!(xmin %in% available.variables)) {
     stop("can't find the xmin variable '", xmin, "' in the data")
+  }
+
+  # Round recognized numeric p-value label columns for display (e.g.
+  # label = "p"/"p.adj"). Restricted to known p-value column names so that other
+  # numeric label columns (e.g. "statistic", "n", effect sizes, fold changes) are
+  # left untouched -- format_p_value() only accepts values in [0, 1]. Character
+  # labels (significance symbols, pre-formatted strings, glue output) also pass
+  # through unchanged. Opt out with p.digits = NULL.
+  .p_value_label_columns <- c("p", "p.adj", "p.value", "p.val", "pval", "padj")
+  if (!is.null(p.digits) && label %in% .p_value_label_columns &&
+      is.numeric(data[[label]])) {
+    data[[label]] <- format_p_value(data[[label]], digits = p.digits)
   }
 
   y.position <- .valide_y_position(y.position, data)

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -68,7 +68,8 @@ of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"}, \code{"pval"},
 rounding. All other labels are left unchanged: other numeric columns (e.g.
 \code{"statistic"}, \code{"n"}, effect sizes), significance symbols
 (\code{"p.signif"}, \code{"p.adj.signif"}), already-formatted strings, and
-\code{\link[glue]{glue}} expressions. Uses the same formatting engine
+\code{\link[glue]{glue}} expressions. A p-named column whose values fall outside
+\code{[0, 1]} is also left as-is. Uses the same formatting engine
 (\code{\link{format_p_value}()}) as \code{\link{stat_anova_test}()} for
 consistency across layers.}
 

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -13,6 +13,7 @@ stat_pvalue_manual(
   x = NULL,
   size = 3.88,
   label.size = size,
+  p.digits = 3,
   bracket.size = 0.3,
   bracket.nudge.y = 0,
   bracket.shorten = 0,
@@ -59,6 +60,17 @@ as a simple text.}
 p-value as text (without brackets).}
 
 \item{size, label.size}{size of label text.}
+
+\item{p.digits}{integer indicating the number of significant digits used to
+format recognized \strong{numeric} p-value label columns (\code{label} is one
+of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"}, \code{"pval"},
+\code{"padj"}). Default is 3. Set to \code{NULL} to print the raw value without
+rounding. All other labels are left unchanged: other numeric columns (e.g.
+\code{"statistic"}, \code{"n"}, effect sizes), significance symbols
+(\code{"p.signif"}, \code{"p.adj.signif"}), already-formatted strings, and
+\code{\link[glue]{glue}} expressions. Uses the same formatting engine
+(\code{\link{format_p_value}()}) as \code{\link{stat_anova_test}()} for
+consistency across layers.}
 
 \item{bracket.size}{Width of the lines of the bracket.}
 

--- a/tests/testthat/test-stat-pvalue-manual-pdigits.R
+++ b/tests/testthat/test-stat-pvalue-manual-pdigits.R
@@ -1,0 +1,114 @@
+context("test-stat-pvalue-manual-pdigits")
+
+# p.digits formats numeric p-value label columns for display (restores clean
+# labels with rstatix >= 1.0.0 full-precision pairwise p-values), while leaving
+# character labels (significance symbols, pre-formatted strings, glue output)
+# unchanged. Opt out with p.digits = NULL.
+
+# Build a stat.test with deterministic p-values covering a mid-range value,
+# a very small value, and a large value.
+.make_stat <- function(p = c(0.015625, 0.0000123, 0.7)) {
+  data.frame(
+    group1 = c("0.5", "0.5", "1"),
+    group2 = c("1", "2", "2"),
+    p = p,
+    p.signif = c("*", "****", "ns"),
+    y.position = c(30, 36, 40),
+    stringsAsFactors = FALSE
+  )
+}
+
+# Extract the plotted label aesthetic (one per comparison, in stat.test row
+# order) from a built ggplot. The bracket layer stores several rows per bracket
+# (the bracket corners), all sharing the same `group` (= stat.test row index),
+# so we keep the first label of each group and order by group.
+.plotted_labels <- function(layer) {
+  p <- ggboxplot(ToothGrowth, x = "dose", y = "len") + layer
+  b <- ggplot2::ggplot_build(p)
+  for (d in b$data) {
+    if (all(c("label", "group") %in% names(d))) {
+      first <- d[!duplicated(d$group), ]
+      first <- first[order(first$group), ]
+      return(as.character(first$label))
+    }
+  }
+  stop("no label aesthetic found in built plot")
+}
+
+test_that("numeric p label is rounded by default (p.digits = 3)", {
+  st <- .make_stat()
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "p")),
+    format_p_value(st$p, digits = 3)
+  )
+  # concrete expectation: 0.015625 -> 0.0156
+  expect_true("0.0156" %in% .plotted_labels(stat_pvalue_manual(st, label = "p")))
+})
+
+test_that("p.digits controls the number of significant digits", {
+  st <- .make_stat(p = c(0.012345, 0.5, 0.9))
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "p", p.digits = 2)),
+    format_p_value(st$p, digits = 2)
+  )
+})
+
+test_that("p.digits = NULL prints the raw numeric value (opt-out)", {
+  st <- .make_stat()
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "p", p.digits = NULL)),
+    as.character(st$p)
+  )
+})
+
+test_that("character significance labels are unaffected by p.digits", {
+  st <- .make_stat()
+  # explicit character column
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "p.signif")),
+    st$p.signif
+  )
+  # default label = NULL resolves to the significance column
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st)),
+    st$p.signif
+  )
+})
+
+test_that("numeric NON-p label columns are left untouched (no NA, no warning)", {
+  # stat_pvalue_manual is generic: the label column need not be a p-value.
+  # Columns outside [0, 1] (statistic, n, effect size, ...) must NOT be routed
+  # through format_p_value(), which would coerce them to NA with a warning.
+  st <- .make_stat()
+  st$statistic <- c(5.3, -2.1, 12.0)
+  st$n <- c(20L, 20L, 20L)
+
+  expect_warning(
+    labs_stat <- .plotted_labels(stat_pvalue_manual(st, label = "statistic")),
+    NA
+  )
+  expect_equal(labs_stat, as.character(st$statistic))
+
+  expect_warning(
+    labs_n <- .plotted_labels(stat_pvalue_manual(st, label = "n")),
+    NA
+  )
+  expect_equal(labs_n, as.character(st$n))
+})
+
+test_that("glue label expressions are unaffected (documented limitation)", {
+  st <- .make_stat()
+  # glue is evaluated on the raw numeric column, so it keeps full precision;
+  # users round inside the expression, e.g. {signif(p, 3)}.
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "{p}")),
+    as.character(st$p)
+  )
+})
+
+test_that("NA p-values do not error and render as NA", {
+  st <- .make_stat(p = c(0.015625, NA, 0.7))
+  labs <- .plotted_labels(stat_pvalue_manual(st, label = "p"))
+  expect_equal(labs[2], NA_character_)
+  expect_equal(labs[c(1, 3)], format_p_value(c(0.015625, 0.7), digits = 3))
+})

--- a/tests/testthat/test-stat-pvalue-manual-pdigits.R
+++ b/tests/testthat/test-stat-pvalue-manual-pdigits.R
@@ -96,6 +96,18 @@ test_that("numeric NON-p label columns are left untouched (no NA, no warning)", 
   expect_equal(labs_n, as.character(st$n))
 })
 
+test_that("a p-named column holding out-of-[0,1] values is left untouched", {
+  # A numeric column merely NAMED like a p-value but holding other quantities
+  # must NOT be routed through format_p_value() (which would return NA + warn).
+  # The range guard leaves the whole column as-is if any value is outside [0, 1].
+  st <- .make_stat(p = c(5.3, 0.2, 0.7))
+  expect_warning(
+    labs <- .plotted_labels(stat_pvalue_manual(st, label = "p")),
+    NA
+  )
+  expect_equal(labs, as.character(st$p))
+})
+
 test_that("glue label expressions are unaffected (documented limitation)", {
   st <- .make_stat()
   # glue is evaluated on the raw numeric column, so it keeps full precision;


### PR DESCRIPTION
Fixes #716.

## Problem
`stat_pvalue_manual()` renders its label column verbatim, so rstatix >= 1.0.0 full-precision pairwise p-values print as e.g. `p = 0.015625` when users pass `label = "p"` / `label = "p.adj"` (common in tutorials). Pre-1.0.0 they saw `p = 0.0156`.

## Change
Add a `p.digits` argument (default `3`) that formats **recognized numeric p-value label columns** (`p`, `p.adj`, `p.value`, `p.val`, `pval`, `padj`) via the existing `format_p_value()` engine — the same one `stat_anova_test()` uses, so the two stat layers format consistently. Opt out with `p.digits = NULL`.

The formatting is gated on recognized p-value **column names**, not bare `is.numeric()`, so other numeric label columns (`statistic`, `n`, effect sizes, fold changes) are left untouched — `format_p_value()` only accepts values in [0, 1]. Character labels (significance symbols, pre-formatted strings, glue output) are unchanged.

### Behavior note
This changes the default rendered label for numeric p-value label columns (restores the pre-1.0.0 clean look and matches `stat_anova_test`, which already rounds by default). `p.digits = NULL` reproduces the previous raw output.

## Verification
- `label = "p"` → `0.0156` (was `0.015625`); `label = NULL` (stars), `label = "statistic"`/`"n"`, glue, and `p.digits = NULL` all byte-identical to before.
- New regression tests in `tests/testthat/test-stat-pvalue-manual-pdigits.R` (numeric-format, non-p numeric columns untouched, stars/opt-out/glue unchanged, NA-safe).
- Clean-session `devtools::test()`: 738 pass / 0 fail.
- `R CMD check --as-cran`: 0 errors / 0 warnings / 2 pre-existing NOTEs.

## Coordination
Companion to rstatix #249 (same pattern as rstatix #153 ↔ ggpubr #669). rstatix #249 (de-rounding the *omnibus* ANOVA p) remains a separate, deferred decision — `stat_anova_test()` already rounds the omnibus p, so it is not blocked by this.