### PR TITLE
feat(annotate_figure): add column.titles and row.titles (#573)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,15 @@
   text-line units, around each plot. Default is `0` (no extra space; each plot
   keeps its own margins, so existing arrangements are unchanged) (#151).
 
+- `annotate_figure()` gains `column.titles` and `row.titles` arguments to add a
+  title above each column and to the left of each row of an arranged grid
+  (useful for publication panels). Each accepts a character vector (one title
+  per column / per row, rendered in bold) or a list of grobs (e.g. built with
+  `text_grob()`) for full styling control; `row.titles` are rotated 90 degrees.
+  The titles are placed in reserved space (they do not overlap the plots) and
+  are evenly spaced, so they assume equal-sized columns / rows (the `ggarrange()`
+  default). Default is `NULL` (no titles; existing figures are unchanged) (#573).
+
 - `ggbarplot()` gains a `numeric.x.axis` argument (already available in
   `ggline()` and `ggerrorplot()`). With `numeric.x.axis = TRUE` the x variable
   is kept numeric instead of being coerced to a discrete factor, so bars are

--- a/R/annotate_figure.R
+++ b/R/annotate_figure.R
@@ -14,6 +14,15 @@ NULL
 #' @param fig.lab.size optional size of the figure label.
 #' @param fig.lab.face optional font face of the figure label. Allowed values
 #'  include: "plain", "bold", "italic", "bold.italic".
+#' @param column.titles,row.titles optional character vector giving one title per
+#'  column / per row of the arranged figure, adding titles above each column and
+#'  to the left of each row (useful for publication grids, see
+#'  \code{\link{ggarrange}()}). Can also be a list of grobs (e.g. built with
+#'  \code{\link{text_grob}()}) for full control over styling; a character vector
+#'  is rendered in bold using the current theme text settings. The titles are
+#'  evenly spaced and therefore assume equal-sized columns / rows (the
+#'  \code{ggarrange()} default), with one entry per column / row. \code{row.titles}
+#'  are rotated 90 degrees.
 #' @author Laszlo Erdey \email{erdey.laszlo@@econ.unideb.hu}
 #' @seealso \code{\link{ggarrange}()}
 #' @examples
@@ -50,6 +59,14 @@ NULL
 #'   fig.lab = "Figure 1", fig.lab.face = "bold"
 #' )
 #'
+#' # Add a title to each column and each row of an arranged grid
+#' # ::::::::::::::::::::::::::::::::::::::::::::::::::
+#' grid <- ggarrange(bxp, dp, dens, bxp, ncol = 2, nrow = 2)
+#' annotate_figure(grid,
+#'   column.titles = c("Column 1", "Column 2"),
+#'   row.titles = c("Row 1", "Row 2")
+#' )
+#'
 #' @export
 annotate_figure <- function(p,
                             top = NULL, bottom = NULL, left = NULL, right = NULL,
@@ -58,7 +75,8 @@ annotate_figure <- function(p,
                               "top.left", "top", "top.right",
                               "bottom.left", "bottom", "bottom.right"
                             ),
-                            fig.lab.size, fig.lab.face) {
+                            fig.lab.size, fig.lab.face,
+                            column.titles = NULL, row.titles = NULL) {
   fig.lab.pos <- match.arg(fig.lab.pos)
   annot.args <- list(top = top, bottom = bottom, left = left, right = right) %>%
     .compact()
@@ -84,6 +102,18 @@ annotate_figure <- function(p,
   lab.args$fontface <- if (!missing(fig.lab.face)) fig.lab.face else ggplot2::theme_get()$text$face
 
 
+  # Per-column / per-row titles (#573). Wrapped closest to the plots (inside any
+  # figure-wide top/left labels) using space-reserving strips so they do not
+  # overlap the plot content. Evenly spaced -> assumes equal column/row sizes.
+  has.col.titles <- !is.null(column.titles) && length(column.titles) > 0
+  has.row.titles <- !is.null(row.titles) && length(row.titles) > 0
+  if (has.col.titles || has.row.titles) {
+    col.grob <- if (has.col.titles) .titles_grob(column.titles, rot = 0) else NULL
+    row.grob <- if (has.row.titles) .titles_grob(row.titles, rot = 90) else NULL
+    p <- gridExtra::arrangeGrob(p, top = col.grob, left = row.grob) %>%
+      as_ggplot()
+  }
+
   if (!.is_empty(annot.args)) {
     p <- gridExtra::arrangeGrob(p, top = top, bottom = bottom, left = left, right = right) %>%
       as_ggplot()
@@ -94,4 +124,30 @@ annotate_figure <- function(p,
   }
 
   p
+}
+
+# Build an evenly-spaced strip of per-column (rot = 0) or per-row (rot = 90)
+# titles for annotate_figure() (#573). `titles` is a character vector (rendered
+# in bold via text_grob()), a single grob, or a list of grobs.
+.titles_grob <- function(titles, rot = 0) {
+  if (is.character(titles)) {
+    grobs <- lapply(titles, function(x) text_grob(x, face = "bold", rot = rot))
+  } else if (grid::is.grob(titles)) {
+    grobs <- list(titles)
+  } else if (is.list(titles)) {
+    grobs <- titles
+  } else {
+    stop(
+      "`column.titles`/`row.titles` must be a character vector or a list of grobs.",
+      call. = FALSE
+    )
+  }
+  n <- length(grobs)
+  if (rot == 0) {
+    # per-column titles: a single row of n evenly spaced cells
+    gridExtra::arrangeGrob(grobs = grobs, nrow = 1, ncol = n)
+  } else {
+    # per-row titles: a single column of n evenly spaced cells
+    gridExtra::arrangeGrob(grobs = grobs, ncol = 1, nrow = n)
+  }
 }

--- a/man/annotate_figure.Rd
+++ b/man/annotate_figure.Rd
@@ -14,7 +14,9 @@ annotate_figure(
   fig.lab.pos = c("top.left", "top", "top.right", "bottom.left", "bottom",
     "bottom.right"),
   fig.lab.size,
-  fig.lab.face
+  fig.lab.face,
+  column.titles = NULL,
+  row.titles = NULL
 )
 }
 \arguments{
@@ -32,6 +34,16 @@ annotate_figure(
 
 \item{fig.lab.face}{optional font face of the figure label. Allowed values
 include: "plain", "bold", "italic", "bold.italic".}
+
+\item{column.titles, row.titles}{optional character vector giving one title per
+column / per row of the arranged figure, adding titles above each column and
+to the left of each row (useful for publication grids, see
+\code{\link{ggarrange}()}). Can also be a list of grobs (e.g. built with
+\code{\link{text_grob}()}) for full control over styling; a character vector
+is rendered in bold using the current theme text settings. The titles are
+evenly spaced and therefore assume equal-sized columns / rows (the
+\code{ggarrange()} default), with one entry per column / row. \code{row.titles}
+are rotated 90 degrees.}
 }
 \description{
 Annotate figures including: i) ggplots, ii) arranged ggplots from
@@ -70,6 +82,14 @@ annotate_figure(figure,
   left = text_grob("Figure arranged using ggpubr", color = "green", rot = 90),
   right = text_grob(bquote("Superscript: (" * kg ~ NH[3] ~ ha^-1 ~ yr^-1 * ")"), rot = 90),
   fig.lab = "Figure 1", fig.lab.face = "bold"
+)
+
+# Add a title to each column and each row of an arranged grid
+# ::::::::::::::::::::::::::::::::::::::::::::::::::
+grid <- ggarrange(bxp, dp, dens, bxp, ncol = 2, nrow = 2)
+annotate_figure(grid,
+  column.titles = c("Column 1", "Column 2"),
+  row.titles = c("Row 1", "Row 2")
 )
 
 }

--- a/tests/testthat/test-annotate-figure-titles.R
+++ b/tests/testthat/test-annotate-figure-titles.R
@@ -1,0 +1,115 @@
+context("test-annotate-figure-titles")
+
+# annotate_figure() gains column.titles / row.titles to add a title above each
+# column and to the left of each row of an arranged grid (#573). Opt-in: default
+# NULL leaves the figure unchanged.
+
+.fig <- ggarrange(
+  ggboxplot(ToothGrowth, "dose", "len"),
+  ggboxplot(ToothGrowth, "dose", "len"),
+  ggboxplot(ToothGrowth, "dose", "len"),
+  ggboxplot(ToothGrowth, "dose", "len"),
+  ncol = 2, nrow = 2
+)
+
+# --- .titles_grob helper ----------------------------------------------------
+
+test_that(".titles_grob builds one cell per title with the right labels", {
+  g <- ggpubr:::.titles_grob(c("A", "B", "C"), rot = 0)
+  expect_true(grid::is.grob(g))
+  labels <- vapply(g$grobs, function(x) x$label, character(1))
+  expect_equal(labels, c("A", "B", "C"))
+})
+
+test_that(".titles_grob rotates row titles by 90 degrees", {
+  g <- ggpubr:::.titles_grob(c("R1", "R2"), rot = 90)
+  rots <- vapply(g$grobs, function(x) x$rot, numeric(1))
+  expect_equal(rots, c(90, 90))
+})
+
+test_that(".titles_grob accepts a list of grobs (custom styling passthrough)", {
+  custom <- list(
+    text_grob("X", color = "red", size = 14),
+    text_grob("Y", color = "blue", size = 14)
+  )
+  g <- ggpubr:::.titles_grob(custom, rot = 0)
+  labels <- vapply(g$grobs, function(x) x$label, character(1))
+  expect_equal(labels, c("X", "Y"))
+  expect_equal(g$grobs[[1]]$gp$col, "red")
+})
+
+test_that(".titles_grob rejects invalid input", {
+  expect_error(ggpubr:::.titles_grob(1:3), "character vector or a list of grobs")
+})
+
+# --- annotate_figure() integration ------------------------------------------
+
+test_that("column.titles / row.titles render without error", {
+  expect_no_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      annotate_figure(.fig,
+        column.titles = c("Col 1", "Col 2"),
+        row.titles = c("Row 1", "Row 2")
+      )
+    ))
+  )
+  # combined with a figure-wide top label
+  expect_no_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      annotate_figure(.fig,
+        top = text_grob("Whole figure", face = "bold"),
+        column.titles = c("Col 1", "Col 2")
+      )
+    ))
+  )
+})
+
+test_that("column.titles accepts a list of grobs", {
+  expect_no_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      annotate_figure(.fig,
+        column.titles = list(
+          text_grob("A", color = "red"),
+          text_grob("B", color = "blue")
+        )
+      )
+    ))
+  )
+})
+
+test_that("default (no titles) is unchanged: passing NULL equals omitting", {
+  omitted <- annotate_figure(.fig, top = text_grob("T"))
+  explicit_null <- annotate_figure(.fig, top = text_grob("T"),
+    column.titles = NULL, row.titles = NULL)
+  # same object structure (the titles block is skipped when both are NULL)
+  expect_equal(
+    ggplot2::ggplot_build(omitted)$data,
+    ggplot2::ggplot_build(explicit_null)$data
+  )
+})
+
+test_that("positional fig.lab still binds correctly (no signature-order break)", {
+  # column.titles / row.titles are appended at the END of the signature, so the
+  # 6th positional argument is still fig.lab (not column.titles). A positional
+  # fig.lab call must still draw the figure label.
+  lab_layer <- function(p) {
+    i <- utils::tail(which(vapply(p$layers,
+      function(l) inherits(l$geom, "GeomText"), logical(1))), 1)
+    p$layers[[i]]
+  }
+  p <- annotate_figure(.fig, NULL, NULL, NULL, NULL, "Figure 1")
+  expect_equal(as.character(lab_layer(p)$data$text), "Figure 1")
+})
+
+test_that("empty title vectors are handled gracefully (no crash)", {
+  expect_no_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      annotate_figure(.fig, column.titles = character(0), row.titles = character(0))
+    ))
+  )
+  # an empty vector behaves like NULL (no titles added)
+  base <- ggplot2::ggplot_build(annotate_figure(.fig))$data
+  empty <- ggplot2::ggplot_build(
+    annotate_figure(.fig, column.titles = character(0)))$data
+  expect_equal(base, empty)
+})


### PR DESCRIPTION
Adds per-column and per-row titles to `annotate_figure()`, as requested in #573.

## What
When combining plots into a grid with `ggarrange()`, it is often useful to label each column and each row (e.g. condition across columns, cohort down rows). `annotate_figure()` now accepts:

- `column.titles` — one title above each column
- `row.titles` — one title to the left of each row (rotated 90°)

Each accepts a character vector (one entry per column / row, rendered in bold) or a list of grobs (e.g. via `text_grob()`) for full styling control.

```r
library(ggpubr)
p <- ggscatter(mtcars, "wt", "mpg")
grid <- ggarrange(p, p, p, p, p, p, ncol = 3, nrow = 2)

annotate_figure(grid,
  column.titles = c("Group 1", "Group 2", "Group 3"),
  row.titles = c("Cohort A", "Cohort B"),
  top = text_grob("My combined figure", face = "bold", size = 16)
)

# custom styling via grobs
annotate_figure(grid,
  column.titles = list(
    text_grob("A", color = "red"),
    text_grob("B", color = "blue"),
    text_grob("C", color = "darkgreen")
  ))
```

The titles are drawn in reserved space (via `gridExtra::arrangeGrob()`), so they do not overlap the plots, and sit inside any figure-wide `top`/`left` labels.

## Compatibility
- **Opt-in — default output is unchanged.** With `column.titles = NULL` / `row.titles = NULL` (the defaults), the figure is byte-identical to before.
- The two new arguments are appended at the **end** of the signature, so existing positional and named calls (including a positional `fig.lab`) are unaffected.
- Titles are evenly spaced and therefore assume equal-sized columns / rows (the `ggarrange()` default) — provide one title per column / row.

## Tests
- New `tests/testthat/test-annotate-figure-titles.R`: the `.titles_grob()` helper (character / grob-list / rotation / invalid input), rendering of all combinations, a positional-`fig.lab` no-regression check, empty-vector handling, and a default-unchanged check.
- Full suite: 767 pass / 0 fail.

Fixes #573.