### PR TITLE
feat: add show.n to ggboxplot/ggviolin/ggstripchart for per-group observation counts (#598, #627)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,14 @@
 
 ## New features
 
+- `ggboxplot()`, `ggviolin()` and `ggstripchart()` gain an opt-in `show.n`
+  argument. When `show.n = TRUE`, the number of observations (`"n = <count>"`)
+  is displayed at the top of each group. When the groups are dodged (a
+  `color`/`fill` grouping with a dodging `position`), one count is shown per
+  group; otherwise a single count is shown per x-axis tick. Counts respect
+  `select`/`remove` and are computed per facet. Default is `show.n = FALSE`, so
+  existing plots are unchanged (#598, #627).
+
 - Passing `ggtheme = NULL` to the plotting functions (e.g. `ggscatter()`,
   `ggboxplot()`, `ggline()`, `gghistogram()`, ...) now skips applying a ggpubr
   theme, so the plot keeps ggplot2's default theme or the theme set globally with

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -61,6 +61,12 @@ NULL
 #' @param position position adjustment, either as a string, or the result of a
 #'  call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 #'  Used to control the spacing between grouped elements.
+#' @param show.n logical. If TRUE, displays the number of observations
+#'  (\code{"n = <count>"}) at the top of each group. Off by default. When the
+#'  groups are dodged (a \code{color}/\code{fill} grouping with a dodging
+#'  \code{position}), one count is shown per group; otherwise a single count is
+#'  shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
+#'  computed per facet.
 #' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 #'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'  theme_minimal(), theme_classic(), theme_void(), ....
@@ -170,7 +176,7 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
                       label = NULL, font.label = list(size = 11, color = "black"),
                       label.select = NULL, repel = FALSE, label.rectangle = FALSE,
                       position = position_dodge(0.8),
-                      ggtheme = theme_pubr(), ...) {
+                      ggtheme = theme_pubr(), show.n = FALSE, ...) {
   # Default options
   # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   .opts <- list(
@@ -211,6 +217,16 @@ ggboxplot <- function(data, x, y, combine = FALSE, merge = FALSE,
   # keeping an explicit NULL intact via single-bracket list assignment (#561).
   if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
+
+  if (isTRUE(show.n) && !missing(x)) {
+    if (.is_list(p)) {
+      p <- purrr::map(p, .add_show_n, x = x, color = color, fill = fill,
+                      facet.by = facet.by, position = position)
+    } else {
+      p <- .add_show_n(p, x = x, color = color, fill = fill,
+                       facet.by = facet.by, position = position)
+    }
+  }
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]
   return(p)

--- a/R/ggstripchart.R
+++ b/R/ggstripchart.R
@@ -118,6 +118,7 @@ ggstripchart <- function(data, x, y, combine = FALSE, merge = FALSE,
                          jitter = 0.2,
                          position = position_jitter(jitter, seed = 123),
                          ggtheme = theme_pubr(),
+                         show.n = FALSE,
                          ...) {
   # Default options
   # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -157,6 +158,16 @@ ggstripchart <- function(data, x, y, combine = FALSE, merge = FALSE,
   # keeping an explicit NULL intact via single-bracket list assignment (#561).
   if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
   p <- do.call(.plotter, .opts)
+
+  if (isTRUE(show.n) && !missing(x)) {
+    if (.is_list(p)) {
+      p <- purrr::map(p, .add_show_n, x = x, color = color, fill = fill,
+                      facet.by = facet.by, position = position)
+    } else {
+      p <- .add_show_n(p, x = x, color = color, fill = fill,
+                       facet.by = facet.by, position = position)
+    }
+  }
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]
   return(p)

--- a/R/ggviolin.R
+++ b/R/ggviolin.R
@@ -135,6 +135,7 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
                      label = NULL, font.label = list(size = 11, color = "black"),
                      label.select = NULL, repel = FALSE, label.rectangle = FALSE,
                      position = position_dodge(0.8), ggtheme = theme_pubr(),
+                     show.n = FALSE,
                      ...) {
   # Default options
   # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -178,6 +179,16 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
   if (!missing(ggtheme)) .opts["ggtheme"] <- list(ggtheme)
 
   p <- do.call(.plotter, .opts)
+
+  if (isTRUE(show.n) && !missing(x)) {
+    if (.is_list(p)) {
+      p <- purrr::map(p, .add_show_n, x = x, color = color, fill = fill,
+                      facet.by = facet.by, position = position)
+    } else {
+      p <- .add_show_n(p, x = x, color = color, fill = fill,
+                       facet.by = facet.by, position = position)
+    }
+  }
 
   if (.is_list(p) & length(p) == 1) p <- p[[1]]
   return(p)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1137,3 +1137,71 @@ keep_only_tbl_df_classes <- function(x) {
   }
   return(legend)
 }
+
+
+# show.n: per-group observation counts on box/violin/strip charts (#598, #627)
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Dodge width implied by a position (NULL = the layer is not dodged).
+.dodge_width_of <- function(position) {
+  if (is.null(position)) return(NULL)
+  if (is.character(position)) {
+    if (position %in% c("dodge", "dodge2")) return(0.8)
+    if (position == "jitterdodge") return(0.75)
+    return(NULL)
+  }
+  if (inherits(position, "PositionJitterdodge")) return(position$dodge.width %||% 0.75)
+  if (inherits(position, c("PositionDodge2", "PositionDodge"))) return(position$width %||% 0.8)
+  NULL
+}
+
+# Facet variables actually used by the plot. Reads them from the facet object so
+# the internal `.y.` panel of combine = TRUE is handled like any other facet.
+.plot_facet_vars <- function(p) {
+  f <- p$facet
+  if (is.null(f) || inherits(f, "FacetNull")) return(character(0))
+  pr <- f$params
+  unique(c(names(pr$facets), names(pr$rows), names(pr$cols)))
+}
+
+# Add "n = <count>" labels at the top of each panel, one per group. Counts are
+# taken from the plot's own data (so select/remove/order and combine's reshaped
+# data are respected). When the groups are dodged (a dodging position + a
+# colour/fill grouping), the labels dodge to sit above each box; otherwise a
+# single count per x tick is shown. Opt-in via show.n = TRUE; default output is
+# unchanged.
+.add_show_n <- function(p, x, color = NULL, fill = NULL, facet.by = NULL,
+                        position = NULL, size = 3.2, vjust = 1.4) {
+  d <- p$data
+  if (is.null(d) || !(x %in% colnames(d))) return(p)
+  group <- intersect(unique(c(color, fill)), colnames(d))
+  facet.vars <- intersect(unique(c(.plot_facet_vars(p), facet.by)), colnames(d))
+  dodge.w <- .dodge_width_of(position)
+  dodged <- length(group) > 0 && !is.null(dodge.w)
+  keys <- if (dodged) unique(c(facet.vars, x, group)) else unique(c(facet.vars, x))
+  keys <- intersect(keys, colnames(d))
+  cnt <- d %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(keys))) %>%
+    dplyr::summarise(.n = dplyr::n(), .groups = "drop") %>%
+    as.data.frame()
+  if (nrow(cnt) == 0) return(p)
+  cnt$.n. <- paste0("n = ", cnt$.n)
+  # y = Inf pins the label to the top of each panel (facet-robust); the .data
+  # pronoun keeps non-syntactic column names (spaces/hyphens) working.
+  if (dodged) {
+    # dodge by the interaction of all grouping columns, matching the boxes.
+    # Use a collision-proof temp column name (never a real data column).
+    grp.col <- ".ggpubr_show_n_grp."
+    cnt[[grp.col]] <- interaction(cnt[group], drop = TRUE, lex.order = TRUE)
+    mapping <- ggplot2::aes(
+      x = .data[[x]], y = Inf, label = .data$.n., group = .data[[grp.col]]
+    )
+    pos <- ggplot2::position_dodge(width = dodge.w)
+  } else {
+    mapping <- ggplot2::aes(x = .data[[x]], y = Inf, label = .data$.n.)
+    pos <- "identity"
+  }
+  p + ggplot2::geom_text(
+    data = cnt, mapping = mapping, position = pos, vjust = vjust,
+    size = size, colour = "black", inherit.aes = FALSE, show.legend = FALSE
+  )
+}

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -41,6 +41,7 @@ ggboxplot(
   label.rectangle = FALSE,
   position = position_dodge(0.8),
   ggtheme = theme_pubr(),
+  show.n = FALSE,
   ...
 )
 }
@@ -172,6 +173,13 @@ text, making it easier to read.}
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
+
+\item{show.n}{logical. If TRUE, displays the number of observations
+(\code{"n = <count>"}) at the top of each group. Off by default. When the
+groups are dodged (a \code{color}/\code{fill} grouping with a dodging
+\code{position}), one count is shown per group; otherwise a single count is
+shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
+computed per facet.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -35,6 +35,7 @@ ggstripchart(
   jitter = 0.2,
   position = position_jitter(jitter, seed = 123),
   ggtheme = theme_pubr(),
+  show.n = FALSE,
   ...
 )
 }
@@ -143,6 +144,13 @@ text, making it easier to read.}
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function. Used to adjust position for
 multiple groups.}
+
+\item{show.n}{logical. If TRUE, displays the number of observations
+(\code{"n = <count>"}) at the top of each group. Off by default. When the
+groups are dodged (a \code{color}/\code{fill} grouping with a dodging
+\code{position}), one count is shown per group; otherwise a single count is
+shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
+computed per facet.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -48,6 +48,7 @@ ggviolin(
   label.rectangle = FALSE,
   position = position_dodge(0.8),
   ggtheme = theme_pubr(),
+  show.n = FALSE,
   ...
 )
 }
@@ -186,6 +187,13 @@ text, making it easier to read.}
 \item{position}{position adjustment, either as a string, or the result of a
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
+
+\item{show.n}{logical. If TRUE, displays the number of observations
+(\code{"n = <count>"}) at the top of each group. Off by default. When the
+groups are dodged (a \code{color}/\code{fill} grouping with a dodging
+\code{position}), one count is shown per group; otherwise a single count is
+shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
+computed per facet.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-show-n.R
+++ b/tests/testthat/test-show-n.R
@@ -1,0 +1,109 @@
+context("test-show-n")
+
+# #598 / #627: ggboxplot(), ggviolin() and ggstripchart() gain an opt-in
+# `show.n` argument that prints the per-group number of observations at the top
+# of each group. Default (show.n = FALSE) adds nothing (byte-identical output).
+
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+
+.text_layer <- function(p) {
+  which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+}
+.n_labels <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- .text_layer(p)[1]
+  if (is.na(i)) return(character(0))
+  as.character(b$data[[i]]$label)
+}
+
+test_that("default show.n = FALSE adds no text layer (unchanged output)", {
+  for (fn in list(ggboxplot, ggviolin, ggstripchart)) {
+    p <- fn(df, "dose", "len")
+    expect_length(.text_layer(p), 0)
+  }
+})
+
+test_that("show.n = TRUE shows one count per x tick when ungrouped", {
+  for (fn in list(ggboxplot, ggviolin, ggstripchart)) {
+    p <- fn(df, "dose", "len", show.n = TRUE)
+    expect_equal(sort(.n_labels(p)), c("n = 20", "n = 20", "n = 20"))
+    expect_silent(ggplot2::ggplotGrob(p))
+  }
+})
+
+test_that("show.n = TRUE shows per-group counts for dodged box/violin", {
+  for (fn in list(ggboxplot, ggviolin)) {
+    p <- fn(df, "dose", "len", color = "supp", show.n = TRUE)
+    labs <- .n_labels(p)
+    expect_length(labs, 6)                 # 3 doses x 2 supp
+    expect_true(all(labs == "n = 10"))
+  }
+})
+
+test_that("stripchart adapts to its position (total when not dodged, per-group when jitterdodged)", {
+  # default position_jitter (points not dodged) -> total per x
+  p1 <- ggstripchart(df, "dose", "len", color = "supp", show.n = TRUE)
+  expect_equal(sort(.n_labels(p1)), c("n = 20", "n = 20", "n = 20"))
+  # position_jitterdodge -> per-group
+  p2 <- ggstripchart(df, "dose", "len", color = "supp",
+                     position = ggplot2::position_jitterdodge(), show.n = TRUE)
+  expect_length(.n_labels(p2), 6)
+  expect_true(all(.n_labels(p2) == "n = 10"))
+})
+
+test_that("counts respect select/remove (taken from the plotted data)", {
+  p <- ggboxplot(df, "dose", "len", select = c("0.5", "1"), show.n = TRUE)
+  expect_equal(sort(.n_labels(p)), c("n = 20", "n = 20"))
+
+  d2 <- rbind(df, data.frame(len = c(1, 2), supp = "OJ", dose = factor("0.5")))
+  p2 <- ggboxplot(d2, "dose", "len", show.n = TRUE)
+  # dose 0.5 now has 22 observations
+  b <- ggplot2::ggplot_build(p2)
+  labs <- as.character(b$data[[.text_layer(p2)[1]]]$label)
+  expect_true("n = 22" %in% labs)
+})
+
+test_that("show.n works with facets (one set of counts per panel)", {
+  p <- ggboxplot(df, "dose", "len", color = "supp", facet.by = "supp", show.n = TRUE)
+  expect_length(.n_labels(p), 6)
+  expect_silent(ggplot2::ggplotGrob(p))
+})
+
+test_that("show.n handles combine = TRUE per response variable (not double-counted)", {
+  df2 <- df
+  df2$len2 <- df2$len * 1.1
+  p <- ggboxplot(df2, "supp", c("len", "len2"), combine = TRUE, show.n = TRUE)
+  labs <- .n_labels(p)
+  expect_length(labs, 4)                       # 2 supp x 2 response panels
+  expect_true(all(labs == "n = 30"))           # not n = 60
+  expect_silent(ggplot2::ggplotGrob(p))
+})
+
+test_that("show.n with an empty selection does not error and adds no labels", {
+  p <- ggboxplot(df, "dose", "len", select = "does-not-exist", show.n = TRUE)
+  expect_length(.text_layer(p), 0)
+  expect_error(ggplot2::ggplot_build(p), NA)
+})
+
+test_that("show.n counts per box when color and fill map to different columns", {
+  d <- data.frame(
+    x = rep(c("A", "B"), each = 8),
+    s = rep(c("p", "q"), 8),
+    b = rep(rep(c("m", "n"), each = 2), 4),
+    y = 1:16
+  )
+  p <- ggboxplot(d, "x", "y", color = "s", fill = "b", show.n = TRUE)
+  labs <- .n_labels(p)
+  expect_length(labs, 8)                        # 2 x * (2 s * 2 b)
+  expect_true(all(labs == "n = 2"))
+})
+
+test_that("show.n counts each group correctly on an unbalanced dataset", {
+  d <- data.frame(
+    g = c("a", "a", "a", "b", "b"),
+    y = c(1, 2, 3, 4, 5)
+  )
+  p <- ggboxplot(d, "g", "y", show.n = TRUE)
+  expect_equal(sort(.n_labels(p)), c("n = 2", "n = 3"))
+})


### PR DESCRIPTION
### What

Adds an opt-in `show.n` argument to `ggboxplot()`, `ggviolin()` and `ggstripchart()`. When `show.n = TRUE`, the number of observations (`"n = <count>"`) is displayed at the top of each group — a frequently requested addition for publication-ready plots (#598).

```r
ggboxplot(ToothGrowth, "dose", "len", color = "supp", show.n = TRUE)
```

### Behaviour

- Default is `show.n = FALSE`, so existing plots are unchanged.
- When the groups are dodged (a `color`/`fill` grouping with a dodging `position`), one count is shown per group, positioned above its box/violin. Otherwise a single count is shown per x-axis tick.
- Counts are taken from the plotted data, so `select`/`remove`/`order` and `combine`'s reshaped data are respected, and counts are computed per facet.

### Notes

- Implemented as a small post-build step; `show.n` is never forwarded to the geoms, so default output is byte-identical.
- Adds tests covering ungrouped/grouped/dodged/faceted/combined cases, `select`, unbalanced groups, and the default-unchanged path.

Implements #598. Reimplements the feature proposed in #627 (thanks @mailis-L) cleanly against the current functions.
