### PR TITLE
feat(compare_means): broaden id to pairwise/ref.group; require rstatix >= 1.0.0 (#560)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     glue,
     polynom,
     rlang (>= 1.1.7),
-    rstatix (>= 0.7.3),
+    rstatix (>= 1.0.0),
     tibble,
     magrittr
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -99,13 +99,19 @@
   text-line units, around each plot. Default is `0` (no extra space; each plot
   keeps its own margins, so existing arrangements are unchanged) (#151).
 
-- `compare_means()` gains an `id` argument for paired two-group comparisons.
-  Without it, a paired test (`paired = TRUE`) pairs observations by row order, so
-  the p-value is wrong when the data are not sorted so that the two groups align
-  by subject. Passing `id` (the name of a subject-identifier column) pairs the
-  observations by id instead — row-order independent, using only the complete
-  pairs. Default (`id = NULL`) is unchanged. Supported for a two-group `t.test`
-  or `wilcox.test` (#560).
+- `compare_means()` gains an `id` argument for paired comparisons. Without it, a
+  paired test (`paired = TRUE`) pairs observations by row order, so the p-value is
+  wrong when the data are not sorted so that the compared groups align by subject.
+  Passing `id` (the name of a subject-identifier column) pairs the observations by
+  id instead — row-order independent, using only the complete pairs (via
+  `rstatix`, so the result matches a direct `rstatix::t_test()`/`wilcox_test()`
+  call). It works for a two-group, a pairwise (more than two groups) and a
+  `ref.group` comparison with `t.test`/`wilcox.test`. Default (`id = NULL`) is
+  unchanged (#560).
+
+- The minimum required `rstatix` version is now `>= 1.0.0` (the version that
+  introduced the `id` argument used by `compare_means(id = )`, and the
+  full-precision pairwise p-values relied on by the p-value formatting).
 
 - `geom_pwc()` and `stat_pwc()` gain a `p.adjust.n` argument giving the number of
   comparisons to use for the p-value adjustment (passed as `n` to

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -21,14 +21,15 @@ NULL
 #' @param paired a logical indicating whether you want a paired test. Used only
 #'  in \code{\link[stats]{t.test}} and in \link[stats]{wilcox.test}.
 #' @param id optional character string naming a column that identifies matched
-#'  subjects for a \strong{paired} two-group comparison (\code{method =
-#'  "t.test"} or \code{"wilcox.test"}). By default (\code{id = NULL}) a paired
-#'  test pairs observations by \emph{row order}, so a p-value can be wrong if the
-#'  data are not sorted so that the two groups align. Providing \code{id} pairs
-#'  the observations by subject id instead (row-order independent), using only
-#'  the complete pairs. Supported for a comparison of exactly two groups; it is
-#'  an error to combine \code{id} with \code{ref.group}, more than two groups, or
-#'  \code{anova}/\code{kruskal.test}.
+#'  subjects for a \strong{paired} comparison (\code{method = "t.test"} or
+#'  \code{"wilcox.test"}). By default (\code{id = NULL}) a paired test pairs
+#'  observations by \emph{row order}, so a p-value can be wrong if the data are
+#'  not sorted so that the compared groups align. Providing \code{id} pairs the
+#'  observations by subject id instead (row-order independent), using only the
+#'  complete pairs (per-comparison pairwise deletion, via \pkg{rstatix}). It
+#'  works for a two-group, a pairwise (more than two groups) and a
+#'  \code{ref.group} comparison; it is an error to combine \code{id} with
+#'  \code{anova}/\code{kruskal.test} or with \code{ref.group = ".all."}.
 #' @param group.by  a character vector containing the name of grouping variables.
 #' @param ref.group a character string specifying the reference group. If
 #'  specified, for a given grouping variable, each of the group levels will be
@@ -165,8 +166,10 @@ compare_means <- function(formula, data, method = "wilcox.test",
   method.name <- method.info$name
 
   # #560: validate id-based pairing. When `id` is supplied the paired test is
-  # aligned by subject id (row-order independent) instead of by row position.
-  # Scoped to a two-group paired t-/Wilcoxon test.
+  # aligned by subject id (row-order independent) instead of by row position,
+  # via rstatix, which handles two-group, pairwise and ref.group comparisons
+  # (per-comparison complete pairs). Only `ref.group = ".all."` (basemean, which
+  # duplicates each observation) is unsupported.
   if (!is.null(id)) {
     if (!isTRUE(paired)) {
       stop("`id` is only used for paired comparisons; set `paired = TRUE`.", call. = FALSE)
@@ -175,8 +178,8 @@ compare_means <- function(formula, data, method = "wilcox.test",
       stop("`id`-based pairing is only supported for `method = \"t.test\"` or ",
            "`method = \"wilcox.test\"`.", call. = FALSE)
     }
-    if (!is.null(ref.group)) {
-      stop("`id`-based pairing is not supported together with `ref.group`.", call. = FALSE)
+    if (!is.null(ref.group) && ref.group == ".all.") {
+      stop("`id`-based pairing is not supported with `ref.group = \".all.\"`.", call. = FALSE)
     }
     if (length(id) != 1L || !is.character(id)) {
       stop("`id` must be a single column name (a character string).", call. = FALSE)
@@ -489,22 +492,13 @@ compare_means <- function(formula, data, method = "wilcox.test",
   pvalues
 }
 
-# Paired two-group test aligned by subject id (#560). Delegates to rstatix's
-# id-aware paired test, which joins the two groups on the id column (row-order
-# independent) and uses only the complete pairs, so mis-sorted or unbalanced
-# data yield the statistically correct paired p-value. Returns the same
-# group1 | group2 | p shape as .test_pairwise().
+# Paired test(s) aligned by subject id (#560). Delegates to rstatix's id-aware
+# paired test, which joins groups on the id column (row-order independent) and
+# uses only the complete pairs per comparison, so mis-sorted or unbalanced data
+# yield the statistically correct paired p-value(s). Handles two-group and
+# pairwise (>2 groups) comparisons; ref.group is applied by the caller's
+# post-filter. Returns the same group1 | group2 | p shape as .test_pairwise().
 .paired_test_by_id <- function(data, x, group, method, id) {
-  group.vec <- .select_vec(data, group)
-  if (is.factor(group.vec)) {
-    g.levels <- levels(droplevels(group.vec))
-  } else {
-    g.levels <- unique(group.vec[!is.na(group.vec)])
-  }
-  if (length(g.levels) != 2L) {
-    stop("`id`-based pairing is only supported for a comparison of exactly two ",
-         "groups (found ", length(g.levels), ").", call. = FALSE)
-  }
   test.fun <- switch(method,
     t.test = rstatix::t_test,
     wilcox.test = rstatix::wilcox_test

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -50,14 +50,15 @@ test comparing multiple groups. }}
 in \code{\link[stats]{t.test}} and in \link[stats]{wilcox.test}.}
 
 \item{id}{optional character string naming a column that identifies matched
-subjects for a \strong{paired} two-group comparison (\code{method =
-"t.test"} or \code{"wilcox.test"}). By default (\code{id = NULL}) a paired
-test pairs observations by \emph{row order}, so a p-value can be wrong if the
-data are not sorted so that the two groups align. Providing \code{id} pairs
-the observations by subject id instead (row-order independent), using only
-the complete pairs. Supported for a comparison of exactly two groups; it is
-an error to combine \code{id} with \code{ref.group}, more than two groups, or
-\code{anova}/\code{kruskal.test}.}
+subjects for a \strong{paired} comparison (\code{method = "t.test"} or
+\code{"wilcox.test"}). By default (\code{id = NULL}) a paired test pairs
+observations by \emph{row order}, so a p-value can be wrong if the data are
+not sorted so that the compared groups align. Providing \code{id} pairs the
+observations by subject id instead (row-order independent), using only the
+complete pairs (per-comparison pairwise deletion, via \pkg{rstatix}). It
+works for a two-group, a pairwise (more than two groups) and a
+\code{ref.group} comparison; it is an error to combine \code{id} with
+\code{anova}/\code{kruskal.test} or with \code{ref.group = ".all."}.}
 
 \item{group.by}{a character vector containing the name of grouping variables.}
 

--- a/tests/testthat/test-compare-means-paired-id.R
+++ b/tests/testthat/test-compare-means-paired-id.R
@@ -73,16 +73,39 @@ test_that("id validation rejects unsupported combinations", {
   expect_error(compare_means(value ~ sampleType, d, id = "ID"), "paired = TRUE")
   expect_error(compare_means(value ~ sampleType, d, method = "anova", paired = TRUE, id = "ID"),
                "wilcox.test")
-  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "ID", ref.group = "Normal"),
-               "ref.group")
   expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "nope"),
                "can't find")
-  # more than two groups
-  g3 <- data.frame(g = rep(c("A", "B", "C"), each = 4), value = rnorm(12), ID = rep(1:4, 3))
-  expect_error(compare_means(value ~ g, g3, paired = TRUE, id = "ID"), "exactly two")
+  # ref.group = ".all." (basemean) is unsupported with id
+  expect_error(compare_means(value ~ sampleType, d, paired = TRUE, id = "ID", ref.group = ".all."),
+               "\\.all\\.")
   # duplicate id within a group is rejected (by the underlying paired test)
   dup <- data.frame(g = c("A", "A", "B", "B"), value = c(1, 2, 3, 4.5), ID = c(1, 1, 1, 2))
   expect_error(compare_means(value ~ g, dup, method = "t.test", paired = TRUE, id = "ID"))
+})
+
+test_that("id works for pairwise (>2 groups) comparisons, matching rstatix (#560)", {
+  set.seed(3)
+  d <- data.frame(g = rep(c("A", "B", "C"), each = 8),
+                  value = rnorm(24),
+                  ID = c(1:8, sample(1:8), sample(1:8)))  # unsorted
+  got <- compare_means(value ~ g, d, method = "wilcox.test", paired = TRUE, id = "ID")
+  ref <- rstatix::wilcox_test(d, value ~ g, paired = TRUE, id = "ID", p.adjust.method = "none")
+  # same set of comparisons and p-values as a direct rstatix call
+  key <- function(x) paste(x$group1, x$group2, signif(x$p, 6))
+  expect_setequal(key(got), key(ref))
+  expect_equal(nrow(got), 3L)  # A-B, A-C, B-C
+})
+
+test_that("id works together with ref.group (only ref comparisons, matching rstatix)", {
+  set.seed(4)
+  d <- data.frame(g = rep(c("ctrl", "t1", "t2"), each = 8),
+                  value = rnorm(24), ID = c(1:8, sample(1:8), sample(1:8)))
+  got <- compare_means(value ~ g, d, method = "t.test", paired = TRUE, id = "ID", ref.group = "ctrl")
+  expect_equal(nrow(got), 2L)                 # ctrl vs t1, ctrl vs t2
+  expect_true(all(got$group1 == "ctrl"))      # ref is always group1
+  ref <- rstatix::t_test(d, value ~ g, paired = TRUE, id = "ID", ref.group = "ctrl",
+                         p.adjust.method = "none")
+  expect_equal(sort(got$p), sort(ref$p))
 })
 
 test_that("id path works with a non-syntactic (hyphenated) group column (#385 parity)", {


### PR DESCRIPTION
Refs #560.

## What
Makes `compare_means()`'s paired `id` argument consistent with `rstatix` and fixes an understated dependency floor.

1. **Broaden `id`.** The paired-`id` comparison (added earlier) supported only a two-group comparison and errored on `ref.group` / more than two groups. It now matches `rstatix`: `id` works for a **two-group**, a **pairwise (more than two groups)**, and a **`ref.group`** comparison — delegating to `rstatix::t_test()`/`wilcox_test(id = )`, which use only the complete pairs per comparison. Only `ref.group = ".all."` (basemean, which duplicates observations) stays unsupported.

```r
library(ggpubr)
# pairwise, matched by subject id (row-order independent)
compare_means(value ~ group, df, paired = TRUE, id = "subject")
# treatments vs a reference control, matched by id
compare_means(value ~ group, df, paired = TRUE, id = "subject", ref.group = "ctrl")
```

The result matches a direct `rstatix::wilcox_test(df, value ~ group, paired = TRUE, id = "subject")`.

2. **Bump the `rstatix` floor to `>= 1.0.0`.** `compare_means(id = )` calls `rstatix::wilcox_test/t_test(id = )`, and the `id` argument was introduced in `rstatix` 1.0.0. The previous `DESCRIPTION` floor (`>= 0.7.3`) would fail with `"unused argument (id = ...)"` on older `rstatix`. (ggpubr already relies on `rstatix` 1.0.0's full-precision p-values for the p-value formatting.)

## Compatibility
- **Default (`id = NULL`) output is byte-identical.** Only the cases that previously errored (`>2` groups, `ref.group`) now work; two-group `id` behavior is unchanged.

## Tests
- `tests/testthat/test-compare-means-paired-id.R`: added pairwise and `ref.group` correctness checks (equal to a direct `rstatix` call), updated the validation tests (`ref.group = ".all."` errors; the old "exactly two groups" restriction is gone), and kept the default-byte-identical no-regression check.
- Full suite: 832 pass / 0 fail.

Note: the `stat_compare_means()` plotting layer will get `id` in a follow-up (that closes #560).