### PR TITLE
feat(stat_cor): display the correlation confidence interval (#418)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,14 @@
   `aes(label = after_stat(rmse.label))`, or combine it with the correlation
   coefficient using `paste()`. The default label is unchanged (#458).
 
+- `stat_cor()` can now display the confidence interval of the correlation
+  coefficient, via the new computed variables `conf.int.low`, `conf.int.high`
+  and `conf.int.label` (e.g. `"95% CI [0.21, 0.75]"`) and a `conf.level` argument
+  (default `0.95`). Show it with `aes(label = after_stat(conf.int.label))`, or
+  combine it with the coefficient using `paste()`. The confidence interval is
+  available for `method = "pearson"` only; it is `NA` for Spearman/Kendall. The
+  default label is unchanged (#418).
+
 ## New features
 
 - Passing `ggtheme = NULL` to the plotting functions (e.g. `ggscatter()`,

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -66,6 +66,13 @@ NULL
 #'  point (e.g., "0.05" vs ".05"). If NULL, uses the style's default setting.
 #' @param p.decimal.mark character string to use as the decimal mark. If NULL,
 #'  uses \code{getOption("OutDec")}.
+#' @param conf.level confidence level for the confidence interval of the
+#'  correlation coefficient, used to compute the \code{conf.int.low},
+#'  \code{conf.int.high} and \code{conf.int.label} computed variables (see the
+#'  \strong{Computed variables} section). Default is 0.95. A confidence interval
+#'  is only available for \code{method = "pearson"} (with at least 4 complete
+#'  observations); for \code{"spearman"}/\code{"kendall"} the confidence-interval
+#'  variables are \code{NA}.
 #' @param ... other arguments to pass to \code{\link[ggplot2]{geom_text}} or
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
@@ -86,8 +93,13 @@ NULL
 #'  settings (\code{r.digits} / \code{r.accuracy}).} \item{r.label}{formatted
 #'  label for the correlation coefficient} \item{rr.label}{formatted label for
 #'  the squared correlation coefficient} \item{p.label}{label for the p-value}
-#'  \item{rmse.label}{formatted label for the RMSE/RMSD} \item{label}{default
-#'  label displayed by \code{stat_cor()}} }
+#'  \item{rmse.label}{formatted label for the RMSE/RMSD}
+#'  \item{conf.int.low, conf.int.high}{lower and upper bounds of the confidence
+#'  interval of the correlation coefficient (Pearson only; \code{NA} for
+#'  Spearman/Kendall), at the level given by \code{conf.level}}
+#'  \item{conf.int.label}{formatted label for the confidence interval, e.g.
+#'  \code{"95\% CI [0.21, 0.75]"} (\code{NA} when the interval is unavailable)}
+#'  \item{label}{default label displayed by \code{stat_cor()}} }
 #'
 #' @examples
 #' # Load data
@@ -131,6 +143,15 @@ NULL
 #'   label.x = 3
 #' )
 #'
+#' # Show the confidence interval of the correlation coefficient (Pearson)
+#' sp + stat_cor(aes(label = after_stat(conf.int.label)), label.x = 3)
+#'
+#' # Correlation coefficient with its confidence interval
+#' sp + stat_cor(
+#'   aes(label = paste(after_stat(r.label), after_stat(conf.int.label), sep = "~`,`~")),
+#'   label.x = 1.5
+#' )
+#'
 #' # Color by groups and facet
 #' # ::::::::::::::::::::::::::::::::::::::::::::::::::::
 #' sp <- ggscatter(df,
@@ -151,11 +172,15 @@ stat_cor <- function(mapping = NULL, data = NULL,
                      r.accuracy = NULL, p.accuracy = NULL,
                      r.leading.zero = NULL,
                      p.format.style = "default", p.leading.zero = NULL,
-                     p.decimal.mark = NULL, p.coef.name = "p",
+                     p.decimal.mark = NULL, p.coef.name = "p", conf.level = 0.95,
                      geom = "text", position = "identity", na.rm = FALSE, show.legend = NA,
                      inherit.aes = TRUE, ...) {
   parse <- ifelse(output.type == "expression", TRUE, FALSE)
   cor.coef.name <- cor.coef.name[1]
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+      conf.level <= 0 || conf.level >= 1) {
+    stop("`conf.level` must be a single number between 0 and 1.", call. = FALSE)
+  }
   layer(
     stat = StatCor, data = data, mapping = mapping, geom = geom,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
@@ -169,6 +194,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
       p.format.style = p.format.style,
       p.leading.zero = p.leading.zero, p.decimal.mark = p.decimal.mark,
       cor.coef.name = cor.coef.name, p.coef.name = p.coef.name,
+      conf.level = conf.level,
       parse = parse, na.rm = na.rm, ...
     )
   )
@@ -182,7 +208,7 @@ StatCor <- ggproto("StatCor", Stat,
                            label.x, label.y, label.y.step = 1.4, label.sep, output.type, digits,
                            r.digits, p.digits, r.accuracy, p.accuracy, r.leading.zero,
                            p.format.style, p.leading.zero, p.decimal.mark, cor.coef.name,
-                           p.coef.name) {
+                           p.coef.name, conf.level = 0.95) {
     if (length(unique(data$x)) < 2) {
       # Not enough data to perform test
       return(data.frame())
@@ -197,7 +223,8 @@ StatCor <- ggproto("StatCor", Stat,
       r.leading.zero = r.leading.zero,
       p.format.style = p.format.style, p.leading.zero = p.leading.zero,
       p.decimal.mark = p.decimal.mark,
-      cor.coef.name = cor.coef.name, p.coef.name = p.coef.name
+      cor.coef.name = cor.coef.name, p.coef.name = p.coef.name,
+      conf.level = conf.level
     )
     # Returns a data frame with label: x, y, hjust, vjust
     .label.pms <- .label_params(
@@ -220,7 +247,7 @@ StatCor <- ggproto("StatCor", Stat,
                       r.accuracy = NULL, p.accuracy = NULL, r.leading.zero = NULL,
                       p.format.style = "default", p.leading.zero = NULL,
                       p.decimal.mark = NULL,
-                      cor.coef.name = "R", p.coef.name = "p") {
+                      cor.coef.name = "R", p.coef.name = "p", conf.level = 0.95) {
   # Overwritting digits by accuracy, if specified
   if (!is.null(p.accuracy)) {
     nb_decimal_places <- round(abs(log10(p.accuracy)))
@@ -235,8 +262,20 @@ StatCor <- ggproto("StatCor", Stat,
   .cor <- suppressWarnings(stats::cor.test(
     x, y,
     method = method, alternative = alternative,
+    conf.level = conf.level,
     use = "complete.obs"
   ))
+  # Confidence interval of the correlation coefficient (#418). Only Pearson's
+  # cor.test() returns a conf.int (and only for n >= 4); Spearman/Kendall do not,
+  # so the bounds are NA in those cases (never an error).
+  ci <- .cor$conf.int
+  if (is.null(ci) || length(ci) < 2) {
+    conf.low.value <- NA_real_
+    conf.high.value <- NA_real_
+  } else {
+    conf.low.value <- ci[1]
+    conf.high.value <- ci[2]
+  }
   # Root Mean Square Deviation (RMSE/RMSD) between x and y, computed on the same
   # complete pairs used by cor.test() (#458). Meaningful when x and y are on the
   # same scale (e.g. predicted vs. reference values).
@@ -244,12 +283,15 @@ StatCor <- ggproto("StatCor", Stat,
   rmse.value <- sqrt(mean((x[ok] - y[ok])^2))
 
   estimate <- p.value <- p <- r <- rr <- rmse <- NULL
+  conf.int.low <- conf.int.high <- NULL
   z <- data.frame(estimate = .cor$estimate, p.value = .cor$p.value, method = method) %>%
     mutate(
       r = signif(estimate, r.digits),
       rr = signif(estimate^2, r.digits),
       p = signif(p.value, p.digits),
-      rmse = signif(rmse.value, r.digits)
+      rmse = signif(rmse.value, r.digits),
+      conf.int.low = signif(conf.low.value, r.digits),
+      conf.int.high = signif(conf.high.value, r.digits)
     )
 
   # Defining p and r labels
@@ -276,6 +318,11 @@ StatCor <- ggproto("StatCor", Stat,
       ),
       rmse.label = get_rmse_label(
         rmse.value, accuracy = r.accuracy, digits = r.digits, type = output.type
+      ),
+      conf.int.label = get_conf_int_label(
+        conf.low.value, conf.high.value, conf.level = conf.level,
+        accuracy = r.accuracy, digits = r.digits,
+        leading.zero = r.leading.zero, type = output.type
       )
     )
 
@@ -442,6 +489,37 @@ get_rmse_label <- function(x, accuracy = NULL, digits = 2, type = "expression") 
     label <- gsub(pattern = "RMSE = ", replacement = "italic(RMSE)~`=`~", x = label, fixed = TRUE)
   }
   label
+}
+
+# Format the confidence interval label of the correlation coefficient (#418),
+# e.g. "95% CI [0.21, 0.75]". Returns NA when the CI is unavailable (Spearman /
+# Kendall / n < 4). For the expression output the whole label is a single quoted
+# plotmath string, so the percent sign and the brackets render literally and the
+# bounds are not re-normalized (e.g. a dropped leading zero survives).
+get_conf_int_label <- function(low, high, conf.level = 0.95, accuracy = NULL,
+                               digits = 2, leading.zero = NULL, type = "expression") {
+  if (length(low) == 0 || length(high) == 0 || is.na(low) || is.na(high)) {
+    return(NA_character_)
+  }
+  fmt <- function(x) {
+    if (is.null(accuracy)) {
+      value <- as.character(signif(x, digits))
+    } else {
+      nb_decimal_places <- round(abs(log10(accuracy)))
+      value <- formatC(x, digits = nb_decimal_places, format = "f", decimal.mark = ".")
+    }
+    if (!is.null(leading.zero) && !leading.zero) {
+      value <- sub("^(-?)0\\.", "\\1.", value)
+    }
+    value
+  }
+  ci.prefix <- paste0(format(conf.level * 100), "% CI")
+  body <- paste0(ci.prefix, " [", fmt(low), ", ", fmt(high), "]")
+  if (type == "expression") {
+    # Quote the whole label so plotmath renders it literally.
+    body <- paste0("\"", body, "\"")
+  }
+  body
 }
 
 # In plotmath, a bare value whose leading zero was dropped (e.g. .87) is parsed

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -27,6 +27,7 @@ stat_cor(
   p.leading.zero = NULL,
   p.decimal.mark = NULL,
   p.coef.name = "p",
+  conf.level = 0.95,
   geom = "text",
   position = "identity",
   na.rm = FALSE,
@@ -128,6 +129,14 @@ uses \code{getOption("OutDec")}.}
 \code{output.type = "expression"} this should be a single valid plotmath
 symbol (e.g. \code{"P"}), since it is parsed as an expression.}
 
+\item{conf.level}{confidence level for the confidence interval of the
+correlation coefficient, used to compute the \code{conf.int.low},
+\code{conf.int.high} and \code{conf.int.label} computed variables (see the
+\strong{Computed variables} section). Default is 0.95. A confidence interval
+is only available for \code{method = "pearson"} (with at least 4 complete
+observations); for \code{"spearman"}/\code{"kendall"} the confidence-interval
+variables are \code{NA}.}
+
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
 can be used to override the default coupling between stats and geoms. The
@@ -187,8 +196,13 @@ Add correlation coefficients with p-values to a scatter plot. Can
  settings (\code{r.digits} / \code{r.accuracy}).} \item{r.label}{formatted
  label for the correlation coefficient} \item{rr.label}{formatted label for
  the squared correlation coefficient} \item{p.label}{label for the p-value}
- \item{rmse.label}{formatted label for the RMSE/RMSD} \item{label}{default
- label displayed by \code{stat_cor()}} }
+ \item{rmse.label}{formatted label for the RMSE/RMSD}
+ \item{conf.int.low, conf.int.high}{lower and upper bounds of the confidence
+ interval of the correlation coefficient (Pearson only; \code{NA} for
+ Spearman/Kendall), at the level given by \code{conf.level}}
+ \item{conf.int.label}{formatted label for the confidence interval, e.g.
+ \code{"95\% CI [0.21, 0.75]"} (\code{NA} when the interval is unavailable)}
+ \item{label}{default label displayed by \code{stat_cor()}} }
 }
 
 \examples{
@@ -231,6 +245,15 @@ sp + stat_cor(aes(label = after_stat(rmse.label)), label.x = 3)
 sp + stat_cor(
   aes(label = paste(after_stat(r.label), after_stat(rmse.label), sep = "~`,`~")),
   label.x = 3
+)
+
+# Show the confidence interval of the correlation coefficient (Pearson)
+sp + stat_cor(aes(label = after_stat(conf.int.label)), label.x = 3)
+
+# Correlation coefficient with its confidence interval
+sp + stat_cor(
+  aes(label = paste(after_stat(r.label), after_stat(conf.int.label), sep = "~`,`~")),
+  label.x = 1.5
 )
 
 # Color by groups and facet

--- a/tests/testthat/test-stat-cor-conf-int.R
+++ b/tests/testthat/test-stat-cor-conf-int.R
@@ -1,0 +1,88 @@
+context("test-stat-cor-conf-int")
+
+# stat_cor() exposes the confidence interval of the correlation coefficient as
+# computed variables conf.int.low, conf.int.high (numeric) and conf.int.label
+# (formatted), plus a conf.level argument (#418). Pearson only; NA otherwise.
+# Purely additive: the default label is unchanged.
+
+.cor_label <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  d <- b$data[[which(vapply(b$data, function(x) "label" %in% names(x), logical(1)))[1]]]
+  as.character(d$label)[1]
+}
+
+set.seed(1)
+.df <- data.frame(x = rnorm(30))
+.df$y <- .df$x * 0.5 + rnorm(30)
+.sp <- ggscatter(.df, "x", "y")
+
+test_that("the default stat_cor label is unchanged (no regression, #418)", {
+  # The default composed label is R + p only; the CI variables never join it.
+  lab <- .cor_label(.sp + stat_cor(p.accuracy = 0.001, r.accuracy = 0.01))
+  expect_match(lab, "^italic\\(R\\)~`=`~-?[0-9.]+\\*`,`~italic\\(p\\)~`=`~")
+  expect_false(grepl("CI", lab))
+})
+
+test_that("conf.int.label reports the Pearson CI (text output)", {
+  ci <- cor.test(.df$x, .df$y)$conf.int
+  lab <- .cor_label(
+    .sp + stat_cor(aes(label = after_stat(conf.int.label)), output.type = "text")
+  )
+  expect_equal(lab, paste0("95% CI [", signif(ci[1], 2), ", ", signif(ci[2], 2), "]"))
+})
+
+test_that("conf.int.label is valid plotmath and parses", {
+  lab <- .cor_label(.sp + stat_cor(aes(label = after_stat(conf.int.label))))
+  expect_match(lab, "^\"95% CI \\[")
+  expect_error(parse(text = lab), NA)
+})
+
+test_that("conf.level controls the interval and the label prefix", {
+  ci99 <- cor.test(.df$x, .df$y, conf.level = 0.99)$conf.int
+  lab <- .cor_label(
+    .sp + stat_cor(aes(label = after_stat(conf.int.label)),
+      output.type = "text", conf.level = 0.99)
+  )
+  expect_equal(lab, paste0("99% CI [", signif(ci99[1], 2), ", ", signif(ci99[2], 2), "]"))
+})
+
+test_that("conf.int.low/high numeric match cor.test bounds (Pearson)", {
+  ci <- cor.test(.df$x, .df$y)$conf.int
+  b <- ggplot2::ggplot_build(
+    .sp + stat_cor(aes(label = after_stat(paste(conf.int.low, conf.int.high))))
+  )
+  d <- b$data[[which(vapply(b$data, function(x) "label" %in% names(x), logical(1)))[1]]]
+  expect_equal(as.character(d$label)[1],
+               paste(signif(ci[1], 2), signif(ci[2], 2)))
+})
+
+test_that("conf.int variables are NA for Spearman and Kendall (no error)", {
+  for (m in c("spearman", "kendall")) {
+    lab <- .cor_label(
+      .sp + stat_cor(aes(label = after_stat(conf.int.label)),
+        method = m, output.type = "text")
+    )
+    expect_true(is.na(lab))
+  }
+})
+
+test_that("invalid conf.level is rejected with a clear error", {
+  expect_error(stat_cor(conf.level = 95), "between 0 and 1")
+  expect_error(stat_cor(conf.level = 2), "between 0 and 1")
+  expect_error(stat_cor(conf.level = -0.1), "between 0 and 1")
+  expect_error(stat_cor(conf.level = c(0.9, 0.95)), "single number")
+  expect_error(stat_cor(conf.level = NA), "between 0 and 1")
+  # valid values are accepted
+  expect_error(stat_cor(conf.level = 0.9), NA)
+})
+
+test_that("conf.int.label honors r.accuracy and r.leading.zero", {
+  ci <- cor.test(.df$x, .df$y)$conf.int
+  lab_acc <- .cor_label(
+    .sp + stat_cor(aes(label = after_stat(conf.int.label)),
+      output.type = "text", r.accuracy = 0.001)
+  )
+  expect_equal(lab_acc, paste0("95% CI [",
+    formatC(ci[1], digits = 3, format = "f"), ", ",
+    formatC(ci[2], digits = 3, format = "f"), "]"))
+})


### PR DESCRIPTION
Adds the ability to display the confidence interval of the correlation coefficient in `stat_cor()`, as requested in #418.

## What
`stat_cor()` now exposes three new computed variables and a `conf.level` argument:
- `conf.int.low`, `conf.int.high` — numeric bounds of the CI
- `conf.int.label` — formatted, e.g. `"95% CI [0.21, 0.75]"`
- `conf.level` — confidence level (default `0.95`)

```r
library(ggpubr)
sp <- ggscatter(mtcars, "wt", "mpg", add = "reg.line")

# CI alone
sp + stat_cor(aes(label = after_stat(conf.int.label)))

# Coefficient + CI
sp + stat_cor(aes(label = paste(after_stat(r.label), after_stat(conf.int.label), sep = "~`,`~")))

# a different confidence level
sp + stat_cor(aes(label = after_stat(conf.int.label)), conf.level = 0.99)
```

## Compatibility
- **Purely additive — the default `stat_cor()` label is unchanged.** The CI variables only appear when you map them via `after_stat()`.
- The confidence interval is provided by `stats::cor.test()` and is available for `method = "pearson"` only (and with at least 4 complete observations); it is `NA` for Spearman/Kendall (never an error).
- The CI bounds honor the existing `r.digits` / `r.accuracy` / `r.leading.zero` formatting knobs, and work with `output.type = "expression"`/`"text"`/`"latex"`/`"tex"`, per group and per facet.
- An out-of-range `conf.level` gives a clear error.

## Tests
- New `tests/testthat/test-stat-cor-conf-int.R`: CI value/formatting, `conf.level` control, NA for Spearman/Kendall, plotmath parsing, `conf.level` validation, and a default-label no-regression check.
- Full suite: 791 pass / 0 fail.

Fixes #418.