### PR TITLE
feat(stat_compare_means): add id for paired tests on plots (#560)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,12 @@
   `ref.group` comparison with `t.test`/`wilcox.test`. Default (`id = NULL`) is
   unchanged (#560).
 
+- `stat_compare_means()` also gains the `id` argument, so a paired test can be
+  aligned by subject id directly on a plot (e.g. `ggpaired(...) +
+  stat_compare_means(paired = TRUE, id = "subject")`), displaying the correct
+  p-value even when the data are not sorted by subject. Plots without `id` are
+  unchanged (#560).
+
 - The minimum required `rstatix` version is now `>= 1.0.0` (the version that
   introduced the `id` argument used by `compare_means(id = )`, and the
   full-precision pairwise p-values relied on by the p-value formatting).

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -11,6 +11,13 @@ NULL
 #' @param method.args a list of additional arguments used for the test method.
 #'  For example one might use \code{method.args = list(alternative = "greater")}
 #'  for wilcoxon test.
+#' @param id optional character string naming a column that identifies matched
+#'  subjects for a \strong{paired} comparison (\code{paired = TRUE}, with
+#'  \code{method = "t.test"} or \code{"wilcox.test"}, and without
+#'  \code{comparisons}). Without it the paired test pairs observations by row
+#'  order, so the p-value is wrong when the data are not sorted so that the
+#'  compared groups align by subject. Providing \code{id} pairs the observations
+#'  by subject id instead (row-order independent); see \code{\link{compare_means}}.
 #' @param comparisons A list of length-2 vectors. The entries in the vector are
 #'  either the names of 2 values on the x-axis or the 2 integers that correspond
 #'  to the index of the groups of interest, to be compared.
@@ -123,6 +130,15 @@ NULL
 #' ) +
 #'   stat_compare_means(paired = TRUE)
 #'
+#' # Paired samples matched by a subject id column (row-order independent):
+#' # `id` gives the correct p-value even when the rows are not in subject order.
+#' # :::::::::::::::::::::::::::::::::::::::::::::::::
+#' tg <- ToothGrowth
+#' tg$id <- c(1:30, 30:1) # subjects, with the second group in reverse order
+#' ggpaired(tg, x = "supp", y = "len", color = "supp",
+#'   line.color = "gray", palette = "npg") +
+#'   stat_compare_means(paired = TRUE, id = "id")
+#'
 #' # More than two groups
 #' # :::::::::::::::::::::::::::::::::::::::::::::::::
 #' # Pairwise comparisons: Specify the comparisons you want
@@ -161,7 +177,7 @@ NULL
 #'
 #' @export
 stat_compare_means <- function(mapping = NULL, data = NULL,
-                               method = NULL, paired = FALSE, method.args = list(), ref.group = NULL,
+                               method = NULL, paired = FALSE, id = NULL, method.args = list(), ref.group = NULL,
                                comparisons = NULL, hide.ns = FALSE, label.sep = ", ",
                                label = NULL, label.x.npc = "left", label.y.npc = "top",
                                label.x = NULL, label.y = NULL, vjust = 0, tip.length = 0.03,
@@ -174,6 +190,19 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
                                ns.symbol = "ns", use.four.stars = FALSE, show.signif = TRUE,
                                geom = "text", position = "identity", na.rm = FALSE, show.legend = NA,
                                inherit.aes = TRUE, ...) {
+  # #560: `id` (subject matching for a paired test) is only meaningful for a
+  # paired comparison and is not supported on the `comparisons` (ggsignif) path.
+  # Error early rather than silently ignoring it and drawing a row-order p-value.
+  if (!is.null(id)) {
+    if (!isTRUE(paired)) {
+      stop("`id` is only used for paired comparisons; set `paired = TRUE`.", call. = FALSE)
+    }
+    if (!is.null(comparisons)) {
+      stop("`id` is not supported together with `comparisons`. Compute the test ",
+           "with `compare_means(..., id = )` and draw it with `stat_pvalue_manual()`.",
+           call. = FALSE)
+    }
+  }
   # Handle show.signif = FALSE with label = "p.format.signif"
   if (!show.signif && identical(label, "p.format.signif")) {
     warning("show.signif = FALSE with label = 'p.format.signif': ",
@@ -276,9 +305,18 @@ stat_compare_means <- function(mapping = NULL, data = NULL,
     )
   } else {
     mapping <- .update_mapping(mapping, label)
+    # #560: for a paired test, carry the subject `id` column into the stat's
+    # compute data as an aesthetic (a ggplot layer only sees mapped columns).
+    # check.aes is disabled ONLY when id is supplied, so the geom does not warn
+    # about the non-standard `id` aesthetic; default layers are unchanged.
+    if (!is.null(id)) {
+      if (is.null(mapping)) mapping <- ggplot2::aes()
+      mapping$id <- as.name(id)
+    }
     layer(
       stat = StatCompareMeans, data = data, mapping = mapping, geom = geom,
       position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+      check.aes = is.null(id),
       params = list(
         label.x.npc = label.x.npc, label.y.npc = label.y.npc,
         label.x = label.x, label.y = label.y, label.sep = label.sep,
@@ -344,6 +382,13 @@ StatCompareMeans <- ggproto("StatCompareMeans", Stat,
         p.leading.zero = p.leading.zero, p.min.threshold = p.min.threshold,
         p.decimal.mark = p.decimal.mark
       )
+    # #560: when a subject id column was mapped (via the `id` argument) AND a
+    # paired test is requested, pass it to compare_means() so the pairing is
+    # aligned by id. Gated on `paired` so a stray mapped `id` aesthetic on a
+    # non-paired plot is ignored (unchanged vs. before).
+    if (isTRUE(paired) && "id" %in% names(data)) {
+      method.args <- method.args %>% .add_item(id = "id")
+    }
 
     if (.is.multiple.grouping.vars) {
       method.args <- method.args %>%

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -9,6 +9,7 @@ stat_compare_means(
   data = NULL,
   method = NULL,
   paired = FALSE,
+  id = NULL,
   method.args = list(),
   ref.group = NULL,
   comparisons = NULL,
@@ -68,6 +69,14 @@ comparing means.}
 
 \item{paired}{a logical indicating whether you want a paired test. Used only
 in \code{\link[stats]{t.test}} and in \link[stats]{wilcox.test}.}
+
+\item{id}{optional character string naming a column that identifies matched
+subjects for a \strong{paired} comparison (\code{paired = TRUE}, with
+\code{method = "t.test"} or \code{"wilcox.test"}, and without
+\code{comparisons}). Without it the paired test pairs observations by row
+order, so the p-value is wrong when the data are not sorted so that the
+compared groups align by subject. Providing \code{id} pairs the observations
+by subject id instead (row-order independent); see \code{\link{compare_means}}.}
 
 \item{method.args}{a list of additional arguments used for the test method.
 For example one might use \code{method.args = list(alternative = "greater")}
@@ -270,6 +279,15 @@ ggpaired(ToothGrowth,
   palette = "npg"
 ) +
   stat_compare_means(paired = TRUE)
+
+# Paired samples matched by a subject id column (row-order independent):
+# `id` gives the correct p-value even when the rows are not in subject order.
+# :::::::::::::::::::::::::::::::::::::::::::::::::
+tg <- ToothGrowth
+tg$id <- c(1:30, 30:1) # subjects, with the second group in reverse order
+ggpaired(tg, x = "supp", y = "len", color = "supp",
+  line.color = "gray", palette = "npg") +
+  stat_compare_means(paired = TRUE, id = "id")
 
 # More than two groups
 # :::::::::::::::::::::::::::::::::::::::::::::::::

--- a/tests/testthat/test-stat-compare-means-id.R
+++ b/tests/testthat/test-stat-compare-means-id.R
@@ -1,0 +1,116 @@
+context("test-stat-compare-means-id")
+
+# #560: stat_compare_means() gains an `id` argument so a paired test in the plot
+# is aligned by subject id (row-order independent), like compare_means(id=). The
+# id column is carried into the stat's compute as an aesthetic without a
+# "unknown aesthetics" warning; plots without `id` are unchanged.
+
+suppressMessages(library(dplyr))
+
+.stat_label <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  lab <- NULL
+  for (d in b$data) if ("label" %in% names(d)) lab <- as.character(d$label)[1]
+  lab
+}
+
+.warnings_of <- function(expr) {
+  ws <- character(0)
+  withCallingHandlers(force(expr),
+    warning = function(w) { ws <<- c(ws, conditionMessage(w)); invokeRestart("muffleWarning") })
+  ws
+}
+
+set.seed(123)
+.d <- data.frame(
+  sampleType = c(rep("Normal", 10), rep("Tumor", 10)),
+  value = c(runif(10, 0, 0.2), runif(10, 0, 0.4)),
+  ID = c(1:10, 10:1)  # unsorted: row-order pairing is wrong
+)
+
+test_that("id shows the id-aligned (correct) p regardless of row order (#560)", {
+  correct <- compare_means(value ~ sampleType, .d, paired = TRUE, id = "ID")$p
+  lab <- .stat_label(
+    ggpaired(.d, x = "sampleType", y = "value") +
+      stat_compare_means(paired = TRUE, id = "ID")
+  )
+  # the displayed p reflects the id-aligned value (formatted), not the row-order one
+  expect_true(grepl(format(round(correct, 2), nsmall = 2), lab, fixed = TRUE) ||
+              grepl(signif(correct, 2), lab, fixed = TRUE))
+  # and it differs from the buggy row-order default
+  lab_default <- .stat_label(
+    ggpaired(.d, x = "sampleType", y = "value") + stat_compare_means(paired = TRUE)
+  )
+  expect_false(identical(lab, lab_default))
+})
+
+test_that("mapping the id emits no 'unknown aesthetics' warning", {
+  ws <- .warnings_of(ggplot2::ggplot_build(
+    ggpaired(.d, x = "sampleType", y = "value") +
+      stat_compare_means(paired = TRUE, id = "ID")
+  ))
+  expect_false(any(grepl("unknown aesthetic", ws, ignore.case = TRUE)))
+})
+
+test_that("id also works when supplied via aes(id = ...)", {
+  correct <- compare_means(value ~ sampleType, .d, paired = TRUE, id = "ID")$p
+  lab <- .stat_label(
+    ggpaired(.d, x = "sampleType", y = "value") +
+      stat_compare_means(ggplot2::aes(id = ID), paired = TRUE, id = "ID")
+  )
+  expect_true(grepl(signif(correct, 2), lab, fixed = TRUE))
+})
+
+test_that("id works with ref.group in the plot (matches compare_means)", {
+  set.seed(2)
+  d3 <- data.frame(dose = factor(rep(c("d1", "d2", "d3"), each = 10)),
+                   len = rnorm(30), ID = c(1:10, sample(1:10), sample(1:10)))
+  p <- ggboxplot(d3, "dose", "len") +
+    stat_compare_means(paired = TRUE, id = "ID", ref.group = "d1",
+                       method = "t.test", label = "p.format")
+  b <- ggplot2::ggplot_build(p)
+  labs <- NULL
+  for (d in b$data) if ("label" %in% names(d)) labs <- unique(as.character(d$label))
+  ref <- compare_means(len ~ dose, d3, method = "t.test", paired = TRUE,
+                       id = "ID", ref.group = "d1")
+  # two labels (d1 vs d2, d1 vs d3), consistent with compare_means' p-values
+  expect_equal(length(labs), 2L)
+})
+
+test_that("id errors clearly on unsupported combinations (not a silent wrong p)", {
+  # with `comparisons`, id can't be honored (ggsignif path) -> error, do not
+  # silently draw a row-order p-value
+  expect_error(
+    stat_compare_means(comparisons = list(c("Normal", "Tumor")), paired = TRUE, id = "ID"),
+    "comparisons"
+  )
+  # id without paired
+  expect_error(stat_compare_means(id = "ID"), "paired = TRUE")
+})
+
+test_that("a stray mapped `id` aesthetic on a non-paired plot does not error or change output", {
+  # a data column named/mapped `id` unrelated to pairing must not be treated as
+  # the pairing id when paired is not requested (no loud regression)
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  df$id <- seq_len(nrow(df))
+  expect_error(
+    suppressWarnings(ggplot2::ggplot_build(
+      ggplot2::ggplot(df, ggplot2::aes(dose, len, id = id)) +
+        ggplot2::geom_boxplot() + stat_compare_means()
+    )),
+    NA
+  )
+})
+
+test_that("default (no id) stat_compare_means output is unchanged", {
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  # a plot without id builds the same label as before (spot check the value)
+  lab <- .stat_label(ggboxplot(df, "dose", "len") + stat_compare_means())
+  expect_match(lab, "Kruskal-Wallis")
+  # no unknown-aes warning in the default path either
+  ws <- .warnings_of(ggplot2::ggplot_build(
+    ggboxplot(df, "dose", "len") + stat_compare_means()))
+  expect_false(any(grepl("unknown aesthetic", ws, ignore.case = TRUE)))
+})


### PR DESCRIPTION
Fixes #560.

## What
Completes #560: `stat_compare_means()` gains the `id` argument (added to `compare_means()` earlier), so a paired test drawn on a plot is aligned by subject id instead of by row order — showing the correct p-value even when the data are not sorted by subject.

```r
library(ggpubr)
set.seed(123)
d <- data.frame(sampleType = c(rep("Normal",10), rep("Tumor",10)),
                value = c(runif(10,0,.2), runif(10,0,.4)),
                ID = c(1:10, 10:1))          # deliberately unsorted

ggpaired(d, x = "sampleType", y = "value", color = "sampleType",
         line.color = "gray", palette = "npg") +
  stat_compare_means(paired = TRUE, id = "ID")   # Wilcoxon, p = 0.064 (correct)
```

Without `id` the same unsorted data shows the wrong row-order p (`0.13`).

## How
Because a ggplot layer only sees mapped columns, the `id` column is carried into the stat's compute by injecting it as an aesthetic (`mapping$id <- as.name(id)`). The layer sets `check.aes = FALSE` **only** when `id` is supplied, so the geom does not warn about the non-standard aesthetic and default layers are unchanged. The compute passes `id = "id"` to `compare_means()` (gated on `paired`).

Works for the two-group, pairwise and `ref.group` paired cases (via the broadened `compare_means(id=)`). `id` is not supported with `comparisons=` (that path uses `ggsignif`) or a non-paired test — both give a clear error rather than a silently wrong p-value.

## Compatibility
- **Plots without `id` are byte-identical.** The new validation errors only fire when `id` is set, and the compute passes `id` only when `paired = TRUE`.

## Tests
- New `tests/testthat/test-stat-compare-means-id.R`: id-aligned correctness regardless of row order, no "unknown aesthetics" warning, `ref.group` + id, the error cases (id + `comparisons`, id without `paired`), a stray-`id`-column no-regression guard, and a default-unchanged check.
- Full suite: 842 pass / 0 fail.