### PR TITLE
feat(ggpaired): add jitter to spread paired points while keeping the pairing lines (#407)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,12 @@
 
 ## New features
 
+- `ggpaired()` gains an opt-in `jitter` argument that spreads the paired points
+  horizontally to reduce overlap. Each subject (`id`) gets a single offset, so
+  its two points move together and the connecting line stays intact, and only
+  the horizontal positions change (the values are never moved). Default
+  `jitter = 0` leaves the plot unchanged (#407).
+
 - `ggboxplot()`, `ggviolin()` and `ggstripchart()` gain an opt-in `show.n`
   argument. When `show.n = TRUE`, the number of observations (`"n = <count>"`)
   is displayed at the top of each group. When the groups are dodged (a

--- a/R/ggpaired.R
+++ b/R/ggpaired.R
@@ -18,6 +18,14 @@ NULL
 #' @param linetype line type.
 #' @param point.size,line.size point and line size, respectively.
 #' @param width box plot width.
+#' @param jitter numeric value (default 0, no jitter) giving the amount of
+#'   horizontal jitter added to the paired points to reduce overlap. Points are
+#'   nudged sideways within \code{[-jitter, jitter]}; each subject (\code{id})
+#'   gets a single offset so its two points move together and the connecting
+#'   line stays intact. Only the horizontal positions change (the values are
+#'   never moved). Typical values are small relative to the box \code{width}
+#'   (e.g. \code{jitter = 0.05} to \code{0.1}). \code{jitter = 0} leaves the plot
+#'   unchanged.
 #' @param ... other arguments to be passed to be passed to \link{ggpar}().
 #' @examples
 #'
@@ -50,6 +58,7 @@ ggpaired <- function(data, cond1, cond2, x = NULL, y = NULL, id = NULL,
                      label = NULL, font.label = list(size = 11, color = "black"),
                      label.select = NULL, repel = FALSE, label.rectangle = FALSE,
                      ggtheme = theme_pubr(),
+                     jitter = 0,
                      ...) {
   grouping.vars <- c(x, color, fill) %>%
     unique() %>%
@@ -80,7 +89,8 @@ ggpaired <- function(data, cond1, cond2, x = NULL, y = NULL, id = NULL,
     title = title, xlab = xlab, ylab = ylab,
     facet.by = facet.by, panel.labs = panel.labs, short.panel.labs = short.panel.labs,
     label = label, font.label = font.label, label.select = label.select,
-    repel = repel, label.rectangle = label.rectangle, ggtheme = ggtheme, ...
+    repel = repel, label.rectangle = label.rectangle, ggtheme = ggtheme,
+    jitter = jitter, ...
   )
 
   # User options
@@ -117,6 +127,7 @@ ggpaired_core <- function(data, x = NULL, y = NULL, id = NULL,
                           width = 0.5, point.size = 1.2, line.size = 0.5, line.color = "black",
                           linetype = "solid", title = NULL, xlab = "Condition", ylab = "Value",
                           ggtheme = theme_pubr(),
+                          jitter = 0,
                           ...) {
   if (!is.factor(data[[x]])) data[[x]] <- as.factor(data[[x]])
 
@@ -133,6 +144,31 @@ ggpaired_core <- function(data, x = NULL, y = NULL, id = NULL,
   }
   data$id <- id
 
+  # Optional horizontal jitter of the paired points (#407). Spreads the points
+  # to reduce overlap while keeping each pair's connecting line intact: one
+  # offset per subject id (so the connecting lines stay parallel and readable),
+  # applied to BOTH the points and the lines, and horizontal only (the values
+  # `y` are never moved). A fixed seed keeps a given plot reproducible; the
+  # caller's RNG stream is left untouched. Default jitter = 0 leaves the output
+  # exactly unchanged (no jittered-x column, no RNG use).
+  jitter.x <- NULL
+  if (!is.null(jitter) && length(jitter) == 1 && is.numeric(jitter) &&
+      !is.na(jitter) && jitter > 0) {
+    ids <- unique(data$id)
+    if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+      old.seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+      on.exit(assign(".Random.seed", old.seed, envir = .GlobalEnv), add = TRUE)
+    } else {
+      # no RNG used yet: remove the seed we are about to create, so ggpaired()
+      # leaves the caller's random stream exactly as it found it
+      on.exit(suppressWarnings(rm(".Random.seed", envir = .GlobalEnv)), add = TRUE)
+    }
+    set.seed(123)
+    offsets <- stats::runif(length(ids), -jitter, jitter)
+    names(offsets) <- as.character(ids)
+    data$.ggpubr.x.jitter. <- as.integer(data[[x]]) + offsets[as.character(data$id)]
+    jitter.x <- ".ggpubr.x.jitter."
+  }
 
   position <- "identity"
   # if(length(grouping.vars) > 1)
@@ -145,12 +181,12 @@ ggpaired_core <- function(data, x = NULL, y = NULL, id = NULL,
       position = position
     ) +
     geom_exec(geom_line,
-      data = data, group = "id",
+      data = data, x = jitter.x, group = "id",
       color = line.color, linewidth = line.size, linetype = linetype,
       position = position
     ) +
     geom_exec(geom_point,
-      data = data, color = color, size = point.size,
+      data = data, x = jitter.x, color = color, size = point.size,
       position = position
     )
 

--- a/man/ggpaired.Rd
+++ b/man/ggpaired.Rd
@@ -31,6 +31,7 @@ ggpaired(
   repel = FALSE,
   label.rectangle = FALSE,
   ggtheme = theme_pubr(),
+  jitter = 0,
   ...
 )
 }
@@ -63,6 +64,15 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 \item{width}{box plot width.}
 
 \item{point.size, line.size}{point and line size, respectively.}
+
+\item{jitter}{numeric value (default 0, no jitter) giving the amount of
+horizontal jitter added to the paired points to reduce overlap. Points are
+nudged sideways within \code{[-jitter, jitter]}; each subject (\code{id})
+gets a single offset so its two points move together and the connecting
+line stays intact. Only the horizontal positions change (the values are
+never moved). Typical values are small relative to the box \code{width}
+(e.g. \code{jitter = 0.05} to \code{0.1}). \code{jitter = 0} leaves the plot
+unchanged.}
 
 \item{line.color}{line color.}
 

--- a/tests/testthat/test-ggpaired-jitter.R
+++ b/tests/testthat/test-ggpaired-jitter.R
@@ -1,0 +1,71 @@
+context("test-ggpaired-jitter")
+
+# #407: ggpaired() gains an opt-in `jitter` argument that spreads the paired
+# points horizontally to reduce overlap, while keeping each pair's connecting
+# line intact (one offset per subject id) and never moving the values (y).
+# Default jitter = 0 leaves the output byte-identical.
+
+before <- c(200.1, 190.9, 192.7, 213, 241.4, 196.9, 172.2, 185.5, 205.2, 193.7)
+after  <- c(392.9, 393.2, 345.1, 393, 434, 427.9, 422, 383.9, 392.3, 352.2)
+d <- data.frame(before = before, after = after)
+
+.layers <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  pt <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1)))[1]
+  ln <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomLine"), logical(1)))[1]
+  list(pt = b$data[[pt]], ln = b$data[[ln]])
+}
+
+test_that("default jitter = 0 is byte-identical to omitting it", {
+  p_omit <- ggpaired(d, cond1 = "before", cond2 = "after", fill = "condition")
+  p_zero <- ggpaired(d, cond1 = "before", cond2 = "after", fill = "condition", jitter = 0)
+  expect_equal(ggplot2::ggplot_build(p_omit)$data, ggplot2::ggplot_build(p_zero)$data)
+  # points sit exactly on x = 1 and x = 2 (no spread)
+  expect_equal(sort(unique(round(.layers(p_zero)$pt$x, 6))), c(1, 2))
+})
+
+test_that("jitter > 0 spreads the points but does not move the values", {
+  p <- ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.1)
+  L <- .layers(p)
+  expect_gt(diff(range(L$pt$x)), 0.15)                 # horizontal spread
+  expect_equal(sort(L$pt$y), sort(c(before, after)))   # y untouched
+  expect_silent(ggplot2::ggplotGrob(p))
+})
+
+test_that("the connecting lines follow the jittered points", {
+  p <- ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.12)
+  L <- .layers(p)
+  lv <- as.matrix(L$ln[order(L$ln$x, L$ln$y), c("x", "y")])
+  pv <- as.matrix(L$pt[order(L$pt$x, L$pt$y), c("x", "y")])
+  expect_equal(lv, pv, tolerance = 1e-6)
+})
+
+test_that("jitter is paired: each subject's two points share the same offset", {
+  p <- ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.1)
+  pt <- .layers(p)$pt
+  cond <- ifelse(pt$x < 1.5, "before", "after")
+  ob <- (pt$x[cond == "before"] - 1)[order(match(round(pt$y[cond == "before"], 4), round(before, 4)))]
+  oa <- (pt$x[cond == "after"]  - 2)[order(match(round(pt$y[cond == "after"], 4),  round(after, 4)))]
+  expect_equal(ob, oa, tolerance = 1e-6)
+})
+
+test_that("jitter is reproducible across calls (fixed seed) and leaves the RNG untouched", {
+  p1 <- ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.1)
+  p2 <- ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.1)
+  expect_equal(.layers(p1)$pt$x, .layers(p2)$pt$x)
+
+  set.seed(999); r1 <- runif(3)
+  set.seed(999); invisible(ggpaired(d, cond1 = "before", cond2 = "after", jitter = 0.1)); r2 <- runif(3)
+  expect_equal(r1, r2)
+})
+
+test_that("jitter works in x/y mode with color and a supplied id", {
+  tg <- ToothGrowth
+  tg$id <- rep(1:30, 2)
+  p <- ggpaired(tg, x = "supp", y = "len", color = "supp", id = "id", jitter = 0.08)
+  L <- .layers(p)
+  lv <- as.matrix(L$ln[order(L$ln$x, L$ln$y), c("x", "y")])
+  pv <- as.matrix(L$pt[order(L$pt$x, L$pt$y), c("x", "y")])
+  expect_equal(lv, pv, tolerance = 1e-6)
+  expect_silent(ggplot2::ggplotGrob(p))
+})


### PR DESCRIPTION
### What

`ggpaired()` gains an opt-in `jitter` argument to spread the paired points horizontally and reduce overlap — a frequently requested addition (#407). Previously the points sat exactly on the two condition positions and overlapped (and `add="jitter"` had no effect, since `ggpaired()` has no `add` parameter).

```r
before <- c(200.1, 190.9, 192.7, 213, 241.4, 196.9, 172.2, 185.5, 205.2, 193.7)
after  <- c(392.9, 393.2, 345.1, 393, 434, 427.9, 422, 383.9, 392.3, 352.2)
d <- data.frame(before = before, after = after)

ggpaired(d, cond1 = "before", cond2 = "after", fill = "condition",
         palette = "jco", jitter = 0.08)
```

### Behaviour

- Default is `jitter = 0`, so existing plots are unchanged.
- Each subject (`id`) gets a single horizontal offset, so its two points move together and the connecting line stays intact and readable (the lines don't crisscross).
- Only the horizontal positions change — the values (`y`) are never moved.
- A fixed internal seed makes a given plot reproducible, and the caller's random-number stream is left untouched.

### Notes

- Works in both input modes (`cond1`/`cond2` and `x`/`y`), with `color`/`fill = "condition"`, facets, and a supplied or auto `id`.
- Adds tests for the byte-identical default, point spread, value integrity, line-follows-point, paired-offset, reproducibility, RNG hygiene, and the x/y mode.

Fixes #407.
