### PR TITLE
feat(stat_pvalue_manual): add p-value formatting style arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,12 @@
   `0.015625`) with rstatix `>= 1.0.0`, which now returns full-precision pairwise
   p-values. Character labels (significance symbols, pre-formatted strings, glue
   expressions) are unaffected. Set `p.digits = NULL` to print the raw value.
+- `stat_pvalue_manual()` additionally gains `p.format.style`, `p.leading.zero`,
+  `p.min.threshold` and `p.decimal.mark`, matching the p-value formatting
+  arguments already available in `stat_compare_means()`, `geom_pwc()` and
+  `stat_anova_test()`. These are opt-in and default so that the rendered labels
+  are unchanged; for example `p.min.threshold = 0.001` displays very small
+  p-values as `< 0.001`, and `p.format.style = "nejm"` applies a journal style.
 - `stat_cor()` gains two label-formatting arguments:
   - `r.leading.zero` — set to `FALSE` to drop the leading zero of the
     correlation coefficient (e.g. `.73` instead of `0.73`), completing

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -41,17 +41,38 @@ NULL
 #' @param x x position of the p-value. Should be used only when you want plot the
 #'  p-value as text (without brackets).
 #' @param size,label.size size of label text.
-#' @param p.digits integer indicating the number of significant digits used to
+#' @param p.digits integer indicating the number of digits used to
 #'  format recognized \strong{numeric} p-value label columns (\code{label} is one
 #'  of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
 #'  \code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
-#'  raw value without rounding. All other labels are left unchanged: other
+#'  raw value without rounding (this also disables \code{p.format.style} and the
+#'  related formatting arguments). All other labels are left unchanged: other
 #'  numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
 #'  significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
 #'  already-formatted strings, and \code{\link[glue]{glue}} expressions. A
 #'  p-named column whose values fall outside \code{[0, 1]} is also left as-is.
 #'  Uses the same formatting engine (\code{\link{format_p_value}()}) as
-#'  \code{\link{stat_anova_test}()} for consistency across layers.
+#'  \code{\link{stat_anova_test}()} for consistency across layers. The style of
+#'  this formatting is further controlled by \code{p.format.style},
+#'  \code{p.leading.zero}, \code{p.min.threshold} and \code{p.decimal.mark}
+#'  (same arguments as \code{\link{stat_compare_means}()}).
+#' @param p.format.style character string specifying the p-value formatting style
+#'  applied to recognized numeric p-value label columns (see \code{p.digits}).
+#'  One of: \code{"default"} (backward compatible, uses scientific notation),
+#'  \code{"apa"} (APA style, no leading zero), \code{"nejm"} (NEJM style),
+#'  \code{"lancet"} (Lancet style), \code{"ama"} (AMA style), \code{"graphpad"}
+#'  (GraphPad style), or \code{"scientific"} (scientific notation for GWAS). See
+#'  \code{\link{list_p_format_styles}} for details. Default is \code{"default"},
+#'  which leaves the rendered p-value labels unchanged.
+#' @param p.leading.zero logical indicating whether to include the leading zero
+#'  before the decimal point (e.g., "0.05" vs ".05"). If provided, overrides the
+#'  style default.
+#' @param p.min.threshold numeric specifying the minimum p-value to display
+#'  exactly. Values below this threshold are shown as "< threshold" (e.g.
+#'  \code{p.min.threshold = 0.001} renders very small p-values as "< 0.001"). If
+#'  provided, overrides the style default.
+#' @param p.decimal.mark character string to use as the decimal mark. If
+#'  \code{NULL}, uses \code{getOption("OutDec")}.
 #' @param bracket.size Width of the lines of the bracket.
 #' @param color text and line color. Can be variable name in the data for coloring by groups.
 #' @param linetype linetype. Can be variable name in the data for changing linetype by groups.
@@ -150,7 +171,9 @@ NULL
 stat_pvalue_manual <- function(
   data, label = NULL, y.position = "y.position",
   xmin = "group1", xmax = "group2", x = NULL,
-  size = 3.88, label.size = size, p.digits = 3, bracket.size = 0.3,
+  size = 3.88, label.size = size, p.digits = 3,
+  p.format.style = "default", p.leading.zero = NULL,
+  p.min.threshold = NULL, p.decimal.mark = NULL, bracket.size = 0.3,
   bracket.nudge.y = 0, bracket.shorten = 0,
   color = "black", linetype = 1, tip.length = 0.03,
   tip.length.ref = c("data", "axis"),
@@ -227,7 +250,11 @@ stat_pvalue_manual <- function(
   if (!is.null(p.digits) && label %in% .p_value_label_columns &&
       is.numeric(.label_values) &&
       all(.label_values >= 0 & .label_values <= 1, na.rm = TRUE)) {
-    data[[label]] <- format_p_value(.label_values, digits = p.digits)
+    data[[label]] <- format_p_value(
+      .label_values, style = p.format.style, digits = p.digits,
+      leading.zero = p.leading.zero, min.threshold = p.min.threshold,
+      decimal.mark = p.decimal.mark
+    )
   }
 
   y.position <- .valide_y_position(y.position, data)

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -14,6 +14,10 @@ stat_pvalue_manual(
   size = 3.88,
   label.size = size,
   p.digits = 3,
+  p.format.style = "default",
+  p.leading.zero = NULL,
+  p.min.threshold = NULL,
+  p.decimal.mark = NULL,
   bracket.size = 0.3,
   bracket.nudge.y = 0,
   bracket.shorten = 0,
@@ -65,17 +69,42 @@ p-value as text (without brackets).}
 
 \item{size, label.size}{size of label text.}
 
-\item{p.digits}{integer indicating the number of significant digits used to
+\item{p.digits}{integer indicating the number of digits used to
 format recognized \strong{numeric} p-value label columns (\code{label} is one
-of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"}, \code{"pval"},
-\code{"padj"}). Default is 3. Set to \code{NULL} to print the raw value without
-rounding. All other labels are left unchanged: other numeric columns (e.g.
-\code{"statistic"}, \code{"n"}, effect sizes), significance symbols
-(\code{"p.signif"}, \code{"p.adj.signif"}), already-formatted strings, and
-\code{\link[glue]{glue}} expressions. A p-named column whose values fall outside
-\code{[0, 1]} is also left as-is. Uses the same formatting engine
-(\code{\link{format_p_value}()}) as \code{\link{stat_anova_test}()} for
-consistency across layers.}
+of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
+\code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
+raw value without rounding (this also disables \code{p.format.style} and the
+related formatting arguments). All other labels are left unchanged: other
+numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
+significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
+already-formatted strings, and \code{\link[glue]{glue}} expressions. A
+p-named column whose values fall outside \code{[0, 1]} is also left as-is.
+Uses the same formatting engine (\code{\link{format_p_value}()}) as
+\code{\link{stat_anova_test}()} for consistency across layers. The style of
+this formatting is further controlled by \code{p.format.style},
+\code{p.leading.zero}, \code{p.min.threshold} and \code{p.decimal.mark}
+(same arguments as \code{\link{stat_compare_means}()}).}
+
+\item{p.format.style}{character string specifying the p-value formatting style
+applied to recognized numeric p-value label columns (see \code{p.digits}).
+One of: \code{"default"} (backward compatible, uses scientific notation),
+\code{"apa"} (APA style, no leading zero), \code{"nejm"} (NEJM style),
+\code{"lancet"} (Lancet style), \code{"ama"} (AMA style), \code{"graphpad"}
+(GraphPad style), or \code{"scientific"} (scientific notation for GWAS). See
+\code{\link{list_p_format_styles}} for details. Default is \code{"default"},
+which leaves the rendered p-value labels unchanged.}
+
+\item{p.leading.zero}{logical indicating whether to include the leading zero
+before the decimal point (e.g., "0.05" vs ".05"). If provided, overrides the
+style default.}
+
+\item{p.min.threshold}{numeric specifying the minimum p-value to display
+exactly. Values below this threshold are shown as "< threshold" (e.g.
+\code{p.min.threshold = 0.001} renders very small p-values as "< 0.001"). If
+provided, overrides the style default.}
+
+\item{p.decimal.mark}{character string to use as the decimal mark. If
+\code{NULL}, uses \code{getOption("OutDec")}.}
 
 \item{bracket.size}{Width of the lines of the bracket.}
 

--- a/tests/testthat/test-stat-pvalue-manual-pformat.R
+++ b/tests/testthat/test-stat-pvalue-manual-pformat.R
@@ -1,0 +1,129 @@
+context("test-stat-pvalue-manual-pformat")
+
+# stat_pvalue_manual() exposes the same p-value formatting knobs as its sibling
+# bracket layers (stat_compare_means / geom_pwc / stat_anova_test):
+# p.format.style, p.leading.zero, p.min.threshold, p.decimal.mark. All default
+# so that the rendered labels are byte-identical to before (opt-in only).
+
+.make_stat <- function(p = c(0.015625, 0.0000000004, 0.7)) {
+  data.frame(
+    group1 = c("0.5", "0.5", "1"),
+    group2 = c("1", "2", "2"),
+    p = p,
+    y.position = c(30, 36, 40),
+    stringsAsFactors = FALSE
+  )
+}
+
+.plotted_labels <- function(layer) {
+  p <- ggboxplot(ToothGrowth, x = "dose", y = "len") + layer
+  b <- ggplot2::ggplot_build(p)
+  for (d in b$data) {
+    if (all(c("label", "group") %in% names(d))) {
+      first <- d[!duplicated(d$group), ]
+      first <- first[order(first$group), ]
+      return(as.character(first$label))
+    }
+  }
+  stop("no label aesthetic found in built plot")
+}
+
+test_that("defaults leave the rendered p labels byte-identical (opt-in only)", {
+  st <- .make_stat()
+  # The style arguments at their defaults must reproduce the plain
+  # format_p_value(p, digits = 3) output exactly.
+  expect_identical(
+    .plotted_labels(stat_pvalue_manual(st, label = "p")),
+    format_p_value(st$p, digits = 3)
+  )
+  # Explicitly passing the defaults is a no-op vs omitting them.
+  expect_identical(
+    .plotted_labels(stat_pvalue_manual(st, label = "p")),
+    .plotted_labels(stat_pvalue_manual(
+      st, label = "p", p.format.style = "default",
+      p.leading.zero = NULL, p.min.threshold = NULL, p.decimal.mark = NULL
+    ))
+  )
+})
+
+test_that("p.min.threshold renders very small p-values as '< threshold'", {
+  st <- .make_stat()
+  labs <- .plotted_labels(stat_pvalue_manual(st, label = "p", p.min.threshold = 0.001))
+  expect_equal(labs[2], "< 0.001")
+  # values above the threshold are untouched
+  expect_equal(labs[c(1, 3)], format_p_value(st$p[c(1, 3)], digits = 3))
+})
+
+test_that("p.format.style selects a journal style", {
+  st <- .make_stat()
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(st, label = "p", p.format.style = "nejm")),
+    format_p_value(st$p, style = "nejm", digits = 3)
+  )
+})
+
+test_that("p.leading.zero = FALSE drops the leading zero", {
+  st <- .make_stat()
+  labs <- .plotted_labels(stat_pvalue_manual(st, label = "p", p.leading.zero = FALSE))
+  expect_equal(labs[1], ".0156")
+})
+
+test_that("p.decimal.mark controls the decimal separator", {
+  st <- .make_stat()
+  labs <- .plotted_labels(stat_pvalue_manual(st, label = "p", p.decimal.mark = ","))
+  expect_equal(labs[1], "0,0156")
+})
+
+test_that("p.digits = NULL disables all formatting, including the style args", {
+  st <- .make_stat()
+  # NULL is the documented raw opt-out; the style args must then be ignored.
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(
+      st, label = "p", p.digits = NULL,
+      p.format.style = "nejm", p.min.threshold = 0.001
+    )),
+    as.character(st$p)
+  )
+})
+
+test_that("style args are a no-op on character, significance and glue labels", {
+  st <- .make_stat()
+  st$p.signif <- c("*", "****", "ns")
+  # character significance column
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(
+      st, label = "p.signif", p.format.style = "nejm", p.min.threshold = 0.001
+    )),
+    st$p.signif
+  )
+  # glue expression is evaluated on the raw column, unaffected by style args
+  expect_equal(
+    .plotted_labels(stat_pvalue_manual(
+      st, label = "p = {p}", p.format.style = "nejm", p.leading.zero = FALSE
+    )),
+    paste0("p = ", as.character(st$p))
+  )
+})
+
+test_that("style args do not touch non-p numeric columns or out-of-range values", {
+  st <- .make_stat()
+  st$statistic <- c(5.3, -2.1, 12.0)
+  # a numeric column named like a p-value but out of [0, 1]
+  st_bad <- .make_stat(p = c(0.5, 5.3, 0.7))
+
+  expect_warning(
+    labs_stat <- .plotted_labels(stat_pvalue_manual(
+      st, label = "statistic", p.min.threshold = 0.001, p.format.style = "nejm"
+    )),
+    NA
+  )
+  expect_equal(labs_stat, as.character(st$statistic))
+
+  expect_warning(
+    labs_bad <- .plotted_labels(stat_pvalue_manual(
+      st_bad, label = "p", p.min.threshold = 0.001
+    )),
+    NA
+  )
+  expect_equal(labs_bad, as.character(st_bad$p))
+})


### PR DESCRIPTION
Adds four opt-in p-value formatting arguments to `stat_pvalue_manual()`, matching the ones already available in `stat_compare_means()`, `geom_pwc()` and `stat_anova_test()`.

## What
`stat_pvalue_manual()` was the only bracket layer that could format p-value labels (`p.digits`, added recently) but could not control the *style* of that formatting. This adds the missing four:

- `p.format.style` — `"default"`, `"apa"`, `"nejm"`, `"lancet"`, `"ama"`, `"graphpad"`, `"scientific"`
- `p.leading.zero` — drop the leading zero (`.016` vs `0.016`)
- `p.min.threshold` — display small p-values as `< threshold`, e.g. `p.min.threshold = 0.001` → `< 0.001`
- `p.decimal.mark` — decimal separator

They are forwarded to the same `format_p_value()` engine the sibling layers use.

```r
library(ggpubr)
st <- data.frame(group1 = "0.5", group2 = "1", p = 0.00000004, y.position = 30)
bxp <- ggboxplot(ToothGrowth, "dose", "len")

bxp + stat_pvalue_manual(st, label = "p")                        # 4e-08 (unchanged default)
bxp + stat_pvalue_manual(st, label = "p", p.min.threshold = 0.001)   # < 0.001
bxp + stat_pvalue_manual(st, label = "p", p.format.style = "nejm")   # journal style
```

## Compatibility
- **Opt-in only — default output is byte-identical.** With the four args at their defaults the `format_p_value()` call resolves to exactly the previous call, so existing plots render unchanged.
- `p.digits = NULL` still prints the raw value and disables the style arguments.
- Formatting continues to apply only to recognized numeric p-value columns holding values in `[0, 1]`; other columns (statistics, counts, out-of-range values), significance symbols and glue expressions are untouched.

## Tests
- New `tests/testthat/test-stat-pvalue-manual-pformat.R`: byte-identical default, each argument, the `p.digits = NULL` opt-out, and no-op behaviour on character / glue / non-p / out-of-range labels.
- Full suite: 754 pass / 0 fail.

Refs #716.