### PR TITLE
feat(geom_pwc): add p.adjust.n for a manual number of comparisons (#612)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,15 @@
   text-line units, around each plot. Default is `0` (no extra space; each plot
   keeps its own margins, so existing arrangements are unchanged) (#151).
 
+- `geom_pwc()` and `stat_pwc()` gain a `p.adjust.n` argument giving the number of
+  comparisons to use for the p-value adjustment (passed as `n` to
+  `stats::p.adjust()`). Default is `NULL` (adjust by the number of computed
+  p-values, unchanged behavior); set it when the displayed comparisons are a
+  subset of a larger family so the adjustment reflects that larger size. It must
+  be at least the number of p-values being adjusted, and applies to the
+  panel-level adjustment (`p.adjust.by = "panel"`) and the single-comparison
+  case (#612).
+
 - `annotate_figure()` gains `column.titles` and `row.titles` arguments to add a
   title above each column and to the left of each row of an arranged grid
   (useful for publication panels). Each accepts a character vector (one title

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -84,6 +84,19 @@ NULL
 #'  performed, then the p-values are adjusted for each group level
 #'  independently. P-values are adjusted by panel when \code{p.adjust.by =
 #'  "panel"}.
+#' @param p.adjust.n optional single number giving the number of comparisons to
+#'  use for the p-value adjustment, passed as \code{n} to
+#'  \code{\link[stats]{p.adjust}}. Default is \code{NULL}, which uses the number
+#'  of p-values actually computed (the standard behavior). Set it when the
+#'  displayed comparisons are a subset of a larger family and the adjustment
+#'  should reflect that larger family size. As required by
+#'  \code{\link[stats]{p.adjust}}, \code{p.adjust.n} must be greater than or
+#'  equal to the number of p-values being adjusted. It affects the adjustment
+#'  that \code{geom_pwc()} performs itself: the panel-level adjustment
+#'  (\code{p.adjust.by = "panel"}) and cases where the test returns a single set
+#'  of p-values (a single comparison, or grouped comparisons with two levels per
+#'  group). It does not alter the adjustment that pairwise tests already perform
+#'  internally per group.
 #' @param symnum.args a list of arguments to pass to the function
 #'  \code{\link[stats]{symnum}} for symbolic number coding of p-values. For
 #'  example, \code{symnum.args = list(cutpoints = c(0, 0.0001, 0.001, 0.01,
@@ -277,6 +290,7 @@ stat_pwc <- function(mapping = NULL, data = NULL,
                      step.increase = 0.12, tip.length = 0.03,
                      size = 0.3, label.size = 3.88, family = "", vjust = 0, hjust = 0.5,
                      p.adjust.method = "holm", p.adjust.by = c("group", "panel"),
+                     p.adjust.n = NULL,
                      symnum.args = list(), hide.ns = FALSE, remove.bracket = FALSE,
                      p.format.style = "default", p.digits = NULL,
                      p.leading.zero = NULL, p.min.threshold = NULL,
@@ -326,6 +340,7 @@ stat_pwc <- function(mapping = NULL, data = NULL,
       remove.bracket = remove.bracket,
       family = family, vjust = vjust, hjust = hjust, na.rm = na.rm,
       p.adjust.method = p.adjust.method, p.adjust.by = p.adjust.by,
+      p.adjust.n = p.adjust.n,
       symnum.args = symnum.args,
       hide.ns = hide.ns, parse = parse,
       p.format.style = p.format.style, p.digits = p.digits,
@@ -355,7 +370,7 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
   compute_panel = function(self, data, scales, method, method.args, ref.group,
                            tip.length, stat.label, y.position, step.increase,
                            bracket.nudge.y, bracket.shorten, bracket.group.by,
-                           p.adjust.method, p.adjust.by,
+                           p.adjust.method, p.adjust.by, p.adjust.n = NULL,
                            symnum.args, hide.ns, group.by, dodge, remove.bracket,
                            p.format.style, p.digits, p.leading.zero,
                            p.min.threshold, p.decimal.mark) {
@@ -555,15 +570,14 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
     # P-value adjustment, formatting and significance
     if (!("p.adj" %in% colnames(stat.test))) {
       # Case of one comparison of two groups
-      stat.test <- stat.test %>% rstatix::adjust_pvalue(method = p.adjust.method)
+      stat.test <- .pwc_adjust_pvalue(stat.test, p.adjust.method, p.adjust.n)
     }
 
     # Adjust all the p-values in a given panel
     # no matter the grouping
     if (p.adjust.by == "panel") {
       if ("p" %in% colnames(stat.test)) {
-        stat.test <- stat.test %>%
-          rstatix::adjust_pvalue(method = p.adjust.method)
+        stat.test <- .pwc_adjust_pvalue(stat.test, p.adjust.method, p.adjust.n)
       } else {
         warning(
           "p-values can't be adjusted by panel for the specified stat method.\n",
@@ -710,6 +724,32 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
 )
 
 
+# Adjust the p-values of a pwc stat.test, optionally against a user-supplied
+# number of comparisons `n` (#612). With n = NULL (default) this is exactly
+# rstatix::adjust_pvalue(method = method) -- byte-identical to the previous
+# behavior. With n set, stats::p.adjust(p, method, n = n) is used so the
+# adjustment reflects a custom family size (e.g. when the displayed comparisons
+# are a subset of a larger set); `n` must be >= the number of p-values adjusted,
+# matching stats::p.adjust()'s own requirement.
+.pwc_adjust_pvalue <- function(stat.test, method, n = NULL) {
+  if (is.null(n)) {
+    return(rstatix::adjust_pvalue(stat.test, method = method))
+  }
+  if (!is.numeric(n) || length(n) != 1L || is.na(n) || n < 1) {
+    stop("`p.adjust.n` must be a single positive number or NULL.", call. = FALSE)
+  }
+  n.pvalues <- sum(!is.na(stat.test$p))
+  if (n < n.pvalues) {
+    stop(
+      "`p.adjust.n` (", n, ") must be >= the number of p-values being adjusted (",
+      n.pvalues, ").", call. = FALSE
+    )
+  }
+  stat.test$p.adj <- stats::p.adjust(stat.test$p, method = method, n = n)
+  stat.test
+}
+
+
 #' @rdname geom_pwc
 #' @export
 geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
@@ -720,6 +760,7 @@ geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
                      bracket.nudge.y = 0.05, bracket.shorten = 0, bracket.group.by = c("x.var", "legend.var"),
                      size = 0.3, label.size = 3.88, family = "", vjust = 0, hjust = 0.5,
                      p.adjust.method = "holm", p.adjust.by = c("group", "panel"),
+                     p.adjust.n = NULL,
                      symnum.args = list(), hide.ns = FALSE, remove.bracket = FALSE,
                      p.format.style = "default", p.digits = NULL,
                      p.leading.zero = NULL, p.min.threshold = NULL,
@@ -774,6 +815,7 @@ geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
       size = size, label.size = label.size,
       family = family, na.rm = na.rm, hjust = hjust, vjust = vjust,
       p.adjust.method = p.adjust.method, p.adjust.by = p.adjust.by,
+      p.adjust.n = p.adjust.n,
       symnum.args = symnum.args,
       hide.ns = hide.ns, remove.bracket = remove.bracket,
       p.format.style = p.format.style, p.digits = p.digits,

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -27,6 +27,7 @@ stat_pwc(
   hjust = 0.5,
   p.adjust.method = "holm",
   p.adjust.by = c("group", "panel"),
+  p.adjust.n = NULL,
   symnum.args = list(),
   hide.ns = FALSE,
   remove.bracket = FALSE,
@@ -71,6 +72,7 @@ geom_pwc(
   hjust = 0.5,
   p.adjust.method = "holm",
   p.adjust.by = c("group", "panel"),
+  p.adjust.n = NULL,
   symnum.args = list(),
   hide.ns = FALSE,
   remove.bracket = FALSE,
@@ -207,6 +209,20 @@ Default is \code{"group"}: for a grouped data, if pairwise test is
 performed, then the p-values are adjusted for each group level
 independently. P-values are adjusted by panel when \code{p.adjust.by =
 "panel"}.}
+
+\item{p.adjust.n}{optional single number giving the number of comparisons to
+use for the p-value adjustment, passed as \code{n} to
+\code{\link[stats]{p.adjust}}. Default is \code{NULL}, which uses the number
+of p-values actually computed (the standard behavior). Set it when the
+displayed comparisons are a subset of a larger family and the adjustment
+should reflect that larger family size. As required by
+\code{\link[stats]{p.adjust}}, \code{p.adjust.n} must be greater than or
+equal to the number of p-values being adjusted. It affects the adjustment
+that \code{geom_pwc()} performs itself: the panel-level adjustment
+(\code{p.adjust.by = "panel"}) and cases where the test returns a single set
+of p-values (a single comparison, or grouped comparisons with two levels per
+group). It does not alter the adjustment that pairwise tests already perform
+internally per group.}
 
 \item{symnum.args}{a list of arguments to pass to the function
  \code{\link[stats]{symnum}} for symbolic number coding of p-values. For

--- a/tests/testthat/test-geom-pwc-p-adjust-n.R
+++ b/tests/testthat/test-geom-pwc-p-adjust-n.R
@@ -1,0 +1,63 @@
+context("test-geom-pwc-p-adjust-n")
+
+# geom_pwc() / stat_pwc() gain p.adjust.n: an optional number of comparisons for
+# the p-value adjustment, passed as `n` to stats::p.adjust (#612). Default NULL
+# keeps the standard behavior (adjust by the number of computed p-values), so
+# existing output is byte-identical.
+
+df <- ToothGrowth
+df$dose <- as.factor(df$dose)
+
+.panel_padj <- function(layer) {
+  p <- ggboxplot(df, "dose", "len") + layer
+  b <- ggplot2::ggplot_build(p)
+  for (d in b$data) {
+    if ("p.adj" %in% names(d)) return(sort(unique(d$p.adj)))
+  }
+  stop("no p.adj found")
+}
+
+.raw_p <- sort(rstatix::wilcox_test(df, len ~ dose)$p)
+
+test_that("default p.adjust.n = NULL is unchanged (byte-identical to holm on the computed p-values)", {
+  got <- .panel_padj(geom_pwc(method = "wilcox_test", p.adjust.by = "panel"))
+  expect_equal(got, sort(stats::p.adjust(.raw_p, method = "holm")))
+})
+
+test_that(".pwc_adjust_pvalue with n = NULL equals rstatix::adjust_pvalue", {
+  st <- data.frame(group1 = c("a", "a", "b"), group2 = c("b", "c", "c"),
+                   p = c(0.01, 0.04, 0.2))
+  expect_equal(
+    ggpubr:::.pwc_adjust_pvalue(st, "holm", NULL),
+    rstatix::adjust_pvalue(st, method = "holm")
+  )
+})
+
+test_that("p.adjust.n adjusts against the supplied family size", {
+  got <- .panel_padj(geom_pwc(method = "wilcox_test", p.adjust.by = "panel", p.adjust.n = 10))
+  expect_equal(got, sort(stats::p.adjust(.raw_p, method = "holm", n = 10)))
+  # bonferroni is easy to reason about: p.adj = min(1, p * n)
+  got_bonf <- .panel_padj(
+    geom_pwc(method = "wilcox_test", p.adjust.by = "panel",
+             p.adjust.method = "bonferroni", p.adjust.n = 100)
+  )
+  expect_equal(got_bonf, sort(pmin(1, .raw_p * 100)))
+})
+
+test_that("p.adjust.n below the number of p-values is rejected", {
+  # 3 dose comparisons; n = 2 is invalid. The stat compute fails.
+  expect_error(
+    ggpubr:::.pwc_adjust_pvalue(
+      data.frame(p = c(0.01, 0.02, 0.03)), "holm", 2
+    ),
+    "must be >= the number of p-values"
+  )
+})
+
+test_that("p.adjust.n validates its input type", {
+  st <- data.frame(p = c(0.01, 0.02))
+  expect_error(ggpubr:::.pwc_adjust_pvalue(st, "holm", c(3, 4)),
+               "single positive number")
+  expect_error(ggpubr:::.pwc_adjust_pvalue(st, "holm", -1),
+               "single positive number")
+})


### PR DESCRIPTION
Adds an opt-in `p.adjust.n` argument to `geom_pwc()` and `stat_pwc()`, as requested in #612.

## What
`p.adjust.n` sets the number of comparisons used for the p-value adjustment — it is passed as `n` to `stats::p.adjust()`. This is useful when the comparisons shown on the plot are a subset of a larger family of tests and the multiple-testing correction should reflect that larger size.

```r
library(ggpubr)
df <- ToothGrowth; df$dose <- as.factor(df$dose)

# default adjustment (by the number of computed comparisons)
ggboxplot(df, "dose", "len") +
  geom_pwc(method = "wilcox_test", p.adjust.by = "panel", p.adjust.method = "bonferroni")

# adjust as if there were 10 comparisons in the family
ggboxplot(df, "dose", "len") +
  geom_pwc(method = "wilcox_test", p.adjust.by = "panel",
           p.adjust.method = "bonferroni", p.adjust.n = 10)
```

## Compatibility
- **Opt-in — default output is byte-identical.** With `p.adjust.n = NULL` (the default) the adjustment still goes through `rstatix::adjust_pvalue()` exactly as before. Only when `p.adjust.n` is set is `stats::p.adjust(p, method, n)` used.
- As required by `stats::p.adjust()`, `p.adjust.n` must be at least the number of p-values being adjusted; a smaller value is rejected.

## Tests
- New `tests/testthat/test-geom-pwc-p-adjust-n.R`: default-unchanged (byte-identical), the adjustment against a supplied family size (holm and bonferroni), input validation, and the too-small-`n` rejection.
- Full suite: 781 pass / 0 fail.

Fixes #612.