### PR TITLE
docs(stat_pvalue_manual): clarify glue labels are not rounded by p.digits

### DIFF
--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -25,7 +25,11 @@ NULL
 #'  "p.adj"), where \code{p} is the p-value. Can be also an expression that can
 #'  be formatted by the \code{\link[glue]{glue}()} package. For example, when
 #'  specifying label = "t-test, p = \{p\}", the expression \{p\} will be
-#'  replaced by its value.
+#'  replaced by its value. Values inserted through a glue expression are taken
+#'  from the raw data column and are \strong{not} rounded by \code{p.digits}; to
+#'  round within a glue expression, wrap the value, e.g.
+#'  \code{label = "p = \{signif(p, 3)\}"} (or \code{\{format_p_value(p)\}} for the
+#'  p-value house style).
 #' @param y.position column containing the coordinates (in data units) to be used
 #'  for absolute positioning of the label. Default value is "y.position". Can be
 #'  also a numeric vector.

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -43,7 +43,11 @@ the y coordinates of the p-values in the plot.}
 "p.adj"), where \code{p} is the p-value. Can be also an expression that can
 be formatted by the \code{\link[glue]{glue}()} package. For example, when
 specifying label = "t-test, p = \{p\}", the expression \{p\} will be
-replaced by its value.}
+replaced by its value. Values inserted through a glue expression are taken
+from the raw data column and are \strong{not} rounded by \code{p.digits}; to
+round within a glue expression, wrap the value, e.g.
+\code{label = "p = \{signif(p, 3)\}"} (or \code{\{format_p_value(p)\}} for the
+p-value house style).}
 
 \item{y.position}{column containing the coordinates (in data units) to be used
 for absolute positioning of the label. Default value is "y.position". Can be


### PR DESCRIPTION
Refs #716.

## What
Documentation-only clarification for `stat_pvalue_manual()`. The `p.digits` argument (added in #717) rounds recognized numeric p-value label columns such as `label = "p"` / `label = "p.adj"`, but values inserted through a `glue` expression (e.g. `label = "p = {p}"`) are taken from the raw data column and are **not** affected by `p.digits`.

The `@param label` docs now say this explicitly and point to the fix: wrap the value inside the expression, e.g. `label = "p = {signif(p, 3)}"` for simple rounding, or `label = "p = {format_p_value(p)}"` for the p-value house style.

## Notes
- Documentation only — no behavior change; default output is unchanged.
- Touches `R/stat_pvalue_manual.R` (roxygen) and the regenerated `man/stat_pvalue_manual.Rd`.