### PR TITLE
feat(stat_cor): add RMSE/RMSD computed variable (#458)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,12 @@
     `expression` output).
   - `p.coef.name` — symbol for the p-value label; use `"P"` for an uppercase
     p-value (#541).
+- `stat_cor()` exposes two new computed variables, `rmse` and `rmse.label`, for
+  the root mean square deviation (RMSE/RMSD) between `x` and `y` — useful for
+  reporting agreement between paired measurements on the same scale (e.g.
+  predicted vs. reference values). Display it with
+  `aes(label = after_stat(rmse.label))`, or combine it with the correlation
+  coefficient using `paste()`. The default label is unchanged (#458).
 
 ## New features
 

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -79,10 +79,15 @@ NULL
 #'  horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
 #'  the label-positioning logic in \code{stat_cor()} was originally adapted.
 #' @section Computed variables: \describe{ \item{r}{correlation coefficient}
-#'  \item{rr}{correlation coefficient squared} \item{r.label}{formatted label
-#'  for the correlation coefficient} \item{rr.label}{formatted label for the
-#'  squared correlation coefficient} \item{p.label}{label for the p-value}
-#'  \item{label}{default label displayed by \code{stat_cor()}} }
+#'  \item{rr}{correlation coefficient squared} \item{rmse}{root mean square
+#'  deviation (RMSE/RMSD) between \code{x} and \code{y}, computed on the complete
+#'  pairs; meaningful when \code{x} and \code{y} are on the same scale (e.g.
+#'  predicted vs. reference values). Rounded and formatted with the coefficient
+#'  settings (\code{r.digits} / \code{r.accuracy}).} \item{r.label}{formatted
+#'  label for the correlation coefficient} \item{rr.label}{formatted label for
+#'  the squared correlation coefficient} \item{p.label}{label for the p-value}
+#'  \item{rmse.label}{formatted label for the RMSE/RMSD} \item{label}{default
+#'  label displayed by \code{stat_cor()}} }
 #'
 #' @examples
 #' # Load data
@@ -115,6 +120,16 @@ NULL
 #'     aes(label = paste(after_stat(rr.label), after_stat(p.label), sep = "~`,`~")),
 #'     label.x = 3
 #'   )
+#'
+#' # Show the RMSE/RMSD (root mean square deviation) between x and y
+#' # (useful for agreement between paired measurements on the same scale)
+#' sp + stat_cor(aes(label = after_stat(rmse.label)), label.x = 3)
+#'
+#' # Combine the correlation coefficient and the RMSE (comma-separated)
+#' sp + stat_cor(
+#'   aes(label = paste(after_stat(r.label), after_stat(rmse.label), sep = "~`,`~")),
+#'   label.x = 3
+#' )
 #'
 #' # Color by groups and facet
 #' # ::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -222,12 +237,19 @@ StatCor <- ggproto("StatCor", Stat,
     method = method, alternative = alternative,
     use = "complete.obs"
   ))
-  estimate <- p.value <- p <- r <- rr <- NULL
+  # Root Mean Square Deviation (RMSE/RMSD) between x and y, computed on the same
+  # complete pairs used by cor.test() (#458). Meaningful when x and y are on the
+  # same scale (e.g. predicted vs. reference values).
+  ok <- stats::complete.cases(x, y)
+  rmse.value <- sqrt(mean((x[ok] - y[ok])^2))
+
+  estimate <- p.value <- p <- r <- rr <- rmse <- NULL
   z <- data.frame(estimate = .cor$estimate, p.value = .cor$p.value, method = method) %>%
     mutate(
       r = signif(estimate, r.digits),
       rr = signif(estimate^2, r.digits),
-      p = signif(p.value, p.digits)
+      p = signif(p.value, p.digits),
+      rmse = signif(rmse.value, r.digits)
     )
 
   # Defining p and r labels
@@ -251,6 +273,9 @@ StatCor <- ggproto("StatCor", Stat,
         p.digits = p.digits, accuracy = p.accuracy, type = output.type,
         p.format.style = p.format.style, p.leading.zero = p.leading.zero,
         p.decimal.mark = p.decimal.mark, p.coef.name = p.coef.name
+      ),
+      rmse.label = get_rmse_label(
+        rmse.value, accuracy = r.accuracy, digits = r.digits, type = output.type
       )
     )
 
@@ -390,6 +415,32 @@ get_corcoef_label <- function(x, accuracy = 0.01, prefix = "R", cor.coef.name = 
     }
   }
   label <- gsub(pattern = "R", cor.coef.name, x = label, fixed = TRUE)
+  label
+}
+
+# Format the RMSE/RMSD label (#458). Kept separate from get_corcoef_label()
+# because the latter substitutes "R" -> cor.coef.name, which would corrupt
+# "RMSE". `x` is the RAW rmse value: unlike the correlation coefficient it is
+# not bounded to [-1, 1], so it is formatted from the raw value (significant
+# digits when `accuracy` is NULL, else fixed decimal places) rather than a
+# pre-rounded one, to avoid losing precision for values > 1.
+get_rmse_label <- function(x, accuracy = NULL, digits = 2, type = "expression") {
+  if (is.null(accuracy)) {
+    value <- signif(x, digits)
+    label <- paste0("RMSE = ", value)
+  } else if (!(accuracy < 1)) {
+    stop(
+      "Accuracy should be < 1; For example use 0.01, 0.001, 0.0001, etc.",
+      call. = FALSE
+    )
+  } else {
+    nb_decimal_places <- round(abs(log10(accuracy)))
+    value <- formatC(x, digits = nb_decimal_places, format = "f", decimal.mark = ".")
+    label <- paste0("RMSE = ", value)
+  }
+  if (type == "expression") {
+    label <- gsub(pattern = "RMSE = ", replacement = "italic(RMSE)~`=`~", x = label, fixed = TRUE)
+  }
   label
 }
 

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -180,10 +180,15 @@ Add correlation coefficients with p-values to a scatter plot. Can
 }
 \section{Computed variables}{
  \describe{ \item{r}{correlation coefficient}
- \item{rr}{correlation coefficient squared} \item{r.label}{formatted label
- for the correlation coefficient} \item{rr.label}{formatted label for the
- squared correlation coefficient} \item{p.label}{label for the p-value}
- \item{label}{default label displayed by \code{stat_cor()}} }
+ \item{rr}{correlation coefficient squared} \item{rmse}{root mean square
+ deviation (RMSE/RMSD) between \code{x} and \code{y}, computed on the complete
+ pairs; meaningful when \code{x} and \code{y} are on the same scale (e.g.
+ predicted vs. reference values). Rounded and formatted with the coefficient
+ settings (\code{r.digits} / \code{r.accuracy}).} \item{r.label}{formatted
+ label for the correlation coefficient} \item{rr.label}{formatted label for
+ the squared correlation coefficient} \item{p.label}{label for the p-value}
+ \item{rmse.label}{formatted label for the RMSE/RMSD} \item{label}{default
+ label displayed by \code{stat_cor()}} }
 }
 
 \examples{
@@ -217,6 +222,16 @@ ggscatter(df, x = "wt", y = "mpg", add = "reg.line") +
     aes(label = paste(after_stat(rr.label), after_stat(p.label), sep = "~`,`~")),
     label.x = 3
   )
+
+# Show the RMSE/RMSD (root mean square deviation) between x and y
+# (useful for agreement between paired measurements on the same scale)
+sp + stat_cor(aes(label = after_stat(rmse.label)), label.x = 3)
+
+# Combine the correlation coefficient and the RMSE (comma-separated)
+sp + stat_cor(
+  aes(label = paste(after_stat(r.label), after_stat(rmse.label), sep = "~`,`~")),
+  label.x = 3
+)
 
 # Color by groups and facet
 # ::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/tests/testthat/test-stat-cor-rmse.R
+++ b/tests/testthat/test-stat-cor-rmse.R
@@ -1,0 +1,66 @@
+context("test-stat-cor-rmse")
+
+# stat_cor() exposes RMSE/RMSD (root mean square deviation between x and y) as a
+# computed variable `rmse` and a formatted label `rmse.label` (#458). Purely
+# additive: the default label is unchanged.
+
+.cor_label <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  d <- b$data[[which(vapply(b$data, function(x) "label" %in% names(x), logical(1)))[1]]]
+  as.character(d$label)[1]
+}
+
+set.seed(1)
+.df <- data.frame(x = rnorm(20))
+.df$y <- .df$x * 0.4 + rnorm(20)
+.sp <- ggscatter(.df, "x", "y")
+
+.expected_rmse <- function(x, y, r.digits = 2) {
+  ok <- stats::complete.cases(x, y)
+  signif(sqrt(mean((x[ok] - y[ok])^2)), r.digits)
+}
+
+test_that("rmse.label reports the RMSE between x and y (text output)", {
+  expected <- .expected_rmse(.df$x, .df$y)
+  lab <- .cor_label(
+    .sp + stat_cor(aes(label = after_stat(rmse.label)), output.type = "text")
+  )
+  expect_equal(lab, paste0("RMSE = ", expected))
+})
+
+test_that("rmse.label is a valid plotmath expression by default", {
+  expected <- .expected_rmse(.df$x, .df$y)
+  lab <- .cor_label(.sp + stat_cor(aes(label = after_stat(rmse.label))))
+  expect_equal(lab, paste0("italic(RMSE)~`=`~", expected))
+  # must parse as plotmath (draw-time safety, not just build)
+  expect_error(parse(text = lab), NA)
+})
+
+test_that("rmse.label honors r.accuracy for decimal places", {
+  ok <- stats::complete.cases(.df$x, .df$y)
+  raw <- sqrt(mean((.df$x[ok] - .df$y[ok])^2))
+  lab <- .cor_label(
+    .sp + stat_cor(aes(label = after_stat(rmse.label)),
+      output.type = "text", r.accuracy = 0.001
+    )
+  )
+  expect_equal(lab, paste0("RMSE = ", formatC(raw, digits = 3, format = "f")))
+})
+
+test_that("the default stat_cor label is unchanged (no regression, #458)", {
+  lab <- .cor_label(.sp + stat_cor(p.accuracy = 0.001, r.accuracy = 0.01))
+  expect_equal(lab, "italic(R)~`=`~0.20*`,`~italic(p)~`=`~0.392")
+  expect_false(grepl("RMSE", lab))
+})
+
+test_that("rmse is computed per group", {
+  d <- .df
+  d$g <- rep(c("a", "b"), each = 10)
+  sp <- ggscatter(d, "x", "y", color = "g")
+  b <- ggplot2::ggplot_build(sp + stat_cor(aes(color = g, label = after_stat(rmse.label)), output.type = "text"))
+  dd <- b$data[[which(vapply(b$data, function(x) "label" %in% names(x), logical(1)))[1]]]
+  labs <- as.character(dd$label)
+  exp_a <- .expected_rmse(d$x[d$g == "a"], d$y[d$g == "a"])
+  exp_b <- .expected_rmse(d$x[d$g == "b"], d$y[d$g == "b"])
+  expect_setequal(labs, c(paste0("RMSE = ", exp_a), paste0("RMSE = ", exp_b)))
+})


### PR DESCRIPTION
Adds RMSE/RMSD support to `stat_cor()`, as requested in #458.

## What
`stat_cor()` now exposes two additional computed variables:
- `rmse` — the root mean square deviation between `x` and `y`, `sqrt(mean((x - y)^2))`, computed on the complete pairs (the same pairs `cor.test()` uses).
- `rmse.label` — its formatted label.

This is handy for reporting agreement between paired measurements on the same scale (e.g. predicted vs. reference/gold-standard values), alongside or instead of the correlation coefficient.

```r
library(ggpubr)
sp <- ggscatter(mtcars, x = "wt", y = "mpg", add = "reg.line")

# RMSE alone
sp + stat_cor(aes(label = after_stat(rmse.label)))

# Correlation coefficient + RMSE
sp + stat_cor(aes(label = paste(after_stat(r.label), after_stat(rmse.label), sep = "~`,`~")))
```

RMSE precision follows the existing coefficient settings (`r.digits` / `r.accuracy`).

## Compatibility
- **Purely additive — the default `stat_cor()` label is unchanged.** The new columns are only used when you map them via `after_stat()`.
- Works with `output.type = "expression"` (plotmath, default), `"text"`, `"latex"`, `"tex"`, and is computed per group / per facet.

## Tests
- New `tests/testthat/test-stat-cor-rmse.R`: RMSE value/formatting (default sig-digits and `r.accuracy` decimals), plotmath parses, per-group computation, and a default-label no-regression check.
- Full suite: 761 pass / 0 fail.

Fixes #458.