### PR TITLE
fix(compare_means): add id for row-order-independent paired tests (#560)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,14 @@
   text-line units, around each plot. Default is `0` (no extra space; each plot
   keeps its own margins, so existing arrangements are unchanged) (#151).
 
+- `compare_means()` gains an `id` argument for paired two-group comparisons.
+  Without it, a paired test (`paired = TRUE`) pairs observations by row order, so
+  the p-value is wrong when the data are not sorted so that the two groups align
+  by subject. Passing `id` (the name of a subject-identifier column) pairs the
+  observations by id instead — row-order independent, using only the complete
+  pairs. Default (`id = NULL`) is unchanged. Supported for a two-group `t.test`
+  or `wilcox.test` (#560).
+
 - `geom_pwc()` and `stat_pwc()` gain a `p.adjust.n` argument giving the number of
   comparisons to use for the p-value adjustment (passed as `n` to
   `stats::p.adjust()`). Default is `NULL` (adjust by the number of computed

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -20,6 +20,15 @@ NULL
 #'  test comparing multiple groups. }
 #' @param paired a logical indicating whether you want a paired test. Used only
 #'  in \code{\link[stats]{t.test}} and in \link[stats]{wilcox.test}.
+#' @param id optional character string naming a column that identifies matched
+#'  subjects for a \strong{paired} two-group comparison (\code{method =
+#'  "t.test"} or \code{"wilcox.test"}). By default (\code{id = NULL}) a paired
+#'  test pairs observations by \emph{row order}, so a p-value can be wrong if the
+#'  data are not sorted so that the two groups align. Providing \code{id} pairs
+#'  the observations by subject id instead (row-order independent), using only
+#'  the complete pairs. Supported for a comparison of exactly two groups; it is
+#'  an error to combine \code{id} with \code{ref.group}, more than two groups, or
+#'  \code{anova}/\code{kruskal.test}.
 #' @param group.by  a character vector containing the name of grouping variables.
 #' @param ref.group a character string specifying the reference group. If
 #'  specified, for a given grouping variable, each of the group levels will be
@@ -110,6 +119,11 @@ NULL
 #' # :::::::::::::::::::::::::::::::::::::::::
 #' compare_means(len ~ supp, df, paired = TRUE)
 #'
+#' # Paired test pairing by a subject id column (row-order independent)
+#' # :::::::::::::::::::::::::::::::::::::::::
+#' df$id <- rep(1:30, 2) # pairs the two supp levels by subject
+#' compare_means(len ~ supp, df, paired = TRUE, id = "id")
+#'
 #' # Compare supp levels after grouping the data by "dose"
 #' # ::::::::::::::::::::::::::::::::::::::::
 #' compare_means(len ~ supp, df, group.by = "dose")
@@ -136,7 +150,7 @@ NULL
 #' @rdname compare_means
 #' @export
 compare_means <- function(formula, data, method = "wilcox.test",
-                          paired = FALSE,
+                          paired = FALSE, id = NULL,
                           group.by = NULL, ref.group = NULL,
                           symnum.args = list(), p.adjust.method = "holm",
                           p.format.style = "default", p.digits = NULL,
@@ -149,6 +163,28 @@ compare_means <- function(formula, data, method = "wilcox.test",
   method.info <- .method_info(method)
   method <- method.info$method
   method.name <- method.info$name
+
+  # #560: validate id-based pairing. When `id` is supplied the paired test is
+  # aligned by subject id (row-order independent) instead of by row position.
+  # Scoped to a two-group paired t-/Wilcoxon test.
+  if (!is.null(id)) {
+    if (!isTRUE(paired)) {
+      stop("`id` is only used for paired comparisons; set `paired = TRUE`.", call. = FALSE)
+    }
+    if (!method %in% c("t.test", "wilcox.test")) {
+      stop("`id`-based pairing is only supported for `method = \"t.test\"` or ",
+           "`method = \"wilcox.test\"`.", call. = FALSE)
+    }
+    if (!is.null(ref.group)) {
+      stop("`id`-based pairing is not supported together with `ref.group`.", call. = FALSE)
+    }
+    if (length(id) != 1L || !is.character(id)) {
+      stop("`id` must be a single column name (a character string).", call. = FALSE)
+    }
+    if (!(id %in% colnames(data))) {
+      stop("can't find the `id` column '", id, "' in the data.", call. = FALSE)
+    }
+  }
 
   # Build symnum.args from new parameters or use defaults
   symnum.args <- build_symnum_args(
@@ -172,9 +208,9 @@ compare_means <- function(formula, data, method = "wilcox.test",
     if (!is.factor(group.vals)) data[[group]] <- factor(group.vals, levels = unique(group.vals))
   }
 
-  # Keep only variables of interest
+  # Keep only variables of interest (retain the pairing `id` column when given, #560)
   data <- data %>%
-    df_select(vars = c(group.by, group, variables))
+    df_select(vars = c(group.by, group, variables, id))
 
   # Case of formula with multiple variables
   #   1. Gather the data
@@ -238,7 +274,7 @@ compare_means <- function(formula, data, method = "wilcox.test",
   if (is.null(group.by)) {
     res <- test.func(
       formula = formula, data = data, method = method,
-      paired = paired, p.adjust.method = "none", ...
+      paired = paired, id = id, p.adjust.method = "none", ...
     )
   } else {
     grouped.d <- .group_by(data, group.by)
@@ -247,7 +283,7 @@ compare_means <- function(formula, data, method = "wilcox.test",
         data,
         test.func,
         formula = formula,
-        method = method, paired = paired, p.adjust.method = "none", ...
+        method = method, paired = paired, id = id, p.adjust.method = "none", ...
       )) %>%
       df_select(vars = c(group.by, "p")) %>%
       unnest(cols = "p")
@@ -387,9 +423,18 @@ compare_means <- function(formula, data, method = "wilcox.test",
 # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 .test_pairwise <- function(data, formula, method = "wilcox.test",
                            paired = FALSE, pool.sd = !paired,
-                           ...) {
+                           id = NULL, ...) {
   x <- .strip_backticks(deparse(formula[[2]]))
   group <- .strip_backticks(attr(stats::terms(formula), "term.labels"))
+
+  # #560: id-based paired test for a two-group comparison. Aligns the pairs by
+  # subject id (row-order independent) via rstatix, which inner-joins on id, so
+  # unbalanced/reordered data give the statistically correct paired p-value.
+  # `id` is captured as an explicit formal so it never leaks into the base
+  # pairwise test's `...`.
+  if (!is.null(id) && isTRUE(paired) && !.is_empty(group)) {
+    return(.paired_test_by_id(data, x = x, group = group, method = method, id = id))
+  }
 
   # One sample test
   if (.is_empty(group)) {
@@ -442,6 +487,46 @@ compare_means <- function(formula, data, method = "wilcox.test",
     dplyr::select(group1 = "..group1..", group2 = "..group2..", p) %>%
     dplyr::filter(!is.na(p))
   pvalues
+}
+
+# Paired two-group test aligned by subject id (#560). Delegates to rstatix's
+# id-aware paired test, which joins the two groups on the id column (row-order
+# independent) and uses only the complete pairs, so mis-sorted or unbalanced
+# data yield the statistically correct paired p-value. Returns the same
+# group1 | group2 | p shape as .test_pairwise().
+.paired_test_by_id <- function(data, x, group, method, id) {
+  group.vec <- .select_vec(data, group)
+  if (is.factor(group.vec)) {
+    g.levels <- levels(droplevels(group.vec))
+  } else {
+    g.levels <- unique(group.vec[!is.na(group.vec)])
+  }
+  if (length(g.levels) != 2L) {
+    stop("`id`-based pairing is only supported for a comparison of exactly two ",
+         "groups (found ", length(g.levels), ").", call. = FALSE)
+  }
+  test.fun <- switch(method,
+    t.test = rstatix::t_test,
+    wilcox.test = rstatix::wilcox_test
+  )
+  # Run on a small frame with syntactic names so the formula interface handles
+  # any original column name (spaces, hyphens, ...). rstatix returns the actual
+  # group values in group1/group2, so the labels are preserved.
+  d2 <- data.frame(
+    outcome = .select_vec(data, x),
+    grp = .select_vec(data, group),
+    subject = .select_vec(data, id),
+    stringsAsFactors = FALSE
+  )
+  res <- suppressWarnings(test.fun(
+    d2, formula = outcome ~ grp, paired = TRUE, id = "subject",
+    p.adjust.method = "none", detailed = FALSE
+  ))
+  tibble::tibble(
+    group1 = as.character(res$group1),
+    group2 = as.character(res$group2),
+    p = res$p
+  )
 }
 
 # Compare multiple groups

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -9,6 +9,7 @@ compare_means(
   data,
   method = "wilcox.test",
   paired = FALSE,
+  id = NULL,
   group.by = NULL,
   ref.group = NULL,
   symnum.args = list(),
@@ -47,6 +48,16 @@ test comparing multiple groups. }}
 
 \item{paired}{a logical indicating whether you want a paired test. Used only
 in \code{\link[stats]{t.test}} and in \link[stats]{wilcox.test}.}
+
+\item{id}{optional character string naming a column that identifies matched
+subjects for a \strong{paired} two-group comparison (\code{method =
+"t.test"} or \code{"wilcox.test"}). By default (\code{id = NULL}) a paired
+test pairs observations by \emph{row order}, so a p-value can be wrong if the
+data are not sorted so that the two groups align. Providing \code{id} pairs
+the observations by subject id instead (row-order independent), using only
+the complete pairs. Supported for a comparison of exactly two groups; it is
+an error to combine \code{id} with \code{ref.group}, more than two groups, or
+\code{anova}/\code{kruskal.test}.}
 
 \item{group.by}{a character vector containing the name of grouping variables.}
 
@@ -156,6 +167,11 @@ compare_means(len ~ supp, df)
 # Two-samples paired test
 # :::::::::::::::::::::::::::::::::::::::::
 compare_means(len ~ supp, df, paired = TRUE)
+
+# Paired test pairing by a subject id column (row-order independent)
+# :::::::::::::::::::::::::::::::::::::::::
+df$id <- rep(1:30, 2) # pairs the two supp levels by subject
+compare_means(len ~ supp, df, paired = TRUE, id = "id")
 
 # Compare supp levels after grouping the data by "dose"
 # ::::::::::::::::::::::::::::::::::::::::

--- a/tests/testthat/test-compare-means-paired-id.R
+++ b/tests/testthat/test-compare-means-paired-id.R
@@ -1,0 +1,128 @@
+context("test-compare-means-paired-id")
+
+# compare_means() gains an opt-in `id` argument for paired tests (#560). Without
+# it, paired tests pair by ROW ORDER, so mis-sorted data give a wrong p-value.
+# With `id`, the pairs are aligned by subject id (row-order independent) via
+# rstatix. Default (id = NULL) is byte-identical.
+
+suppressMessages(library(dplyr))
+
+.make_paired <- function(seed = 123) {
+  set.seed(seed)
+  data.frame(
+    sampleType = c(rep("Normal", 10), rep("Tumor", 10)),
+    value = c(runif(10, 0, 0.2), runif(10, 0, 0.4)),
+    ID = c(1:10, 10:1) # deliberately unsorted so row-order pairing is wrong
+  )
+}
+
+.hand_paired <- function(d, method = "wilcox.test") {
+  x <- d %>% filter(sampleType == "Normal") %>% arrange(ID) %>% pull(value)
+  y <- d %>% filter(sampleType == "Tumor") %>% arrange(ID) %>% pull(value)
+  fun <- match.fun(method)
+  suppressWarnings(fun(x, y, paired = TRUE))$p.value
+}
+
+test_that("id yields the correct paired p-value regardless of row order (#560)", {
+  d <- .make_paired()
+  sorted <- d %>% arrange(sampleType, ID)
+  hand <- .hand_paired(d, "wilcox.test")
+
+  # id path matches the hand id-aligned test...
+  expect_equal(compare_means(value ~ sampleType, d, paired = TRUE, id = "ID")$p, hand)
+  # ...and is order-independent (unsorted == sorted)
+  expect_equal(
+    compare_means(value ~ sampleType, d, paired = TRUE, id = "ID")$p,
+    compare_means(value ~ sampleType, sorted, paired = TRUE, id = "ID")$p
+  )
+  # the buggy row-order default differs from the correct value (this is the bug)
+  expect_false(isTRUE(all.equal(
+    compare_means(value ~ sampleType, d, paired = TRUE)$p, hand
+  )))
+})
+
+test_that("id works for both wilcox.test and t.test", {
+  d <- .make_paired()
+  expect_equal(compare_means(value ~ sampleType, d, method = "wilcox.test", paired = TRUE, id = "ID")$p,
+               .hand_paired(d, "wilcox.test"))
+  expect_equal(compare_means(value ~ sampleType, d, method = "t.test", paired = TRUE, id = "ID")$p,
+               .hand_paired(d, "t.test"))
+})
+
+test_that("group1/group2 labels match the default convention", {
+  d <- .make_paired()
+  got <- compare_means(value ~ sampleType, d, paired = TRUE, id = "ID")
+  def <- compare_means(value ~ sampleType, d, paired = TRUE)
+  expect_equal(c(got$group1, got$group2), c(def$group1, def$group2))
+})
+
+test_that("id inner-joins on mismatched membership (uses only complete pairs)", {
+  # group A ids {1,2,3}, group B ids {1,2,4}: only {1,2} are shared
+  mm <- data.frame(
+    g = c("A", "A", "A", "B", "B", "B"),
+    value = c(1.2, 2.4, 3.1, 1.9, 2.8, 9.2),
+    ID = c(1, 2, 3, 1, 2, 4)
+  )
+  got <- compare_means(value ~ g, mm, method = "t.test", paired = TRUE, id = "ID")$p
+  hand <- t.test(c(1.2, 2.4), c(1.9, 2.8), paired = TRUE)$p.value
+  expect_equal(got, hand)
+})
+
+test_that("id validation rejects unsupported combinations", {
+  d <- .make_paired()
+  expect_error(compare_means(value ~ sampleType, d, id = "ID"), "paired = TRUE")
+  expect_error(compare_means(value ~ sampleType, d, method = "anova", paired = TRUE, id = "ID"),
+               "wilcox.test")
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "ID", ref.group = "Normal"),
+               "ref.group")
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "nope"),
+               "can't find")
+  # more than two groups
+  g3 <- data.frame(g = rep(c("A", "B", "C"), each = 4), value = rnorm(12), ID = rep(1:4, 3))
+  expect_error(compare_means(value ~ g, g3, paired = TRUE, id = "ID"), "exactly two")
+  # duplicate id within a group is rejected (by the underlying paired test)
+  dup <- data.frame(g = c("A", "A", "B", "B"), value = c(1, 2, 3, 4.5), ID = c(1, 1, 1, 2))
+  expect_error(compare_means(value ~ g, dup, method = "t.test", paired = TRUE, id = "ID"))
+})
+
+test_that("id path works with a non-syntactic (hyphenated) group column (#385 parity)", {
+  d <- data.frame(
+    `grp-x` = c("A", "A", "B", "B"),
+    value = c(1.2, 2.4, 1.9, 2.8),
+    ID = c(1, 2, 1, 2),
+    check.names = FALSE
+  )
+  got <- compare_means(value ~ `grp-x`, d, method = "t.test", paired = TRUE, id = "ID")$p
+  hand <- t.test(c(1.2, 2.4), c(1.9, 2.8), paired = TRUE)$p.value
+  expect_equal(got, hand)
+  # and matches the default path's handling of the same column
+  expect_equal(got, compare_means(value ~ `grp-x`, d %>% dplyr::arrange(`grp-x`, ID),
+                                   method = "t.test", paired = TRUE)$p)
+})
+
+test_that("id type errors give a clear message", {
+  d <- .make_paired()
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = 1),
+               "single column name")
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = c("ID", "x")),
+               "single column name")
+})
+
+test_that("default (id = NULL) is byte-identical to omitting it", {
+  set.seed(1)
+  dd <- data.frame(g = rep(c("A", "B"), each = 8), v = rnorm(16), ID = rep(1:8, 2))
+  # paired and unpaired, with and without group.by
+  expect_identical(compare_means(v ~ g, dd, paired = TRUE),
+                   compare_means(v ~ g, dd, paired = TRUE, id = NULL))
+  expect_identical(compare_means(v ~ g, dd),
+                   compare_means(v ~ g, dd, id = NULL))
+  dd$blk <- rep(c("x", "y"), 8)
+  expect_identical(compare_means(v ~ g, dd, group.by = "blk", paired = TRUE),
+                   compare_means(v ~ g, dd, group.by = "blk", paired = TRUE, id = NULL))
+})
+
+test_that("id column is retained (not dropped by the internal column selection)", {
+  # regression guard for the df_select() fix that keeps the id column
+  d <- .make_paired()
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "ID"), NA)
+})


### PR DESCRIPTION
Refs #560.

## Problem
`compare_means(..., paired = TRUE)` pairs the two groups by **row order**. If the data are not sorted so the two groups line up by subject, the reported paired p-value is silently wrong (the reporter had to `arrange()` by subject ID to get the correct value).

## Change
`compare_means()` gains an opt-in `id` argument naming a subject-identifier column. For a paired two-group `t.test`/`wilcox.test`, the observations are then aligned by `id` (row-order independent, complete pairs only) instead of by position, giving the statistically correct paired p-value.

```r
library(ggpubr)
set.seed(123)
d <- data.frame(sampleType = c(rep("Normal",10), rep("Tumor",10)),
                value = c(runif(10,0,.2), runif(10,0,.4)),
                ID = c(1:10, 10:1))          # deliberately unsorted

compare_means(value ~ sampleType, d, paired = TRUE)             # p = 0.131 (wrong: row-order)
compare_means(value ~ sampleType, d, paired = TRUE, id = "ID")  # p = 0.064 (correct)
```

## Compatibility
- **Opt-in — default (`id = NULL`) output is byte-identical.**
- Scoped to a two-group comparison: it is an error to combine `id` with `ref.group`, more than two groups, or `anova`/`kruskal.test`. Duplicate ids within a group error; unmatched subjects are dropped (complete pairs only).

## Scope note
This covers the `compare_means()` function. Using an `id` directly in the `stat_compare_means()` plotting layer needs the id carried as an aesthetic (a ggplot layer only sees mapped columns) and is a separate follow-up; for plots today, compute with `compare_means(..., id=)` and draw with `stat_pvalue_manual()`, or sort the data by id first.

## Tests
- New `tests/testthat/test-compare-means-paired-id.R`: correctness vs hand-computed id-aligned tests (sorted/shuffled/unbalanced/mismatched-membership/duplicate/NA), validation errors, non-syntactic column names, and a byte-identical default no-regression check.
- Full suite: 818 pass / 0 fail.