### PR TITLE
Fix paired-id comparison edge cases and p-value formatting docs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,8 @@
 ^CRAN-RELEASE$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.git$
+^.*[.]tar[.]gz$
 ^README\.Rmd$
 ^README-.*\.png$
 ^cran-comments\.md$
@@ -16,6 +18,7 @@
 ^_tmp$
 ^CRAN-SUBMISSION$
 ^\.claude$
+^\.codex$
 ^check-as-cran\.sh$
 ^Rplots\.pdf$
 ^PR_SYNC_NOTES\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ docs/
 TODO.Rmd
 _tmp
 Rplots.pdf
+*.tar.gz
+*.Rcheck/
 CLAUDE.md
+.codex/

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -160,6 +160,9 @@ compare_means <- function(formula, data, method = "wilcox.test",
                           signif.cutoffs = NULL, signif.symbols = NULL,
                           ns.symbol = "ns", use.four.stars = FALSE, ...) {
   . <- NULL
+  extra.args <- list(...)
+  .skip_insufficient_id_pairs <- isTRUE(extra.args$.skip_insufficient_id_pairs)
+  extra.args$.skip_insufficient_id_pairs <- NULL
 
   method.info <- .method_info(method)
   method <- method.info$method
@@ -275,19 +278,31 @@ compare_means <- function(formula, data, method = "wilcox.test",
   }
 
   if (is.null(group.by)) {
-    res <- test.func(
-      formula = formula, data = data, method = method,
-      paired = paired, id = id, p.adjust.method = "none", ...
+    res <- do.call(
+      test.func,
+      c(
+        list(
+          formula = formula, data = data, method = method,
+          paired = paired, id = id,
+          .skip_insufficient_id_pairs = .skip_insufficient_id_pairs,
+          p.adjust.method = "none"
+        ),
+        extra.args
+      )
     )
   } else {
     grouped.d <- .group_by(data, group.by)
-    res <- grouped.d %>%
-      mutate(p = purrr::map(
-        data,
-        test.func,
+    test.args <- c(
+      list(
         formula = formula,
-        method = method, paired = paired, id = id, p.adjust.method = "none", ...
-      )) %>%
+        method = method, paired = paired, id = id,
+        .skip_insufficient_id_pairs = TRUE,
+        p.adjust.method = "none"
+      ),
+      extra.args
+    )
+    res <- grouped.d %>%
+      mutate(p = purrr::map(data, ~do.call(test.func, c(list(data = .x), test.args)))) %>%
       df_select(vars = c(group.by, "p")) %>%
       unnest(cols = "p")
   }
@@ -426,7 +441,7 @@ compare_means <- function(formula, data, method = "wilcox.test",
 # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 .test_pairwise <- function(data, formula, method = "wilcox.test",
                            paired = FALSE, pool.sd = !paired,
-                           id = NULL, ...) {
+                           id = NULL, .skip_insufficient_id_pairs = FALSE, ...) {
   x <- .strip_backticks(deparse(formula[[2]]))
   group <- .strip_backticks(attr(stats::terms(formula), "term.labels"))
 
@@ -436,7 +451,11 @@ compare_means <- function(formula, data, method = "wilcox.test",
   # `id` is captured as an explicit formal so it never leaks into the base
   # pairwise test's `...`.
   if (!is.null(id) && isTRUE(paired) && !.is_empty(group)) {
-    return(.paired_test_by_id(data, x = x, group = group, method = method, id = id))
+    return(.paired_test_by_id(
+      data, x = x, group = group, method = method, id = id,
+      .skip_insufficient_pairs = .skip_insufficient_id_pairs,
+      ...
+    ))
   }
 
   # One sample test
@@ -498,7 +517,17 @@ compare_means <- function(formula, data, method = "wilcox.test",
 # yield the statistically correct paired p-value(s). Handles two-group and
 # pairwise (>2 groups) comparisons; ref.group is applied by the caller's
 # post-filter. Returns the same group1 | group2 | p shape as .test_pairwise().
-.paired_test_by_id <- function(data, x, group, method, id) {
+.paired_test_by_id <- function(data, x, group, method, id,
+                               .skip_insufficient_pairs = FALSE, ...) {
+  group.values <- .select_vec(data, group)
+  groups <- .paired_id_group_names(group.values)
+  if (length(groups) < 2L) {
+    return(tibble::tibble(
+      group1 = character(),
+      group2 = character(),
+      p = numeric()
+    ))
+  }
   test.fun <- switch(method,
     t.test = rstatix::t_test,
     wilcox.test = rstatix::wilcox_test
@@ -508,14 +537,26 @@ compare_means <- function(formula, data, method = "wilcox.test",
   # group values in group1/group2, so the labels are preserved.
   d2 <- data.frame(
     outcome = .select_vec(data, x),
-    grp = .select_vec(data, group),
+    grp = group.values,
     subject = .select_vec(data, id),
     stringsAsFactors = FALSE
   )
-  res <- suppressWarnings(test.fun(
-    d2, formula = outcome ~ grp, paired = TRUE, id = "subject",
-    p.adjust.method = "none", detailed = FALSE
+  test.args <- list(...)
+  test.args$p.adjust.method <- "none"
+  test.args$detailed <- FALSE
+  if (isTRUE(.skip_insufficient_pairs)) {
+    test.args$error.as.na <- TRUE
+  }
+  res <- suppressWarnings(do.call(
+    test.fun,
+    c(
+      list(data = d2, formula = outcome ~ grp, paired = TRUE, id = "subject"),
+      test.args
+    )
   ))
+  if (isTRUE(.skip_insufficient_pairs)) {
+    res <- res[!is.na(res$p), , drop = FALSE]
+  }
   tibble::tibble(
     group1 = as.character(res$group1),
     group2 = as.character(res$group2),
@@ -523,10 +564,20 @@ compare_means <- function(formula, data, method = "wilcox.test",
   )
 }
 
+.paired_id_group_names <- function(group.values) {
+  group.values <- group.values[!is.na(group.values)]
+  if (is.factor(group.values)) {
+    as.character(levels(droplevels(group.values)))
+  } else {
+    unique(as.character(group.values))
+  }
+}
+
 # Compare multiple groups
 # ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-.test_multigroups <- function(data, formula, method = c("anova", "kruskal.test"), ...) {
+.test_multigroups <- function(data, formula, method = c("anova", "kruskal.test"),
+                              .skip_insufficient_id_pairs = FALSE, ...) {
   method <- match.arg(method)
   . <- NULL
 

--- a/R/p_format_utils.R
+++ b/R/p_format_utils.R
@@ -161,14 +161,14 @@ list_p_format_styles <- function() {
 #' \strong{APA Style} (Psychology, Social Sciences):
 #' \itemize{
 #'   \item No leading zero (write ".05" not "0.05")
-#'   \item 2-3 decimal places
+#'   \item 3 decimal places
 #'   \item Report as "p < .001" for very small values
 #' }
 #'
 #' \strong{NEJM/Medical Journals}:
 #' \itemize{
-#'   \item P > 0.01: 2 decimal places
-#'   \item P between 0.001 and 0.01: 3 decimal places
+#'   \item Leading zero (write "0.05" not ".05")
+#'   \item 3 decimal places
 #'   \item P < 0.001: report as "< 0.001"
 #' }
 #'

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -387,7 +387,8 @@ StatCompareMeans <- ggproto("StatCompareMeans", Stat,
     # aligned by id. Gated on `paired` so a stray mapped `id` aesthetic on a
     # non-paired plot is ignored (unchanged vs. before).
     if (isTRUE(paired) && "id" %in% names(data)) {
-      method.args <- method.args %>% .add_item(id = "id")
+      method.args <- method.args %>%
+        .add_item(id = "id", .skip_insufficient_id_pairs = TRUE)
     }
 
     if (.is.multiple.grouping.vars) {

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,13 @@
 ## Test environments
-- macOS Tahoe 26.2, R 4.5.2 (aarch64-apple-darwin25.0.0)
+- macOS Tahoe 26.5.2, R 4.6.0 (aarch64-apple-darwin25.4.0)
 
 ## R CMD check results
 - 0 errors | 0 warnings | 1 note
-- NOTE: New submission.
+- NOTE: The Date field is over a month old.
 
 ## Additional comments
-- This release introduces a breaking change by requiring ggplot2 >= 4.0.0.
-- Added ggviolin quantile migration tests and refreshed documentation.
+- The package metadata requires ggplot2 >= 3.5.2. This check was run with
+  ggplot2 4.0.3.
+- The previous cran-comments note incorrectly stated that this release requires
+  ggplot2 >= 4.0.0; DESCRIPTION and NEWS.md keep the ggplot2 floor at >= 3.5.2.
+- Added paired-id comparison tests and refreshed p-value formatting documentation.

--- a/man/format_p_value.Rd
+++ b/man/format_p_value.Rd
@@ -60,14 +60,14 @@ P-value formatting conventions vary across scientific disciplines and journals:
 \strong{APA Style} (Psychology, Social Sciences):
 \itemize{
   \item No leading zero (write ".05" not "0.05")
-  \item 2-3 decimal places
+  \item 3 decimal places
   \item Report as "p < .001" for very small values
 }
 
 \strong{NEJM/Medical Journals}:
 \itemize{
-  \item P > 0.01: 2 decimal places
-  \item P between 0.001 and 0.01: 3 decimal places
+  \item Leading zero (write "0.05" not ".05")
+  \item 3 decimal places
   \item P < 0.001: report as "< 0.001"
 }
 

--- a/tests/testthat/test-compare-means-paired-id.R
+++ b/tests/testthat/test-compare-means-paired-id.R
@@ -16,11 +16,11 @@ suppressMessages(library(dplyr))
   )
 }
 
-.hand_paired <- function(d, method = "wilcox.test") {
+.hand_paired <- function(d, method = "wilcox.test", ...) {
   x <- d %>% filter(sampleType == "Normal") %>% arrange(ID) %>% pull(value)
   y <- d %>% filter(sampleType == "Tumor") %>% arrange(ID) %>% pull(value)
   fun <- match.fun(method)
-  suppressWarnings(fun(x, y, paired = TRUE))$p.value
+  suppressWarnings(fun(x, y, paired = TRUE, ...))$p.value
 }
 
 test_that("id yields the correct paired p-value regardless of row order (#560)", {
@@ -47,6 +47,24 @@ test_that("id works for both wilcox.test and t.test", {
                .hand_paired(d, "wilcox.test"))
   expect_equal(compare_means(value ~ sampleType, d, method = "t.test", paired = TRUE, id = "ID")$p,
                .hand_paired(d, "t.test"))
+})
+
+test_that("id forwards one-sided paired test alternatives", {
+  d <- .make_paired()
+  for (method in c("wilcox.test", "t.test")) {
+    for (alternative in c("greater", "less")) {
+      got <- compare_means(
+        value ~ sampleType, d,
+        method = method, paired = TRUE, id = "ID",
+        alternative = alternative
+      )$p
+      expect_equal(got, .hand_paired(d, method, alternative = alternative))
+      expect_false(isTRUE(all.equal(
+        got,
+        compare_means(value ~ sampleType, d, method = method, paired = TRUE, id = "ID")$p
+      )))
+    }
+  }
 })
 
 test_that("group1/group2 labels match the default convention", {
@@ -83,6 +101,23 @@ test_that("id validation rejects unsupported combinations", {
   expect_error(compare_means(value ~ g, dup, method = "t.test", paired = TRUE, id = "ID"))
 })
 
+test_that("id duplicate errors are preserved in grouped comparisons", {
+  dup_grouped <- data.frame(
+    block = c(rep("x", 4), rep("y", 4)),
+    g = c("A", "A", "B", "B", "A", "A", "B", "B"),
+    value = c(1, 2, 3, 5, 10, 11, 20, 21),
+    ID = c(1, 2, 1, 2, 1, 1, 1, 2)
+  )
+  expect_error(
+    compare_means(
+      value ~ g, dup_grouped,
+      method = "t.test", paired = TRUE, id = "ID",
+      group.by = "block"
+    ),
+    "duplicated ids"
+  )
+})
+
 test_that("id works for pairwise (>2 groups) comparisons, matching rstatix (#560)", {
   set.seed(3)
   d <- data.frame(g = rep(c("A", "B", "C"), each = 8),
@@ -94,6 +129,80 @@ test_that("id works for pairwise (>2 groups) comparisons, matching rstatix (#560
   key <- function(x) paste(x$group1, x$group2, signif(x$p, 6))
   expect_setequal(key(got), key(ref))
   expect_equal(nrow(got), 3L)  # A-B, A-C, B-C
+})
+
+test_that("id skips grouped subsets with fewer than two levels", {
+  d <- data.frame(
+    block = c(rep("x", 6), rep("y", 3)),
+    g = c("A", "A", "A", "B", "B", "B", "A", "A", "A"),
+    value = c(1, 2.5, 4, 2.1, 3, 6.2, 5, 6.5, 8),
+    ID = c(1, 2, 3, 1, 2, 3, 1, 2, 3)
+  )
+  expect_no_error(
+    got <- compare_means(
+      value ~ g, d,
+      method = "t.test", paired = TRUE, id = "ID",
+      group.by = "block"
+    )
+  )
+  expect_equal(unique(as.character(got$block)), "x")
+  expect_equal(nrow(got), 1L)
+  expect_equal(c(got$group1, got$group2), c("A", "B"))
+})
+
+test_that("id skips grouped t-test subsets with too few complete pairs", {
+  d <- data.frame(
+    block = c(rep("x", 6), rep("y", 4)),
+    g = c("A", "A", "A", "B", "B", "B", "A", "A", "B", "B"),
+    value = c(1, 2.5, 4, 2.1, 3, 6.2, 5, 6.5, 8, 9),
+    ID = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 4)
+  )
+  expect_no_error(
+    got <- compare_means(
+      value ~ g, d,
+      method = "t.test", paired = TRUE, id = "ID",
+      group.by = "block"
+    )
+  )
+  expect_equal(unique(as.character(got$block)), "x")
+  expect_equal(nrow(got), 1L)
+  expect_equal(c(got$group1, got$group2), c("A", "B"))
+})
+
+test_that("id skips only invalid grouped pairwise t-test comparisons", {
+  d <- data.frame(
+    block = c(rep("x", 9), rep("y", 6)),
+    g = c(rep(c("A", "B", "C"), each = 3), rep(c("A", "B", "C"), each = 2)),
+    value = c(1, 2, 4, 2.2, 4.1, 7.4, 1.4, 2.9, 5.5, 10, 11, 20, 21, 30, 32),
+    ID = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 4, 1, 2)
+  )
+  expect_no_error(
+    got <- compare_means(
+      value ~ g, d,
+      method = "t.test", paired = TRUE, id = "ID",
+      group.by = "block"
+    )
+  )
+  got$key <- paste(as.character(got$block), got$group1, got$group2)
+  expect_setequal(got$key, c("x A B", "x A C", "x B C", "y A C"))
+})
+
+test_that("id keeps grouped Wilcoxon comparisons with one complete pair", {
+  d <- data.frame(
+    block = c(rep("x", 4), rep("y", 2)),
+    g = c("A", "A", "B", "B", "A", "B"),
+    value = c(1, 3, 2, 5, 10, 12),
+    ID = c(1, 2, 1, 2, 1, 1)
+  )
+  expect_no_error(
+    got <- compare_means(
+      value ~ g, d,
+      method = "wilcox.test", paired = TRUE, id = "ID",
+      group.by = "block"
+    )
+  )
+  expect_setequal(as.character(got$block), c("x", "y"))
+  expect_equal(nrow(got), 2L)
 })
 
 test_that("id works together with ref.group (only ref comparisons, matching rstatix)", {

--- a/tests/testthat/test-stat-compare-means-id.R
+++ b/tests/testthat/test-stat-compare-means-id.R
@@ -77,6 +77,67 @@ test_that("id works with ref.group in the plot (matches compare_means)", {
   expect_equal(length(labs), 2L)
 })
 
+test_that("id forwards one-sided alternatives supplied through method.args", {
+  one_sided <- .stat_label(
+    ggpaired(.d, x = "sampleType", y = "value") +
+      stat_compare_means(
+        paired = TRUE, id = "ID", method = "t.test",
+        method.args = list(alternative = "greater"),
+        label = "p.format"
+      )
+  )
+  two_sided <- .stat_label(
+    ggpaired(.d, x = "sampleType", y = "value") +
+      stat_compare_means(
+        paired = TRUE, id = "ID", method = "t.test",
+        label = "p.format"
+      )
+  )
+  expected <- compare_means(
+    value ~ sampleType, .d,
+    paired = TRUE, id = "ID", method = "t.test",
+    alternative = "greater"
+  )$p.format
+  expect_true(grepl(expected, one_sided, fixed = TRUE))
+  expect_false(identical(one_sided, two_sided))
+})
+
+test_that("id skips sparse faceted subsets in the stat layer", {
+  d <- data.frame(
+    block = c(rep("x", 6), rep("y", 4)),
+    g = c("A", "A", "A", "B", "B", "B", "A", "A", "B", "B"),
+    value = c(1, 2.5, 4, 2.1, 3, 6.2, 5, 6.5, 8, 9),
+    ID = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 4)
+  )
+  warnings <- .warnings_of(
+    built <- ggplot2::ggplot_build(
+      ggboxplot(d, x = "g", y = "value", facet.by = "block") +
+        stat_compare_means(method = "t.test", paired = TRUE, id = "ID")
+    )
+  )
+  expect_false(any(grepl("Computation failed|not enough", warnings)))
+  labels <- unlist(lapply(built$data, function(x) {
+    if ("label" %in% names(x)) as.character(x$label) else NULL
+  }))
+  expect_true(length(labels) >= 1L)
+})
+
+test_that("id duplicate errors are surfaced in faceted stat layers", {
+  d <- data.frame(
+    block = c(rep("x", 4), rep("y", 4)),
+    g = c("A", "A", "B", "B", "A", "A", "B", "B"),
+    value = c(1, 2, 3, 5, 10, 11, 20, 21),
+    ID = c(1, 2, 1, 2, 1, 1, 1, 2)
+  )
+  warnings <- .warnings_of(
+    ggplot2::ggplot_build(
+      ggboxplot(d, x = "g", y = "value", facet.by = "block") +
+        stat_compare_means(method = "t.test", paired = TRUE, id = "ID")
+    )
+  )
+  expect_true(any(grepl("duplicated ids", warnings)))
+})
+
 test_that("id errors clearly on unsupported combinations (not a silent wrong p)", {
   # with `comparisons`, id can't be honored (ggsignif path) -> error, do not
   # silently draw a row-order p-value


### PR DESCRIPTION
## Summary
- forward method arguments correctly through paired-id `compare_means()` and `stat_compare_means()` paths
- skip sparse grouped/faceted paired-id subsets while preserving duplicate-id diagnostics
- align APA/NEJM p-value formatting documentation with implemented presets
- refresh CRAN comments and ignore local publication artifacts

## Validation
- Focused tests: 62 pass, 0 fail, 0 warn, 0 skip
- Full tests after rebasing on upstream PR #731: 992 pass, 0 fail, 8 warn, 0 skip
- `R CMD build`: OK
- `R CMD check --as-cran`: 1 NOTE, Date field is over a month old

## Notes
- Rebased onto `origin/master` at `f20426d3d668c016b0bf3dbb370e9ae5344630ec` after upstream merged #731.
- The 8 full-test warnings are existing warning-emitting tests in `geom_pwc` and `stat_pvalue_manual`, not introduced by this change.
- Prepared from the clean publication worktree `/Users/erdeylaszlo/.codex/worktrees/publication/ggpubr`.
