### PR TITLE
fix(ggbarplot): align error bars with dodged bars under position_dodge2() (#363)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -183,6 +183,14 @@
   their group. The jitter now dodges by the same width. Plots without a
   `position_dodge()` (the default `position = "identity"`) are unchanged (#436).
 
+- `ggbarplot()` now lines the error bars up with the bars when
+  `position = position_dodge2()` is used. `position_dodge2()` places elements
+  according to their own width, so the thin error bars did not sit on the centre
+  of the wider bars they belong to (most visible with `preserve = "single"` when
+  one x group has fewer bars than another). The error bars are now drawn at the
+  actual bar positions. Other positions (`identity`, `position_dodge()`,
+  `position_stack()`) are unchanged (#363).
+
 - `geom_bracket()` and `stat_pvalue_manual()` now place brackets correctly on a
   transformed y axis (e.g. `scale_y_log10()`). `y.position` is given in data units
   but was previously used directly in the scale's transformed space, so brackets
@@ -334,6 +342,10 @@
 ## Credits
 
 - Contributor: Laszlo Erdey (Faculty of Economics and Business, University of Debrecen, Hungary).
+- Thanks to @gumeo (#418), @byzheng (#608) and @JulesROBIN15 (#625) whose pull
+  requests proposed features shipped in this release: the `stat_cor()`
+  confidence interval, the `stat_cor()` RMSE label, and a manual number of
+  comparisons for p-value adjustment in `geom_pwc()`/`stat_pwc()`.
 
 # ggpubr 0.6.3
 

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -375,6 +375,32 @@ ggbarplot_core <- function(data, x, y,
         func = .get_summary_func(add), error.plot = error.plot
       )
     }
+  } else if (inherits(position, "PositionDodge2") &&
+             nb.bars.by.xposition >= 2 &&
+             any(.errorbar_functions() %in% add) &&
+             error.plot %in% .narrow_error_plots()) {
+    # position_dodge2() misplaces thin error bars relative to the dodged bars
+    # (#363). Draw any non-error add layers normally, then re-center the error
+    # bars on the actual bar positions.
+    p <- add.params %>%
+      .add_item(add = .remove_errorbar_func(add), position = add.position) %>%
+      do.call(ggadd, .)
+    cap.width <- (add.params$width %||% 0.1) / nb.bars.by.xposition
+    eb <- .geom_dodge2_errorbar(
+      p, data_sum, x, y,
+      color = add.params$color, fill = add.params$fill,
+      group = add.params$group, facet.by = facet.by,
+      func = .get_summary_func(add), error.plot = error.plot,
+      width = cap.width
+    )
+    if (!is.null(eb)) {
+      p <- p + eb
+    } else {
+      # Could not match centres -> keep the standard (unaligned) error layer
+      p <- add.params %>%
+        .add_item(add = .get_summary_func(add), position = add.position) %>%
+        do.call(ggadd, .)
+    }
   } else {
     p <- add.params %>%
       .add_item(add = add, position = add.position) %>%
@@ -487,6 +513,92 @@ ggbarplot_core <- function(data, x, y,
 
 .is_stacked <- function(p) {
   inherits(p$layers[[1]]$position, "PositionStack")
+}
+
+# Error plots that draw as a thin element (vertical line/cap or a point) and so
+# do NOT self-align with the wide bars under position_dodge2(). These are the
+# ones that need the manual re-centering done by .geom_dodge2_errorbar() (#363).
+.narrow_error_plots <- function() {
+  c(
+    "errorbar", "lower_errorbar", "upper_errorbar",
+    "pointrange", "lower_pointrange", "upper_pointrange",
+    "linerange", "lower_linerange", "upper_linerange"
+  )
+}
+
+# Aligned error bars for position_dodge2() bars (#363).
+# position_dodge2() packs elements according to their own width, so a thin error
+# bar is not placed on the centre of the wide bar it belongs to: bars and error
+# bars end up at different x (the reported bug). Here we read the actual dodged
+# bar centres from the built plot and redraw the error layer at those x with
+# position = "identity", so each error bar sits exactly on its bar while keeping
+# a normal thin cap. Only used for position_dodge2(); every other position keeps
+# the standard ggadd() path unchanged. Returns NULL (caller falls back) if the
+# centres cannot be matched.
+.geom_dodge2_errorbar <- function(p, data_sum, x, y, color = NULL, fill = NULL,
+                                  group = NULL, facet.by = NULL, func = "mean_se",
+                                  error.plot = "errorbar", width = 0.1) {
+  legend.var <- intersect(unique(c(color, fill, group)), colnames(data_sum))
+  if (length(legend.var) == 0) return(NULL)
+  legend.var <- legend.var[1]
+
+  # Error limits (centre +/- error), honouring upper_/lower_/both, from data_sum.
+  # Only symmetric summaries whose error half-width is a data_sum column are
+  # handled here (mean_se/sd/ci/range, median_iqr/mad/range). Asymmetric quantile
+  # summaries (median_hilow(_)/median_q1q3) have no such column and are NOT a
+  # centre +/- error, so we bail out (return NULL) and let the caller keep the
+  # standard path, which draws their correct (if unaligned) interval.
+  error <- .get_errorbar_error_func(func)
+  if (is.null(error) || !(error %in% colnames(data_sum))) return(NULL)
+  err.val <- data_sum[[error]]
+  limit <- unlist(strsplit(error.plot, "_", fixed = TRUE))[1]
+  if (!(limit %in% c("upper", "lower"))) limit <- "both"
+  yc <- data_sum[[y]]
+  ds <- data_sum
+  ds$.yc. <- yc
+  ds$.ymin. <- if (limit %in% c("both", "lower")) yc - err.val else yc
+  ds$.ymax. <- if (limit %in% c("both", "upper")) yc + err.val else yc
+
+  # Actual dodged bar centres from the built plot. Faceting is applied later (by
+  # .plotter), so build against a temporarily-faceted copy: dodge2 positions
+  # depend on which groups are present *within each panel*.
+  build.p <- p
+  if (!is.null(facet.by)) build.p <- p + ggplot2::facet_wrap(facet.by)
+  built <- ggplot2::ggplot_build(build.p)
+  bar.layer <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBar"), logical(1)))
+  if (length(bar.layer) == 0) return(NULL)
+  bd <- built$data[[bar.layer[1]]]
+  bd <- bd[order(bd$PANEL, bd$x), , drop = FALSE]
+
+  # Map each summary row to its panel, then to a bar centre. Bars are laid out
+  # per panel left-to-right by x tick then group; sorting data_sum the same way
+  # aligns it 1:1 with the ordered bar centres (robust to input row order).
+  layout <- built$layout$layout
+  if (!is.null(facet.by) && all(facet.by %in% colnames(layout))) {
+    ds <- dplyr::left_join(ds, layout[, c("PANEL", facet.by), drop = FALSE], by = facet.by)
+  } else {
+    ds$PANEL <- factor(1L)
+  }
+  as.int <- function(v) if (is.factor(v)) as.integer(v) else as.integer(factor(v))
+  ds <- ds[order(as.int(ds$PANEL), as.int(ds[[x]]), as.int(ds[[legend.var]])), , drop = FALSE]
+  if (nrow(ds) != nrow(bd)) return(NULL)
+  ds$.ebx. <- bd$x
+
+  geom.error <- .get_geom_error_function(error.plot)
+  color.is.var <- !is.null(color) && length(color) == 1 && color %in% colnames(ds)
+  if (color.is.var) {
+    mapping <- ggplot2::aes(
+      x = .data$.ebx., ymin = .data$.ymin., ymax = .data$.ymax.,
+      colour = .data[[color]]
+    )
+  } else {
+    mapping <- ggplot2::aes(x = .data$.ebx., ymin = .data$.ymin., ymax = .data$.ymax.)
+  }
+  if (identical(geom.error, ggplot2::geom_pointrange)) mapping$y <- ggplot2::aes(y = .data$.yc.)$y
+  opts <- list(data = ds, mapping = mapping, inherit.aes = FALSE, position = "identity")
+  if (!color.is.var && !is.null(color) && length(color) == 1) opts$colour <- color
+  if (identical(geom.error, ggplot2::geom_errorbar)) opts$width <- width
+  do.call(geom.error, opts)
 }
 
 # remove "mean_se", "mean_sd", etc

--- a/tests/testthat/test-ggbarplot-dodge2-errorbar.R
+++ b/tests/testthat/test-ggbarplot-dodge2-errorbar.R
@@ -1,0 +1,141 @@
+context("test-ggbarplot-dodge2-errorbar")
+
+# #363: with position_dodge2() the thin error bars did not line up with the
+# dodged bars (dodge2 packs elements by their own width, so a thin error bar
+# lands off the centre of its wide bar). ggbarplot() now re-centres the error
+# bars on the actual bar positions when position_dodge2() is used. Every other
+# position (identity / dodge / stack) keeps the standard path unchanged.
+
+.bar_x <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBar"), logical(1)))[1]
+  sort(as.numeric(round(b$data[[i]]$x, 4)))
+}
+.err_x <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(vapply(p$layers, function(l)
+    inherits(l$geom, c("GeomErrorbar", "GeomPointrange", "GeomLinerange")), logical(1)))[1]
+  sort(as.numeric(round(b$data[[i]]$x, 4)))
+}
+
+.reporter <- data.frame(
+  Treatment = c("+", "+", "+", "+", "+", "+", "-", "-", "-"),
+  Group     = c("a", "a", "a", "b", "b", "b", "a", "a", "a"),
+  Count     = c(12, 13, 11, 14, 15, 14, 23, 24, 25)
+)
+
+test_that("dodge2 error bars align with the bars (#363)", {
+  p <- ggbarplot(.reporter, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 position = position_dodge2(preserve = "single"))
+  expect_equal(.err_x(p), .bar_x(p))
+  # renders at draw time (positioning bugs often only surface on draw)
+  expect_silent(ggplot2::ggplotGrob(p))
+})
+
+test_that("alignment holds for both-sided errorbar, pointrange and linerange", {
+  for (ep in c("errorbar", "pointrange", "linerange")) {
+    p <- ggbarplot(.reporter, x = "Treatment", y = "Count", add = "mean_se",
+                   error.plot = ep, fill = "Group",
+                   position = position_dodge2(preserve = "single"))
+    expect_equal(.err_x(p), .bar_x(p), info = ep)
+  }
+})
+
+test_that("alignment is independent of input row order", {
+  shuffled <- .reporter[c(7, 1, 4, 8, 2, 5, 9, 3, 6), ]
+  p <- ggbarplot(shuffled, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 position = position_dodge2(preserve = "single"))
+  expect_equal(.err_x(p), .bar_x(p))
+})
+
+test_that("alignment holds for >2 groups with missing subgroups", {
+  d <- data.frame(
+    Treatment = factor(rep(c("+", "-"), c(9, 6)), levels = c("+", "-")),
+    Group = c(rep(c("a", "b", "c"), each = 3), rep(c("a", "c"), each = 3)),
+    Count = c(12, 13, 11, 14, 15, 14, 9, 10, 11, 23, 24, 25, 7, 8, 9)
+  )
+  p <- ggbarplot(d, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 position = position_dodge2(preserve = "single"))
+  expect_equal(.err_x(p), .bar_x(p))
+})
+
+test_that("alignment holds across facets", {
+  d <- data.frame(
+    Sex = rep(c("M", "F"), each = 9),
+    Treatment = factor(rep(rep(c("+", "-"), c(6, 3)), 2), levels = c("+", "-")),
+    Group = rep(c("a", "a", "a", "b", "b", "b", "a", "a", "a"), 2),
+    Count = c(12, 13, 11, 14, 15, 14, 23, 24, 25, 8, 9, 7, 11, 12, 10, 20, 21, 19)
+  )
+  p <- ggbarplot(d, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 facet.by = "Sex", position = position_dodge2(preserve = "single"))
+  expect_equal(.err_x(p), .bar_x(p))
+})
+
+# ---- No-regression: non-dodge2 positions are unchanged ----
+
+test_that("position_dodge() error bars are unchanged (still aligned)", {
+  p <- ggbarplot(.reporter, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 position = position_dodge(0.8))
+  # dodge (v1) has always aligned thin error bars; pin the exact positions
+  expect_equal(.err_x(p), c(0.8, 1.2, 2.0))
+  expect_equal(.bar_x(p), c(0.8, 1.2, 2.0))
+})
+
+test_that("stacked bars keep the dedicated stacked-errorbar path", {
+  d <- data.frame(
+    Treatment = rep(c("+", "-"), each = 4),
+    Group = rep(c("a", "b"), 4),
+    Count = c(12, 14, 13, 15, 23, 10, 24, 11)
+  )
+  p <- ggbarplot(d, x = "Treatment", y = "Count", add = "mean_se",
+                 error.plot = "upper_errorbar", fill = "Group",
+                 position = position_stack())
+  # stacked error bars sit at the x-tick centres (1 and 2), not dodged
+  expect_equal(.err_x(p), c(1, 1, 2, 2))
+  expect_silent(ggplot2::ggplotGrob(p))
+})
+
+test_that("asymmetric summaries (median_hilow/q1q3) keep correct interval under dodge2", {
+  # These are NOT centre +/- error, so the aligned path must bail out and let the
+  # standard path draw the real asymmetric interval (regression guard).
+  set.seed(1)
+  d <- data.frame(
+    T = rep(c("+", "-"), c(12, 6)),
+    G = c(rep(c("a", "b"), each = 6), rep("a", 6)),
+    Count = c(rnorm(12, 15, 3), rnorm(6, 24, 3))
+  )
+  .h <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+    sort(round(b$data[[i]]$ymax - b$data[[i]]$ymin, 3))
+  }
+  for (f in c("median_hilow", "median_q1q3")) {
+    p_d2 <- ggbarplot(d, "T", "Count", add = f, error.plot = "errorbar", fill = "G",
+                      position = position_dodge2(preserve = "single"))
+    p_d1 <- ggbarplot(d, "T", "Count", add = f, error.plot = "errorbar", fill = "G",
+                      position = position_dodge(0.8))
+    expect_equal(.h(p_d2), .h(p_d1), info = f)          # same interval as before
+    expect_true(all(.h(p_d2) > 0), info = f)            # not collapsed to zero
+  }
+})
+
+test_that("error bar colour follows the color argument (default black; grouped when mapped)", {
+  pd <- ggbarplot(.reporter, x = "Treatment", y = "Count", add = "mean_se",
+                  error.plot = "upper_errorbar", fill = "Group",
+                  position = position_dodge2(preserve = "single"))
+  b <- ggplot2::ggplot_build(pd)
+  ei <- which(vapply(pd$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+  expect_equal(unique(b$data[[ei]]$colour), "black")
+
+  pc <- ggbarplot(.reporter, x = "Treatment", y = "Count", add = "mean_se",
+                  error.plot = "upper_errorbar", fill = "Group", color = "Group",
+                  position = position_dodge2(preserve = "single"))
+  bc <- ggplot2::ggplot_build(pc)
+  eic <- which(vapply(pc$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+  expect_gt(length(unique(bc$data[[eic]]$colour)), 1)
+})


### PR DESCRIPTION
### Problem

With `position = position_dodge2()`, `ggbarplot(..., add = "mean_se")` drew the error bars off-center from their bars. `position_dodge2()` positions elements according to their own width, so a thin error bar does not land on the centre of the wider bar it belongs to. It is most visible with `preserve = "single"` when one x group has fewer bars than another (the reported case: two subgroups under one treatment, one subgroup under the other).

### Fix

`ggbarplot()` now reads the actual dodged bar positions and draws the error bars there when `position_dodge2()` is used, so each error bar sits on its bar while keeping a normal thin cap. Applies to `errorbar` / `pointrange` / `linerange` (and their `upper_`/`lower_` variants). All other positions (`identity`, `position_dodge()`, `position_stack()`) keep the standard path and are unchanged.

Asymmetric quantile summaries (`median_hilow`, `median_q1q3`) are not a centre ± error, so they keep the standard path and draw their correct interval.

### Before / after

The `+` treatment has subgroups `a` and `b`; the `-` treatment has only `a`.

| before | after |
|---|---|
| error bars shifted off their bars | error bars centered on every bar |

### Notes

- Default output for all non-`position_dodge2()` plots is unchanged.
- Adds tests for alignment (base, shuffled input, >2 groups with missing subgroups, facets, pointrange/linerange), the asymmetric-summary interval, colour, and the no-regression paths.

Addresses the error-bar alignment part of #363. The other part of that report — comparing means across unbalanced subgroups with `stat_compare_means()` — is separate and not changed here, so this does not close the issue.
