### PR TITLE
feat(stat_cor): add label.anchor to keep labels aligned across panels (#248)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,14 @@
 
 ## New features
 
+- `stat_cor()` and `stat_regline_equation()` gain a `label.anchor` argument.
+  With `label.anchor = "panel"` the label is placed at the true panel-relative
+  position (npc), so labels stay aligned across panels or facets whose axis
+  ranges differ - e.g. `facet_wrap(scales = "free_y")`, `geom_smooth()`
+  extending each panel by a different amount, or separate plots combined with
+  `ggarrange()`. The default `label.anchor = "data"` keeps the previous
+  data-range placement, so existing plots are unchanged (#248).
+
 - `geom_bracket()` gains an `orientation` argument. `orientation = "vertical"`
   draws a native vertical bracket (the bar spans the y axis, the tips point left
   and the label is rotated), specified with `ymin`/`ymax`/`x.position` — useful

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -40,6 +40,16 @@ NULL
 #'  factor is mapped to an aesthetic that also defines the facets. This places the
 #'  labels flush with the top of each panel; it is similar in spirit to the
 #'  \code{aes(group = 1)} workaround, which instead leaves them one text line lower.
+#' @param label.anchor character. How \code{label.x.npc}/\code{label.y.npc} are
+#'  interpreted. \code{"data"} (default) converts them to data coordinates using
+#'  the data range, so the label follows the data; the output is unchanged from
+#'  previous versions. \code{"panel"} places the label at the true panel-relative
+#'  position (npc), so the labels stay aligned across panels/facets whose axis
+#'  ranges differ - e.g. with \code{facet_wrap(scales = "free_y")}, with
+#'  \code{geom_smooth()} extending each panel by a different amount, or across
+#'  separate plots combined with \code{\link{ggarrange}()}. An explicit
+#'  \code{label.x}/\code{label.y} always stays in data units regardless of
+#'  \code{label.anchor}. Requires ggplot2 >= 3.5.0 (already a dependency).
 #' @param output.type character One of "expression", "latex", "tex" or "text".
 #' @param digits,r.digits,p.digits integer indicating the number of decimal
 #'  places (round) or significant digits (signif) to be used for the correlation
@@ -167,6 +177,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
                      cor.coef.name = c("R", "rho", "tau"), label.sep = ", ",
                      label.x.npc = "left", label.y.npc = "top",
                      label.x = NULL, label.y = NULL, label.y.step = 1.4,
+                     label.anchor = c("data", "panel"),
                      output.type = "expression",
                      digits = 2, r.digits = digits, p.digits = digits,
                      r.accuracy = NULL, p.accuracy = NULL,
@@ -177,6 +188,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
                      inherit.aes = TRUE, ...) {
   parse <- ifelse(output.type == "expression", TRUE, FALSE)
   cor.coef.name <- cor.coef.name[1]
+  label.anchor <- match.arg(label.anchor)
   if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
       conf.level <= 0 || conf.level >= 1) {
     stop("`conf.level` must be a single number between 0 and 1.", call. = FALSE)
@@ -187,6 +199,7 @@ stat_cor <- function(mapping = NULL, data = NULL,
     params = list(
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
       label.x = label.x, label.y = label.y, label.y.step = label.y.step,
+      label.anchor = label.anchor,
       label.sep = label.sep,
       method = method, alternative = alternative, output.type = output.type, digits = digits,
       r.digits = r.digits, p.digits = p.digits, r.accuracy = r.accuracy,
@@ -205,7 +218,8 @@ StatCor <- ggproto("StatCor", Stat,
   required_aes = c("x", "y"),
   default_aes = aes(hjust = after_stat(hjust), vjust = after_stat(vjust)),
   compute_group = function(data, scales, method, alternative, label.x.npc, label.y.npc,
-                           label.x, label.y, label.y.step = 1.4, label.sep, output.type, digits,
+                           label.x, label.y, label.y.step = 1.4, label.anchor = "data",
+                           label.sep, output.type, digits,
                            r.digits, p.digits, r.accuracy, p.accuracy, r.leading.zero,
                            p.format.style, p.leading.zero, p.decimal.mark, cor.coef.name,
                            p.coef.name, conf.level = 0.95) {
@@ -230,7 +244,8 @@ StatCor <- ggproto("StatCor", Stat,
     .label.pms <- .label_params(
       data = data, scales = scales,
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y, label.y.step = label.y.step
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step,
+      label.anchor = label.anchor
     ) %>%
       mutate(hjust = 0)
     cbind(.test, .label.pms)

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -29,6 +29,13 @@ NULL
 #'  units) between the labels of successive groups. Default is 1.4 (unchanged
 #'  behavior). Set \code{label.y.step = 0} to stop the per-group vertical shift so
 #'  labels align across facet panels.
+#' @param label.anchor character. How \code{label.x.npc}/\code{label.y.npc} are
+#'  interpreted. \code{"data"} (default) converts them to data coordinates (the
+#'  previous behavior). \code{"panel"} places the label at the true panel-relative
+#'  position (npc), so labels stay aligned across panels/facets with different
+#'  axis ranges (e.g. \code{scales = "free_y"} or \code{geom_smooth()} extending
+#'  each panel). An explicit \code{label.x}/\code{label.y} always stays in data
+#'  units. Requires ggplot2 >= 3.5.0 (already a dependency).
 #' @param output.type character One of "expression", "latex" or "text".
 #' @param decreasing logical. If \code{TRUE} (the default), the equation is
 #'   formatted in standard mathematical convention with terms in decreasing
@@ -110,12 +117,14 @@ stat_regline_equation <- function(
   mapping = NULL, data = NULL, formula = y ~ x,
   label.x.npc = "left", label.y.npc = "top",
   label.x = NULL, label.y = NULL, label.y.step = 1.4,
+  label.anchor = c("data", "panel"),
   output.type = "expression", decreasing = TRUE,
   coef.digits = 2, rr.digits = 2,
   geom = "text", position = "identity", na.rm = FALSE, show.legend = NA,
   inherit.aes = TRUE, ...
 ) {
   parse <- ifelse(output.type == "expression", TRUE, FALSE)
+  label.anchor <- match.arg(label.anchor)
   # Convert any dot-dot notation in user-provided mapping
   mapping <- convert_label_dotdot_notation_to_after_stat(mapping)
 
@@ -125,6 +134,7 @@ stat_regline_equation <- function(
     params = list(
       formula = formula, label.x.npc = label.x.npc, label.y.npc = label.y.npc,
       label.x = label.x, label.y = label.y, label.y.step = label.y.step,
+      label.anchor = label.anchor,
       output.type = output.type, decreasing = decreasing,
       coef.digits = coef.digits, rr.digits = rr.digits,
       parse = parse, na.rm = na.rm, ...
@@ -137,7 +147,8 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
   required_aes = c("x", "y"),
   default_aes = aes(label = after_stat(eq.label), hjust = after_stat(hjust), vjust = after_stat(vjust)),
   compute_group = function(data, scales, formula, label.x.npc, label.y.npc,
-                           label.x, label.y, label.y.step = 1.4, output.type, decreasing,
+                           label.x, label.y, label.y.step = 1.4, label.anchor = "data",
+                           output.type, decreasing,
                            coef.digits = 2, rr.digits = 2) {
     force(data)
 
@@ -151,7 +162,8 @@ StatReglineEquation <- ggproto("StatReglineEquation", Stat,
     .label.pms <- .label_params(
       data = data, scales = scales,
       label.x.npc = label.x.npc, label.y.npc = label.y.npc,
-      label.x = label.x, label.y = label.y, label.y.step = label.y.step
+      label.x = label.x, label.y = label.y, label.y.step = label.y.step,
+      label.anchor = label.anchor
     ) %>%
       mutate(hjust = 0)
     cbind(.test, .label.pms)

--- a/R/utilities_label.R
+++ b/R/utilities_label.R
@@ -7,11 +7,26 @@
 # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Returns a data frame with x, y, hjust, vjust
 # group.id is the index position of the group in a boxplot for example
+# Pick the axis position for a label from its npc fraction. With
+# label.anchor = "panel" the fraction is returned as an AsIs (`I()`) value so
+# ggplot2 (>= 3.5.0) places it at the true panel-relative npc AT DRAW TIME -
+# this keeps labels aligned across panels/facets whose axis ranges differ (e.g.
+# scales = "free_y" or geom_smooth extending each panel), fixing #248. With
+# label.anchor = "data" (default) the caller-supplied `data.value` - the exact
+# historical data-coordinate expression for that anchor - is returned verbatim,
+# so default output stays bit-identical.
+.npc_to_position <- function(npc, data.value, label.anchor = "data") {
+  if (identical(label.anchor, "panel")) return(I(npc))
+  data.value
+}
+
 .label_params <- function(data, scales, label.x.npc = "left", label.y.npc = "right",
                           label.x = NULL, label.y = NULL, label.y.step = 1.4,
+                          label.anchor = c("data", "panel"),
                           .by = c("group", "panel"),
                           group.id = NULL, ...) {
   .by <- match.arg(.by)
+  label.anchor <- match.arg(label.anchor)
   # Check label coordinates for each group
   # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   if (is.null(group.id)) {
@@ -30,19 +45,25 @@
     x <- label.x
     hjust <- 0.5
   } else if (length(label.x.npc) > 0) {
+    # For each anchor, resolve the npc fraction (for panel mode) alongside the
+    # EXACT historical data expression (for the default data mode), so
+    # label.anchor = "data" is bit-identical to previous versions.
     if (is.numeric(label.x.npc)) {
-      x <- scales$x$dimension()[1] + label.x.npc *
-        diff(scales$x$dimension())
+      x <- .npc_to_position(
+        label.x.npc,
+        scales$x$dimension()[1] + label.x.npc * diff(scales$x$dimension()),
+        label.anchor
+      )
       hjust <- 0.5
     } else if (is.character(label.x.npc)) {
       if (label.x.npc == "right") {
-        x <- scales$x$dimension()[2]
+        x <- .npc_to_position(1, scales$x$dimension()[2], label.anchor)
         hjust <- 1
       } else if (label.x.npc %in% c("center", "centre", "middle")) {
-        x <- mean(scales$x$dimension())
+        x <- .npc_to_position(0.5, mean(scales$x$dimension()), label.anchor)
         hjust <- 0.5
       } else if (label.x.npc == "left") {
-        x <- scales$x$dimension()[1]
+        x <- .npc_to_position(0, scales$x$dimension()[1], label.anchor)
         hjust <- 0
       }
     }
@@ -53,18 +74,21 @@
     vjust <- 0.5
   } else if (length(label.y.npc) > 0) {
     if (is.numeric(label.y.npc)) {
-      y <- scales$y$dimension()[1] + label.y.npc *
-        diff(scales$y$dimension())
+      y <- .npc_to_position(
+        label.y.npc,
+        scales$y$dimension()[1] + label.y.npc * diff(scales$y$dimension()),
+        label.anchor
+      )
       vjust <- label.y.step * group.id - (label.y.step / 2 * length(group.id))
     } else if (is.character(label.y.npc)) {
       if (label.y.npc == "bottom") {
-        y <- scales$y$dimension()[1]
+        y <- .npc_to_position(0, scales$y$dimension()[1], label.anchor)
         vjust <- -label.y.step * group.id
       } else if (label.y.npc %in% c("center", "centre", "middle")) {
-        y <- mean(scales$y$dimension())
+        y <- .npc_to_position(0.5, mean(scales$y$dimension()), label.anchor)
         vjust <- label.y.step * group.id - (label.y.step / 2 * length(group.id))
       } else if (label.y.npc == "top") {
-        y <- scales$y$dimension()[2]
+        y <- .npc_to_position(1, scales$y$dimension()[2], label.anchor)
         vjust <- label.y.step * group.id
       }
     }

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -16,6 +16,7 @@ stat_cor(
   label.x = NULL,
   label.y = NULL,
   label.y.step = 1.4,
+  label.anchor = c("data", "panel"),
   output.type = "expression",
   digits = 2,
   r.digits = digits,
@@ -93,6 +94,17 @@ per-group vertical shift, so that labels align across facet panels when a
 factor is mapped to an aesthetic that also defines the facets. This places the
 labels flush with the top of each panel; it is similar in spirit to the
 \code{aes(group = 1)} workaround, which instead leaves them one text line lower.}
+
+\item{label.anchor}{character. How \code{label.x.npc}/\code{label.y.npc} are
+interpreted. \code{"data"} (default) converts them to data coordinates using
+the data range, so the label follows the data; the output is unchanged from
+previous versions. \code{"panel"} places the label at the true panel-relative
+position (npc), so the labels stay aligned across panels/facets whose axis
+ranges differ - e.g. with \code{facet_wrap(scales = "free_y")}, with
+\code{geom_smooth()} extending each panel by a different amount, or across
+separate plots combined with \code{\link{ggarrange}()}. An explicit
+\code{label.x}/\code{label.y} always stays in data units regardless of
+\code{label.anchor}. Requires ggplot2 >= 3.5.0 (already a dependency).}
 
 \item{output.type}{character One of "expression", "latex", "tex" or "text".}
 

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -13,6 +13,7 @@ stat_regline_equation(
   label.x = NULL,
   label.y = NULL,
   label.y.step = 1.4,
+  label.anchor = c("data", "panel"),
   output.type = "expression",
   decreasing = TRUE,
   coef.digits = 2,
@@ -66,6 +67,14 @@ for absolute positioning of the label. If too short they will be recycled.}
 units) between the labels of successive groups. Default is 1.4 (unchanged
 behavior). Set \code{label.y.step = 0} to stop the per-group vertical shift so
 labels align across facet panels.}
+
+\item{label.anchor}{character. How \code{label.x.npc}/\code{label.y.npc} are
+interpreted. \code{"data"} (default) converts them to data coordinates (the
+previous behavior). \code{"panel"} places the label at the true panel-relative
+position (npc), so labels stay aligned across panels/facets with different
+axis ranges (e.g. \code{scales = "free_y"} or \code{geom_smooth()} extending
+each panel). An explicit \code{label.x}/\code{label.y} always stays in data
+units. Requires ggplot2 >= 3.5.0 (already a dependency).}
 
 \item{output.type}{character One of "expression", "latex" or "text".}
 

--- a/tests/testthat/test-stat-cor-label-anchor.R
+++ b/tests/testthat/test-stat-cor-label-anchor.R
@@ -1,0 +1,137 @@
+context("test-stat-cor-label-anchor")
+
+# #248 (Cause 2): stat_cor()/stat_regline_equation() gain label.anchor. With
+# label.anchor = "panel" the label is placed at true panel-relative npc (via
+# AsIs), so labels align across panels/facets with different axis ranges (e.g.
+# scales = "free_y" or geom_smooth extending each panel differently). The default
+# label.anchor = "data" is byte-identical to the historical behavior.
+
+.cor_label <- function(p) {
+  b <- suppressMessages(ggplot2::ggplot_build(p))
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+  d <- b$data[[i]]
+  d[order(d$PANEL), ]
+}
+
+d1 <- data.frame(x = c(1, 2, 3, 4, 5, 6), y = c(2, 4, 5, 4, 6, 7))
+
+# ---- Characterization: the default "data" positions must not change ----
+
+test_that("default stat_cor label position (data anchor) is unchanged", {
+  d <- .cor_label(ggscatter(d1, "x", "y") + stat_cor())
+  # "left" -> x = data min (1); "top" -> y = data max (7); vjust = label.y.step (1.4).
+  # expect_identical (not just equal) pins the exact endpoint values, so a
+  # regression that changes the anchor formula (wrong fraction, wrong endpoint,
+  # or accidentally emitting an npc/AsIs value) fails here.
+  expect_identical(as.numeric(d$x), 1)
+  expect_identical(as.numeric(d$y), 7)
+  expect_identical(d$vjust, 1.4)
+  expect_false(inherits(d$x, "AsIs"))    # data coords, not npc
+})
+
+test_that("numeric and character npc positions (data anchor) are unchanged", {
+  dn <- .cor_label(ggscatter(d1, "x", "y") + stat_cor(label.x.npc = 0.1, label.y.npc = 0.9))
+  expect_equal(as.numeric(dn$x), 1.5)    # 1 + 0.1*(6-1)
+  expect_equal(as.numeric(dn$y), 6.5)    # 2 + 0.9*(7-2)
+  dc <- .cor_label(ggscatter(d1, "x", "y") + stat_cor(label.x.npc = "center", label.y.npc = "center"))
+  expect_identical(as.numeric(dc$x), mean(c(1, 6)))  # center uses mean(range) exactly
+  expect_identical(as.numeric(dc$y), mean(c(2, 7)))
+  db <- .cor_label(ggscatter(d1, "x", "y") + stat_cor(label.x.npc = "right", label.y.npc = "bottom"))
+  expect_identical(as.numeric(db$x), 6)  # data max x
+  expect_identical(as.numeric(db$y), 2)  # data min y
+})
+
+test_that("per-group vjust formulas (top/bottom/center) are unchanged", {
+  set.seed(1)
+  dg <- data.frame(x = rnorm(30), y = rnorm(30), g = rep(c("a", "b", "c"), 10))
+  vj <- function(npc) {
+    p <- ggplot(dg, aes(x, y, color = g)) + geom_point() +
+      stat_cor(aes(color = g), label.y.npc = npc)
+    sort(.cor_label(p)$vjust)
+  }
+  # group ids 1,2,3 with label.y.step = 1.4 (.label_params runs per group, so
+  # length(group.id) == 1 in each call)
+  expect_equal(vj("top"),    c(1.4, 2.8, 4.2))            # step * id
+  expect_equal(vj("bottom"), c(-4.2, -2.8, -1.4))         # -step * id
+  expect_equal(vj("center"), sort(1.4 * (1:3) - 1.4 / 2))  # step*id - step/2
+})
+
+test_that("stat_compare_means labels are byte-identical (shared helper untouched)", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  scm <- function(p) {
+    b <- suppressMessages(ggplot2::ggplot_build(p))
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+    d <- b$data[[i]]
+    data.frame(x = as.numeric(d$x), y = as.numeric(d$y), vjust = d$vjust)
+  }
+  s1 <- scm(ggboxplot(df, "dose", "len") + stat_compare_means())
+  expect_identical(as.numeric(s1$x), 1)
+  expect_identical(s1$y, 33.9)                # data max area (dimension()[2]) - exact
+  expect_false(inherits(s1$y, "AsIs"))        # never npc/AsIs
+  s2 <- scm(ggboxplot(df, "dose", "len", color = "supp") + stat_compare_means(aes(group = supp)))
+  expect_equal(as.numeric(s2$x), c(1, 2, 3))
+  expect_true(all(s2$y == 33.9))
+})
+
+test_that("explicit label.x/label.y stay in data coordinates in both modes", {
+  dd <- .cor_label(ggscatter(d1, "x", "y") + stat_cor(label.x = 2, label.y = 5))
+  expect_equal(as.numeric(dd$x), 2); expect_equal(as.numeric(dd$y), 5)
+  # even with label.anchor = "panel", explicit coords win and stay data coords
+  dp <- .cor_label(ggscatter(d1, "x", "y") + stat_cor(label.x = 2, label.y = 5, label.anchor = "panel"))
+  expect_equal(as.numeric(dp$x), 2); expect_equal(as.numeric(dp$y), 5)
+  expect_false(inherits(dp$x, "AsIs"))
+})
+
+# ---- The fix: panel anchor aligns labels across free-scale facets ----
+
+.free_facet <- function(anchor) {
+  d <- data.frame(x = c(1, 2, 3, 1, 1, 2, 3, 1), y = c(1, 2, 3, 3, 1, 2, 2, 2),
+                  z = c("A", "A", "A", "A", "B", "B", "B", "B"))
+  p <- ggplot(d, aes(x, y)) + geom_point() +
+    ggplot2::geom_smooth(method = "lm", se = FALSE, formula = y ~ x) +
+    stat_cor(label.anchor = anchor) +
+    ggplot2::facet_wrap(ggplot2::vars(z), scales = "free_y")
+  b <- suppressMessages(ggplot2::ggplot_build(p))
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+  td <- b$data[[i]]
+  td[order(td$PANEL), ]
+}
+
+test_that("label.anchor = 'panel' emits AsIs npc equal across free_y panels", {
+  tp <- .free_facet("panel")
+  expect_true(inherits(tp$y, "AsIs"))
+  expect_equal(length(unique(as.numeric(tp$y))), 1L)   # same npc in every panel
+  # default 'data' anchor gives DIFFERENT y per panel (the bug being fixed)
+  tdd <- .free_facet("data")
+  expect_false(inherits(tdd$y, "AsIs"))
+  expect_gt(length(unique(round(as.numeric(tdd$y), 4))), 1L)
+})
+
+test_that("label.anchor = 'panel' renders for stat_cor and stat_regline_equation", {
+  d <- data.frame(x = c(1, 2, 3, 1, 1, 2, 3, 1), y = c(1, 2, 3, 3, 1, 2, 2, 2),
+                  z = c("A", "A", "A", "A", "B", "B", "B", "B"))
+  base <- ggplot(d, aes(x, y)) + geom_point() +
+    ggplot2::geom_smooth(method = "lm", se = FALSE, formula = y ~ x) +
+    ggplot2::facet_wrap(ggplot2::vars(z), scales = "free_y")
+  expect_error(suppressMessages(ggplot2::ggplotGrob(base + stat_cor(label.anchor = "panel"))), NA)
+  expect_error(suppressMessages(ggplot2::ggplotGrob(base + stat_regline_equation(label.anchor = "panel"))), NA)
+})
+
+test_that("multiple grouped labels still stack under panel anchor (label.y.step)", {
+  set.seed(1)
+  dg <- data.frame(x = rnorm(30), y = rnorm(30), g = rep(c("a", "b", "c"), 10))
+  p <- ggplot(dg, aes(x, y, color = g)) + geom_point() +
+    stat_cor(aes(color = g), label.anchor = "panel")
+  td <- .cor_label(p)
+  expect_equal(nrow(td), 3)
+  expect_true(inherits(td$y, "AsIs"))
+  expect_equal(length(unique(as.numeric(td$y))), 1L)   # same npc anchor...
+  expect_equal(length(unique(td$vjust)), 3L)            # ...offset by vjust per group
+})
+
+test_that("label.anchor rejects invalid values", {
+  # message is locale-dependent (match.arg); just assert it errors
+  expect_error(stat_cor(label.anchor = "nope"))
+  expect_error(stat_regline_equation(label.anchor = "nope"))
+})


### PR DESCRIPTION
### What

`stat_cor()` and `stat_regline_equation()` gain a `label.anchor` argument. With `label.anchor = "panel"` the correlation coefficient / regression equation label is placed at the true **panel-relative** position (npc) instead of being converted to data coordinates, so labels stay aligned across panels or facets whose axis ranges differ (#248).

```r
library(ggpubr)
d <- data.frame(x = c(1,2,3,1,1,2,3,1), y = c(1,2,3,3,1,2,2,2),
                z = c("A","A","A","A","B","B","B","B"))
ggplot(d, aes(x, y)) + geom_point() + geom_smooth(method = "lm", se = FALSE) +
  stat_cor(label.anchor = "panel") +
  facet_wrap(vars(z), scales = "free_y")
```

### Why

This is the original "Cause 2" of the issue: the label was anchored to the **data range**, but each panel's final axis range differs (e.g. `scales = "free_y"`, or `geom_smooth()` extending each panel by a different amount, or separate plots combined with `ggarrange()`), so `label.y.npc = "top"` landed at a different visual height per panel. Placing the label at true panel npc (deferred to draw time via an `AsIs` position) keeps them aligned. (The earlier `label.y.step` addition already handled "Cause 1", the per-group stair-stepping.)

### Behaviour / compatibility

- Default `label.anchor = "data"` reproduces the previous data-coordinate placement **exactly** (bit-identical). Existing `stat_cor`/`stat_regline_equation` plots are unchanged, and `stat_compare_means()` (which shares the internal label helper) is unaffected.
- An explicit `label.x`/`label.y` always stays in data units, in both modes.
- Requires ggplot2 >= 3.5.0 for the panel-npc placement, which is already a package dependency (`>= 3.5.2`).

### Tests

Adds characterization tests pinning the exact default ("data") positions and per-group `vjust` for `top`/`bottom`/`center`, a `stat_compare_means` byte-identity test, and tests for the new panel-mode alignment across `free_y` facets and multi-group stacking.

Addresses the outstanding part of #248.
