### PR TITLE
feat(geom_bracket): add orientation = 'vertical' for native vertical brackets (#456)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,14 @@
 
 ## New features
 
+- `geom_bracket()` gains an `orientation` argument. `orientation = "vertical"`
+  draws a native vertical bracket (the bar spans the y axis, the tips point left
+  and the label is rotated), specified with `ymin`/`ymax`/`x.position` — useful
+  to annotate plots where the comparison runs along the y axis, e.g.
+  Kaplan-Meier curves (it is designed for a continuous x axis). The default
+  `orientation = "horizontal"` is unchanged, and it cannot be combined with
+  `coord.flip = TRUE` (#456).
+
 - `ggpaired()` gains an opt-in `jitter` argument that spreads the paired points
   horizontally to reduce overlap. Each subject (`id`) gets a single offset, so
   its two points move together and the connecting line stays intact, and only

--- a/R/geom_bracket.R
+++ b/R/geom_bracket.R
@@ -18,6 +18,22 @@ NULL
   trans$transform
 }
 
+# Companion to .stat_bracket_y_transform: the INVERSE of a scale's transformation
+# (e.g. 10^x for a log10 scale), or NULL. Used by vertical brackets to undo the
+# x-scale transform that ggplot2 automatically applies to the xmin/xmax columns
+# (which, for a vertical bracket, actually carry y-axis values) before those are
+# re-expressed in the y scale (#456).
+.stat_bracket_scale_inverse <- function(scale) {
+  trans <- NULL
+  if (is.function(scale$get_transformation)) {
+    trans <- tryCatch(scale$get_transformation(), error = function(e) NULL)
+  }
+  if (is.null(trans)) trans <- scale$transformation
+  if (is.null(trans)) trans <- scale$trans
+  if (is.null(trans) || !is.function(trans$inverse)) return(NULL)
+  trans$inverse
+}
+
 StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
   required_aes = c("x", "y", "group"),
   setup_params = function(data, params) {
@@ -25,50 +41,107 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
     if (length(params$tip.length) == length(params$xmin)) params$tip.length <- rep(params$tip.length, each = 2)
     return(params)
   },
-  compute_group = function(data, scales, tip.length, tip.length.ref = "data") {
-    yrange <- scales$y$range$range
-    y.scale.range <- yrange[2] - yrange[1]
+  compute_group = function(data, scales, tip.length, tip.length.ref = "data",
+                           orientation = "horizontal") {
+    # A bracket has a SPAN axis (where its two ends sit) and a POSITION axis
+    # (where the connecting bar sits, with the tips extending toward the data).
+    # For the default horizontal bracket the span is x and the position is y.
+    # For a vertical bracket (#456) the axes swap: the span is y and the bar sits
+    # along x. Selecting the two scales here keeps the geometry identical for the
+    # horizontal (default) path while enabling the vertical one; every quantity
+    # that used to be tied to the y scale (tip length, step increase, the log
+    # transform) follows the POSITION axis, and the character/level mapping and
+    # the log transform of the ENDS follow the SPAN axis.
+    vertical <- identical(orientation, "vertical")
+    span.scale <- if (vertical) scales$y else scales$x
+    pos.scale <- if (vertical) scales$x else scales$y
+    pos.range <- pos.scale$range$range
+    if (is.numeric(pos.range)) {
+      pos.scale.range <- pos.range[2] - pos.range[1]
+    } else {
+      # discrete position axis (e.g. a vertical bracket over a categorical x):
+      # the numeric positions are 1..n_levels, so the usable range is n-1.
+      pos.scale.range <- max(length(pos.range) - 1, 1)
+    }
     # Reference range used to convert the fractional `tip.length` into data units.
     # Default ("data"): fraction of the trained data range (historical behavior) -
     # tips scale with the data, so plots with different data ranges get different
-    # absolute tips. "axis": fraction of the y-axis range (limits set via ylim /
-    # scale_y_*), which renders at the same physical fraction across plots and so
-    # gives visually constant tips regardless of the data (#362).
-    tip.scale.range <- y.scale.range
+    # absolute tips. "axis": fraction of the position-axis range (limits set via
+    # ylim / scale_*), which renders at the same physical fraction across plots
+    # and so gives visually constant tips regardless of the data (#362).
+    tip.scale.range <- pos.scale.range
     if (identical(tip.length.ref, "axis")) {
-      axis.limits <- scales$y$get_limits()
+      axis.limits <- pos.scale$get_limits()
       if (length(axis.limits) == 2 && all(is.finite(axis.limits))) {
         tip.scale.range <- axis.limits[2] - axis.limits[1]
       }
     }
-    # Place the bracket in the transformed space of the y scale, so a user-supplied
-    # y.position given in data units lands correctly on e.g. scale_y_log10(). The
-    # trained range/tips above are already in transformed units. For an identity
-    # scale the transform is a no-op, so default output is unchanged (#342).
-    y.transform <- .stat_bracket_y_transform(scales$y)
-    if (!is.null(y.transform)) {
-      data$y.position <- y.transform(data$y.position)
+    # Place the bracket in the transformed space of the position scale, so a
+    # user-supplied position given in data units lands correctly on e.g.
+    # scale_y_log10(). The trained range/tips above are already in transformed
+    # units. For an identity scale the transform is a no-op, so default output is
+    # unchanged (#342).
+    pos.transform <- .stat_bracket_y_transform(pos.scale)
+    if (!is.null(pos.transform)) {
+      data$y.position <- pos.transform(data$y.position)
     }
     bracket.shorten <- data$bracket.shorten / 2
-    xmin <- data$xmin + bracket.shorten
-    xmax <- data$xmax - bracket.shorten
-    y.position <- data$y.position + (y.scale.range * data$step.increase) + data$bracket.nudge.y
-    label <- data$label
-    if (is.character(xmin)) {
-      xmin <- scales$x$map(xmin)
+    span.min <- data$xmin
+    span.max <- data$xmax
+    # A vertical bracket's ends carry Y-axis values, but they travel in the
+    # xmin/xmax columns, which ggplot2 has already transformed with the X scale
+    # (the position scale here). Undo that x transform so the ends are back in
+    # raw data units before we re-express them in the Y (span) scale below; this
+    # keeps a non-identity x scale (log/sqrt/reverse) from corrupting the span
+    # (#456). The horizontal path skips this entirely and is unchanged.
+    if (vertical) {
+      pos.inverse <- .stat_bracket_scale_inverse(pos.scale)
+      if (!is.null(pos.inverse)) {
+        if (is.numeric(span.min)) span.min <- pos.inverse(span.min)
+        if (is.numeric(span.max)) span.max <- pos.inverse(span.max)
+      }
     }
-    if (is.character(xmax)) {
-      xmax <- scales$x$map(xmax)
+    span.min <- span.min + bracket.shorten
+    span.max <- span.max - bracket.shorten
+    position <- data$y.position + (pos.scale.range * data$step.increase) + data$bracket.nudge.y
+    label <- data$label
+    if (is.character(span.min)) {
+      span.min <- span.scale$map(span.min)
+    }
+    if (is.character(span.max)) {
+      span.max <- span.scale$map(span.max)
+    }
+    # For a vertical bracket the ends run along the (value) y axis; express them
+    # in that scale's transformed space so a log-y span lands correctly.
+    # Horizontal keeps the ends on x with no transform, exactly as before.
+    if (vertical) {
+      span.transform <- .stat_bracket_y_transform(span.scale)
+      if (!is.null(span.transform)) {
+        if (is.numeric(span.min)) span.min <- span.transform(span.min)
+        if (is.numeric(span.max)) span.max <- span.transform(span.max)
+      }
     }
     if ("tip.length" %in% colnames(data)) {
       tip.length <- rep(data$tip.length, each = 2)
     }
-    # Preparing bracket data
+    # Preparing bracket data: three segments (tip, bar, tip) in (span, position)
+    # space, then assigned to x/y according to the orientation.
     data <- dplyr::bind_rows(data, data, data)
-    data$x <- c(xmin, xmin, xmax)
-    data$xend <- c(xmin, xmax, xmax)
-    data$y <- c(y.position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 1], y.position, y.position)
-    data$yend <- c(y.position, y.position, y.position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 0])
+    span <- c(span.min, span.min, span.max)
+    span.end <- c(span.min, span.max, span.max)
+    pos.v <- c(position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 1], position, position)
+    pos.end <- c(position, position, position - tip.scale.range * tip.length[seq_along(tip.length) %% 2 == 0])
+    if (vertical) {
+      data$x <- pos.v
+      data$xend <- pos.end
+      data$y <- span
+      data$yend <- span.end
+    } else {
+      data$x <- span
+      data$xend <- span.end
+      data$y <- pos.v
+      data$yend <- pos.end
+    }
     data$annotation <- rep(label, 3)
     data
   }
@@ -123,6 +196,22 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
 #'   p-values to a horizontal ggplot (generated using
 #'   \code{\link[ggplot2]{coord_flip}()}), you need to specify the option
 #'   \code{coord.flip = TRUE}.
+#' @param orientation the bracket orientation. Either \code{"horizontal"} (the
+#'   default, a bracket spanning the x axis with the bar at \code{y.position}) or
+#'   \code{"vertical"} (a bracket spanning the y axis with the bar at
+#'   \code{x.position}, tips pointing left and the label rotated to the side).
+#'   Vertical brackets are useful to annotate plots where the comparison runs
+#'   along the y axis, e.g. Kaplan-Meier curves. They are designed for a
+#'   continuous x axis; specify the span with \code{ymin}/\code{ymax} and the
+#'   position with \code{x.position}. Cannot be combined with
+#'   \code{coord.flip = TRUE}.
+#' @param ymin,ymax numeric vectors with the positions, along the y axis, of the
+#'   two ends of each vertical bracket. Used only when
+#'   \code{orientation = "vertical"} (the vertical-bracket analogue of
+#'   \code{xmin}/\code{xmax}).
+#' @param x.position numeric vector with the x positions of the vertical
+#'   brackets. Used only when \code{orientation = "vertical"} (the
+#'   vertical-bracket analogue of \code{y.position}).
 #' @param ... other arguments passed on to \code{\link[ggplot2]{layer}()}). These are often
 #'   aesthetics, used to set an aesthetic to a fixed value, like \code{color =
 #'   "red"} or \code{size = 3}. They may also be parameters to the paired
@@ -184,6 +273,14 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
 #'     aes(xmin = group1, xmax = group2, label = signif(p, 2)),
 #'     data = stat.test, y.position = c(32, 35, 38)
 #'   )
+#'
+#' # Vertical bracket (e.g. to annotate a plot with a continuous x axis)
+#' ggscatter(df, x = "len", y = "len") +
+#'   geom_bracket(
+#'     orientation = "vertical",
+#'     ymin = 10, ymax = 25, x.position = 34,
+#'     label = "p < 0.05"
+#'   )
 #' @rdname geom_bracket
 #' @export
 stat_bracket <- function(mapping = NULL, data = NULL,
@@ -229,7 +326,7 @@ GeomBracket <- ggplot2::ggproto("GeomBracket", ggplot2::Geom,
   # for legend:
   draw_key = draw_key_path,
   draw_group = function(data, panel_params, coord, type = "text",
-                        coord.flip = FALSE) {
+                        coord.flip = FALSE, orientation = "horizontal") {
     lab <- as.character(data$annotation)
     if (type == "expression") {
       lab <- parse_as_expression(lab)
@@ -238,7 +335,13 @@ GeomBracket <- ggplot2::ggproto("GeomBracket", ggplot2::Geom,
     label.x <- mean(c(coords$x[1], tail(coords$xend, n = 1)))
     label.y <- max(c(coords$y, coords$yend)) + 0.01
     label.angle <- coords$angle
-    if (coord.flip) {
+    if (identical(orientation, "vertical")) {
+      # native vertical bracket (#456): the bar spans y, tips point left, so the
+      # label sits to the RIGHT of the bar, centered on the span and rotated.
+      label.x <- max(c(coords$x, coords$xend)) + 0.02
+      label.y <- mean(c(coords$y[1], tail(coords$yend, n = 1)))
+      if (is.null(label.angle)) label.angle <- -90
+    } else if (coord.flip) {
       label.y <- mean(c(coords$y[1], tail(coords$yend, n = 1)))
       label.x <- max(c(coords$x, coords$xend)) + 0.01
       if (is.null(label.angle)) label.angle <- -90
@@ -286,16 +389,34 @@ geom_bracket <- function(mapping = NULL, data = NULL, stat = "bracket",
                          bracket.nudge.y = 0, bracket.shorten = 0,
                          size = 0.3, linewidth = size, label.size = 3.88, family = "", vjust = 0,
                          coord.flip = FALSE,
+                         orientation = c("horizontal", "vertical"),
+                         ymin = NULL, ymax = NULL, x.position = NULL,
                          ...) {
   type <- match.arg(type)
   tip.length.ref <- match.arg(tip.length.ref)
+  orientation <- match.arg(orientation)
+  vertical <- identical(orientation, "vertical")
+  if (vertical) {
+    # A vertical bracket takes its span from the value (y) axis and its bar
+    # position from the x axis. Accept the axis-appropriate argument names and
+    # feed them through the same internal slots the horizontal path uses.
+    if (coord.flip) {
+      stop("`orientation = 'vertical'` cannot be combined with `coord.flip = TRUE`. ",
+           "Use `orientation = 'vertical'` for a native vertical bracket on an ",
+           "unflipped plot, or `coord.flip = TRUE` for a plot flipped with coord_flip().",
+           call. = FALSE)
+    }
+    if (!is.null(ymin)) xmin <- ymin
+    if (!is.null(ymax)) xmax <- ymax
+    if (!is.null(x.position)) y.position <- x.position
+  }
   data <- build_signif_data(
     data = data, label = label, y.position = y.position,
     xmin = xmin, xmax = xmax, step.increase = step.increase,
     bracket.nudge.y = bracket.nudge.y, bracket.shorten = bracket.shorten,
     step.group.by = step.group.by, vjust = vjust
   )
-  mapping <- build_signif_mapping(mapping, data)
+  mapping <- build_signif_mapping(mapping, data, orientation)
   ggplot2::layer(
     stat = stat, geom = GeomBracket, mapping = mapping, data = data,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,
@@ -304,6 +425,7 @@ geom_bracket <- function(mapping = NULL, data = NULL, stat = "bracket",
       tip.length = tip.length, tip.length.ref = tip.length.ref,
       size = linewidth, label.size = label.size,
       family = family, na.rm = na.rm, coord.flip = coord.flip,
+      orientation = orientation,
       ...
     )
   )
@@ -368,7 +490,7 @@ build_signif_data <- function(data = NULL, label = NULL, y.position = NULL,
 }
 
 
-build_signif_mapping <- function(mapping, data) {
+build_signif_mapping <- function(mapping, data, orientation = "horizontal") {
   if (is.null(mapping)) {
     # Check if required variables are present in data
     required.vars <- c("xmin", "xmax", "y.position")
@@ -394,11 +516,17 @@ build_signif_mapping <- function(mapping, data) {
   if (is.null(mapping$vjust)) mapping$vjust <- data$vjust
   if (is.null(mapping$bracket.nudge.y)) mapping$bracket.nudge.y <- data$bracket.nudge.y
   if (is.null(mapping$bracket.shorten)) mapping$bracket.shorten <- data$bracket.shorten
-  if (!"x" %in% names(mapping)) {
-    mapping$x <- mapping$xmin
-  }
-  if (!"y" %in% names(mapping)) {
-    mapping$y <- mapping$y.position
+  # Anchor aesthetics that position the bracket for scale training and the
+  # stat's required `x`/`y`. For a vertical bracket the roles swap: the bar sits
+  # along x (from y.position, which holds the x position) and the span runs along
+  # y (from xmin). Mapping them the horizontal way would send an x position into
+  # the y scale and drop the bracket as out-of-range (#456).
+  if (identical(orientation, "vertical")) {
+    if (!"x" %in% names(mapping)) mapping$x <- mapping$y.position
+    if (!"y" %in% names(mapping)) mapping$y <- mapping$xmin
+  } else {
+    if (!"x" %in% names(mapping)) mapping$x <- mapping$xmin
+    if (!"y" %in% names(mapping)) mapping$y <- mapping$y.position
   }
   mapping
 }

--- a/man/geom_bracket.Rd
+++ b/man/geom_bracket.Rd
@@ -56,6 +56,10 @@ geom_bracket(
   family = "",
   vjust = 0,
   coord.flip = FALSE,
+  orientation = c("horizontal", "vertical"),
+  ymin = NULL,
+  ymax = NULL,
+  x.position = NULL,
   ...
 )
 }
@@ -187,6 +191,25 @@ horizontal becomes vertical, and vertical, horizontal. When adding the
 p-values to a horizontal ggplot (generated using
 \code{\link[ggplot2]{coord_flip}()}), you need to specify the option
 \code{coord.flip = TRUE}.}
+
+\item{orientation}{the bracket orientation. Either \code{"horizontal"} (the
+default, a bracket spanning the x axis with the bar at \code{y.position}) or
+\code{"vertical"} (a bracket spanning the y axis with the bar at
+\code{x.position}, tips pointing left and the label rotated to the side).
+Vertical brackets are useful to annotate plots where the comparison runs
+along the y axis, e.g. Kaplan-Meier curves. They are designed for a
+continuous x axis; specify the span with \code{ymin}/\code{ymax} and the
+position with \code{x.position}. Cannot be combined with
+\code{coord.flip = TRUE}.}
+
+\item{ymin, ymax}{numeric vectors with the positions, along the y axis, of the
+two ends of each vertical bracket. Used only when
+\code{orientation = "vertical"} (the vertical-bracket analogue of
+\code{xmin}/\code{xmax}).}
+
+\item{x.position}{numeric vector with the x positions of the vertical
+brackets. Used only when \code{orientation = "vertical"} (the
+vertical-bracket analogue of \code{y.position}).}
 }
 \description{
 add brackets with label annotation to a ggplot. Helpers for
@@ -246,5 +269,13 @@ ggboxplot(df, x = "dose", y = "len") +
   geom_bracket(
     aes(xmin = group1, xmax = group2, label = signif(p, 2)),
     data = stat.test, y.position = c(32, 35, 38)
+  )
+
+# Vertical bracket (e.g. to annotate a plot with a continuous x axis)
+ggscatter(df, x = "len", y = "len") +
+  geom_bracket(
+    orientation = "vertical",
+    ymin = 10, ymax = 25, x.position = 34,
+    label = "p < 0.05"
   )
 }

--- a/tests/testthat/test-geom-bracket-horizontal.R
+++ b/tests/testthat/test-geom-bracket-horizontal.R
@@ -1,0 +1,109 @@
+context("test-geom-bracket-horizontal")
+
+# Characterization tests that PIN the horizontal geom_bracket() geometry (the
+# long-standing default behavior, shared by stat_pvalue_manual() and
+# stat_compare_means()). These lock the exact segment coordinates produced by
+# StatBracket so that any future change which silently alters horizontal
+# brackets - tip length, step increase, bracket.shorten, bracket.nudge.y, the
+# log-scale (#342) or axis (#362) handling - fails here instead of shipping.
+
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+
+.seg <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))[1]
+  d <- b$data[[i]]
+  data.frame(
+    x = as.numeric(d$x), xend = as.numeric(d$xend),
+    y = as.numeric(d$y), yend = as.numeric(d$yend),
+    annotation = as.character(d$annotation), stringsAsFactors = FALSE
+  )
+}
+
+test_that("single bracket with character xmin/xmax is unchanged", {
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "***"))
+  expect_equal(d$x,    c(1, 1, 2))
+  expect_equal(d$xend, c(1, 2, 2))
+  expect_equal(d$y,    c(29.109, 30, 30), tolerance = 1e-4)
+  expect_equal(d$yend, c(30, 30, 29.109), tolerance = 1e-4)
+  expect_equal(d$annotation, rep("***", 3))
+})
+
+test_that("multiple brackets with step.increase are unchanged", {
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = c("0.5", "1"), xmax = c("1", "2"),
+                 y.position = c(30, 35), label = c("***", "**"),
+                 tip.length = 0.01, step.increase = 0.1))
+  expect_equal(d$x,    c(1, 1, 2, 2, 2, 3))
+  expect_equal(d$xend, c(1, 2, 2, 2, 3, 3))
+  expect_equal(d$y,    c(29.692, 30, 30, 37.772, 38.08, 38.08), tolerance = 1e-3)
+  expect_equal(d$yend, c(30, 30, 29.692, 38.08, 38.08, 37.772), tolerance = 1e-3)
+})
+
+test_that("per-tip tip.length vector is unchanged", {
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "*",
+                 tip.length = c(0.2, 0.02)))
+  # asymmetric tips: left tip is long (0.2), right tip is short (0.02)
+  expect_equal(d$y,    c(24.06, 30, 30), tolerance = 1e-3)
+  expect_equal(d$yend, c(30, 30, 29.406), tolerance = 1e-3)
+})
+
+test_that("bracket.shorten and bracket.nudge.y are unchanged", {
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "2", y.position = 30, label = "*",
+                 bracket.shorten = 0.2, bracket.nudge.y = 2))
+  # shorten pulls the ends in by 0.1 each (1->1.1, 3->2.9); nudge lifts y by 2
+  expect_equal(d$x,    c(1.1, 1.1, 2.9))
+  expect_equal(d$xend, c(1.1, 2.9, 2.9))
+  expect_equal(d$y,    c(31.109, 32, 32), tolerance = 1e-3)
+  expect_equal(d$yend, c(32, 32, 31.109), tolerance = 1e-3)
+})
+
+test_that("y positions land in transformed space on a log y scale (#342)", {
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "*") +
+    ggplot2::scale_y_log10())
+  # y.position = 30 -> log10(30) = 1.4771; tip goes down to ~1.4499
+  expect_equal(d$y,    c(1.4499, 1.4771, 1.4771), tolerance = 1e-4)
+  expect_equal(d$yend, c(1.4771, 1.4771, 1.4499), tolerance = 1e-4)
+})
+
+test_that("tip.length.ref = 'axis' uses the axis range, not the data range (#362)", {
+  # with ylim(0, 60) the tip is 0.03 * 60 = 1.8 below y.position
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "*",
+                 tip.length.ref = "axis") + ggplot2::ylim(0, 60))
+  expect_equal(min(d$y), 30 - 0.03 * 60, tolerance = 1e-4)
+})
+
+test_that("numeric xmin/xmax on a continuous x axis are unchanged", {
+  d <- .seg(ggscatter(df, "len", "len") +
+    geom_bracket(xmin = 10, xmax = 20, y.position = 30, label = "ns"))
+  expect_equal(d$x,    c(10, 10, 20))
+  expect_equal(d$xend, c(10, 20, 20))
+  expect_equal(d$y[2:3], c(30, 30))
+})
+
+test_that("stat_pvalue_manual() draws the same horizontal bracket segments", {
+  stat.test <- compare_means(len ~ dose, df, method = "t.test")
+  stat.test$y.position <- c(32, 35, 38)
+  d <- .seg(ggboxplot(df, "dose", "len") +
+    stat_pvalue_manual(stat.test, label = "p.signif"))
+  expect_equal(nrow(d), 9)                       # 3 comparisons x 3 segments
+  expect_equal(unique(d$x),    c(1, 2, 3))
+  expect_equal(unique(d$xend), c(1, 2, 3))
+  # the bars sit at the requested y positions
+  expect_true(all(c(32, 35, 38) %in% round(d$y, 3)))
+})
+
+test_that("a plain horizontal geom_bracket() draws without warning", {
+  expect_silent(
+    ggplot2::ggplotGrob(
+      ggboxplot(df, "dose", "len") +
+        geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "*")
+    )
+  )
+})

--- a/tests/testthat/test-geom-bracket-horizontal.R
+++ b/tests/testthat/test-geom-bracket-horizontal.R
@@ -107,3 +107,37 @@ test_that("a plain horizontal geom_bracket() draws without warning", {
     )
   )
 })
+
+# The label is drawn in GeomBracket$draw_group (not in the built layer data), so
+# these render-and-inspect tests pin its ANGLE and PANEL position - guarding the
+# label control flow (horizontal vs coord.flip vs vertical branches).
+.label_grob <- function(p) {
+  g <- ggplot2::ggplotGrob(p)
+  txt <- NULL
+  find_txt <- function(gr) {
+    if (inherits(gr, "text")) { txt <<- gr; return(invisible()) }
+    if (!is.null(gr$children)) for (ch in gr$children) find_txt(ch)
+    if (inherits(gr, "gTree") && !is.null(gr$grobs)) for (ch in gr$grobs) find_txt(ch)
+  }
+  for (pi in which(grepl("panel", g$layout$name))) find_txt(g$grobs[[pi]])
+  txt
+}
+
+test_that("horizontal label is centered above the bracket, not rotated", {
+  t <- .label_grob(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "H"))
+  expect_false(is.null(t))
+  expect_equal(t$rot, 0)                                  # horizontal: no rotation
+  expect_equal(as.numeric(t$x), 0.344, tolerance = 0.03)  # centered over the span
+  expect_equal(as.numeric(t$y), 0.845, tolerance = 0.03)  # above the bar
+})
+
+test_that("coord.flip label sits to the side and is rotated -90", {
+  t <- .label_grob(ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "C",
+                 coord.flip = TRUE) + ggplot2::coord_flip())
+  expect_false(is.null(t))
+  expect_equal(t$rot, -90)
+  expect_equal(as.numeric(t$x), 0.845, tolerance = 0.03)
+  expect_equal(as.numeric(t$y), 0.344, tolerance = 0.03)
+})

--- a/tests/testthat/test-geom-bracket-vertical.R
+++ b/tests/testthat/test-geom-bracket-vertical.R
@@ -115,6 +115,27 @@ test_that("a discrete position axis does not crash the vertical bracket", {
   expect_error(suppressWarnings(ggplot2::ggplotGrob(p)), NA)
 })
 
+test_that("vertical label sits to the right of the bar and is rotated -90", {
+  .label_grob <- function(p) {
+    g <- ggplot2::ggplotGrob(p)
+    txt <- NULL
+    find_txt <- function(gr) {
+      if (inherits(gr, "text")) { txt <<- gr; return(invisible()) }
+      if (!is.null(gr$children)) for (ch in gr$children) find_txt(ch)
+      if (inherits(gr, "gTree") && !is.null(gr$grobs)) for (ch in gr$grobs) find_txt(ch)
+    }
+    for (pi in which(grepl("panel", g$layout$name))) find_txt(g$grobs[[pi]])
+    txt
+  }
+  t <- .label_grob(ggscatter(df, "len", "len") +
+    geom_bracket(orientation = "vertical", ymin = 10, ymax = 25,
+                 x.position = 34, label = "V"))
+  expect_false(is.null(t))
+  expect_equal(t$rot, -90)                                # rotated
+  expect_gt(as.numeric(t$x), 0.85)                        # to the right (near the bar)
+  expect_equal(as.numeric(t$y), 0.45, tolerance = 0.08)   # centered on the span
+})
+
 test_that("expression labels work for vertical brackets", {
   p <- ggscatter(df, "len", "len") +
     geom_bracket(orientation = "vertical", ymin = 10, ymax = 25, x.position = 30,

--- a/tests/testthat/test-geom-bracket-vertical.R
+++ b/tests/testthat/test-geom-bracket-vertical.R
@@ -1,0 +1,123 @@
+context("test-geom-bracket-vertical")
+
+# #456: geom_bracket() gains `orientation = "vertical"` to draw a native vertical
+# bracket (bar spanning y, tips pointing left, rotated label) via ymin/ymax/
+# x.position - useful for plots where the comparison runs along the y axis (e.g.
+# Kaplan-Meier curves). The default orientation = "horizontal" is byte-identical.
+
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+
+.bracket <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))[1]
+  b$data[[i]]
+}
+
+test_that("default (horizontal) output is unchanged by the refactor", {
+  # pin the exact segment coordinates of a representative horizontal bracket
+  p <- ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "***")
+  d <- .bracket(p)
+  expect_equal(as.numeric(d$x),    c(1, 1, 2))
+  expect_equal(as.numeric(d$xend), c(1, 2, 2))
+  # tips go down from y.position = 30 by tip.length (0.03) * data range
+  expect_equal(as.numeric(d$y[2:3]),    c(30, 30))
+  expect_equal(as.numeric(d$yend[1:2]), c(30, 30))
+  expect_lt(d$y[1], 30)          # left tip points down
+  expect_lt(d$yend[3], 30)       # right tip points down
+  # passing orientation = "horizontal" explicitly is identical to omitting it
+  p2 <- ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 30, label = "***",
+                 orientation = "horizontal")
+  expect_equal(.bracket(p2)[, c("x", "xend", "y", "yend")],
+               d[, c("x", "xend", "y", "yend")])
+})
+
+test_that("vertical bracket swaps the geometry: bar spans y, tips point in -x", {
+  p <- ggscatter(df, "len", "len") +
+    geom_bracket(orientation = "vertical", ymin = 10, ymax = 25,
+                 x.position = 30, label = "p<0.05")
+  d <- .bracket(p)
+  # the bar is vertical at x = 30, spanning y in [10, 25]
+  expect_equal(d$y,    c(10, 10, 25))
+  expect_equal(d$yend, c(10, 25, 25))
+  expect_equal(d$x[2:3],    c(30, 30))
+  expect_equal(d$xend[1:2], c(30, 30))
+  # tips point left (toward smaller x)
+  expect_lt(d$x[1], 30)
+  expect_lt(d$xend[3], 30)
+  expect_silent(suppressWarnings(ggplot2::ggplotGrob(p)))
+})
+
+test_that("vertical tip length scales to the x range (not the y range)", {
+  # x range is len (~4.2..33.9); tip.length default 0.03 => tip ~ 0.03 * xrange
+  p <- ggscatter(df, "len", "len") +
+    geom_bracket(orientation = "vertical", ymin = 10, ymax = 25,
+                 x.position = 30, label = "ns")
+  d <- .bracket(p)
+  b <- ggplot2::ggplot_build(p)
+  xr <- diff(b$layout$panel_params[[1]]$x.range)
+  tip <- 30 - d$x[1]
+  # the tip is a small positive fraction of the x range, and not of the (equal-here) y
+  expect_gt(tip, 0)
+  expect_lt(tip, xr)               # sane
+})
+
+test_that("the bar position honors the x-scale transform (log-x)", {
+  set.seed(1)
+  d0 <- data.frame(x = 1:10, y = runif(10, 1, 9))
+  p <- ggscatter(d0, "x", "y") +
+    geom_bracket(orientation = "vertical", ymin = 3, ymax = 7, x.position = 8, label = "ns") +
+    ggplot2::scale_x_log10()
+  d <- .bracket(p)
+  # the bar (the max x among the segment ends) lands at log10(8) in transformed space
+  expect_equal(max(d$xend), log10(8), tolerance = 1e-6)
+  expect_equal(max(d$x), log10(8), tolerance = 1e-6)
+  # and CRUCIALLY the span y must stay at the data values 3 and 7 (a non-identity
+  # x scale must not corrupt the y span, #456)
+  expect_equal(sort(unique(round(c(d$y, d$yend), 6))), c(3, 7))
+})
+
+test_that("the y span is correct under every combination of x/y scale transforms", {
+  set.seed(1)
+  d0 <- data.frame(x = 1:10, y = runif(10, 1, 9))
+  span_y <- function(...) {
+    p <- ggscatter(d0, "x", "y") +
+      geom_bracket(orientation = "vertical", ymin = 3, ymax = 7, x.position = 8, label = "ns")
+    for (s in list(...)) p <- p + s
+    d <- .bracket(suppressWarnings(p))
+    sort(unique(round(c(d$y, d$yend), 4)))
+  }
+  expect_equal(span_y(),                                            c(3, 7))
+  expect_equal(span_y(ggplot2::scale_y_log10()),                    round(c(log10(3), log10(7)), 4))
+  expect_equal(span_y(ggplot2::scale_x_log10()),                    c(3, 7))            # log-x must NOT touch the y span
+  expect_equal(span_y(ggplot2::scale_x_log10(), ggplot2::scale_y_log10()),
+               round(c(log10(3), log10(7)), 4))                                        # no double transform
+  expect_equal(span_y(ggplot2::scale_x_reverse()),                  c(3, 7))
+  expect_equal(span_y(ggplot2::scale_x_sqrt()),                     c(3, 7))
+})
+
+test_that("orientation = 'vertical' errors if combined with coord.flip = TRUE", {
+  expect_error(
+    geom_bracket(orientation = "vertical", coord.flip = TRUE,
+                 ymin = 1, ymax = 2, x.position = 1, label = "x"),
+    "cannot be combined"
+  )
+})
+
+test_that("a discrete position axis does not crash the vertical bracket", {
+  # not the primary use case (vertical brackets target a continuous x axis),
+  # but it must not error
+  p <- ggboxplot(df, "supp", "len") +
+    geom_bracket(orientation = "vertical", ymin = 10, ymax = 25,
+                 x.position = 2.3, label = "*")
+  expect_error(suppressWarnings(ggplot2::ggplotGrob(p)), NA)
+})
+
+test_that("expression labels work for vertical brackets", {
+  p <- ggscatter(df, "len", "len") +
+    geom_bracket(orientation = "vertical", ymin = 10, ymax = 25, x.position = 30,
+                 label = "list(~italic(p)<=0.001)", type = "expression")
+  expect_error(suppressWarnings(ggplot2::ggplotGrob(p)), NA)
+})


### PR DESCRIPTION
### What

`geom_bracket()` gains an `orientation` argument. With `orientation = "vertical"` it draws a native **vertical** bracket — the bar spans the y axis (at `x.position`), the tips point left and the label is rotated to the side — specified with the new `ymin`/`ymax`/`x.position` arguments. This is a long-requested option for annotating plots where the comparison runs along the y axis, e.g. Kaplan-Meier curves (#456).

```r
library(ggpubr)
set.seed(1)
d <- data.frame(
  time = rep(1:10, 2), grp = rep(c("A", "B"), each = 10),
  surv = c(sort(runif(10, 0.3, 1), decreasing = TRUE),
           sort(runif(10, 0.1, 0.8), decreasing = TRUE))
)

ggline(d, "time", "surv", color = "grp", palette = "jco", numeric.x.axis = TRUE) +
  ylim(0, 1) +
  geom_bracket(orientation = "vertical", ymin = 0.30, ymax = 0.75,
               x.position = 10.7, label = "p < 0.05")
```

### Behaviour

- Default `orientation = "horizontal"` is unchanged (byte-identical output — the existing `stat_pvalue_manual()`/`stat_compare_means()` bracket path is untouched).
- Vertical brackets are designed for a continuous x axis; specify the span with `ymin`/`ymax` and the position with `x.position`.
- The bracket is placed correctly under non-identity x scales (`scale_x_log10`/`scale_x_sqrt`/`scale_x_reverse`): the span stays on the y scale rather than being transformed by the x scale.
- `orientation = "vertical"` cannot be combined with `coord.flip = TRUE` (they address different needs); it errors clearly. `geom_pwc()` is unaffected (it has its own draw path and stays horizontal).

### Notes

- Adds tests for the byte-identical horizontal path, vertical geometry, tip/step scaling to the x range, the span-under-every-scale-transform correctness, the `coord.flip` guard, discrete-axis safety, and expression labels.

Fixes #456.
