### PR TITLE
geom_bracket(): draw visible tips for a single bracket over geom_bar()/geom_histogram() (#631)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,13 @@
   no complete pairs) instead of failing the whole result/layer, while still
   reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
   @erdeyl (#732).
+- `geom_bracket()` (and `stat_pvalue_manual()`) now draw visible tips for a single
+  bracket placed over a stat-computed `y` such as `geom_bar()`/`geom_histogram()`.
+  Previously the bracket tips collapsed into a flat line because the y-axis range
+  was trained only on the bracket's single `y.position`; the tips are now sized
+  against the fully-trained panel range at draw time, so they render correctly even
+  with `coord_cartesian(ylim = ...)`. Brackets with an already non-zero y range are
+  unchanged (#631).
 
 ## P-value formatting
 

--- a/R/geom_bracket.R
+++ b/R/geom_bracket.R
@@ -143,6 +143,18 @@ StatBracket <- ggplot2::ggproto("StatBracket", ggplot2::Stat,
       data$yend <- pos.end
     }
     data$annotation <- rep(label, 3)
+    # #631: when the POSITION axis is trained to a zero-width range - e.g. a single
+    # bracket over a stat-computed y such as geom_bar()/geom_histogram(), whose bar
+    # counts do not train the y scale by the time this stat runs - tip.scale.range
+    # is 0 and the tips above collapse to zero length (an invisible flat bar).
+    # Record that so GeomBracket$draw_group can re-derive the tips against the
+    # fully-trained panel range at draw time (the only place the real range,
+    # including coord_cartesian(ylim=), is known). These internal columns are
+    # ignored by rendering; for a normal, non-zero range the flag is FALSE and
+    # nothing downstream changes, so existing plots are byte-identical.
+    data$.bracket.tip.zero. <- !is.finite(tip.scale.range) || isTRUE(tip.scale.range == 0)
+    data$.bracket.tip.left. <- tip.length[seq_along(tip.length) %% 2 == 1][1]
+    data$.bracket.tip.right. <- tip.length[seq_along(tip.length) %% 2 == 0][1]
     data
   }
 )
@@ -332,6 +344,24 @@ GeomBracket <- ggplot2::ggproto("GeomBracket", ggplot2::Geom,
       lab <- parse_as_expression(lab)
     }
     coords <- coord$transform(data, panel_params)
+    # #631: rescue tips that collapsed because the position axis trained to a
+    # zero-width data range (StatBracket flagged it via .bracket.tip.zero.). Here,
+    # after transform, the panel maps to npc [0, 1] over its FULLY-trained range
+    # (which includes coord_cartesian(ylim=) and scale limits), so a tip length
+    # given as a fraction of that range is simply the fraction itself in npc units.
+    # Rebuild the two tips against that range. Gated to the default horizontal,
+    # non-flipped bracket and to the flagged degenerate case, so every normal plot
+    # (tip.scale.range > 0 -> flag FALSE) keeps its exact current tips.
+    if (identical(orientation, "horizontal") && !isTRUE(coord.flip) &&
+        nrow(coords) == 3 && isTRUE(coords$.bracket.tip.zero.[1])) {
+      bar.npc <- coords$y[2]                       # flat bar level (row 2)
+      tip.left <- coords$.bracket.tip.left.[1]     # untransformed fraction
+      tip.right <- coords$.bracket.tip.right.[1]
+      if (is.finite(bar.npc)) {
+        if (is.finite(tip.left) && tip.left > 0) coords$y[1] <- bar.npc - tip.left
+        if (is.finite(tip.right) && tip.right > 0) coords$yend[3] <- bar.npc - tip.right
+      }
+    }
     label.x <- mean(c(coords$x[1], tail(coords$xend, n = 1)))
     label.y <- max(c(coords$y, coords$yend)) + 0.01
     label.angle <- coords$angle

--- a/tests/testthat/test-geom-bracket-tip-collapse.R
+++ b/tests/testthat/test-geom-bracket-tip-collapse.R
@@ -1,0 +1,132 @@
+context("test-geom-bracket-tip-collapse")
+
+# #631: geom_bracket() tips collapsed to an invisible flat line whenever the
+# position axis was trained to a zero-width range - the classic case being a
+# SINGLE bracket over a stat-computed y (geom_bar()/geom_histogram()), where the
+# bar counts do not train the y scale by the time StatBracket runs, so the only
+# y value is the bracket's own y.position. StatBracket now flags that case and
+# GeomBracket$draw_group re-derives the tips against the fully-trained panel range
+# at draw time (which knows coord_cartesian(ylim=) / scale limits). Normal
+# brackets (mapped y, non-zero range) are byte-identical - the flag is FALSE and
+# the draw path is untouched.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+# Drawn segment grob (npc coords) for the bracket layer.
+.bracket_segments <- function(p) {
+  li <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))[1]
+  lg <- ggplot2::layer_grob(p, li)[[1]]
+  ch <- lg$children
+  seg <- ch[[which(vapply(ch, function(g) inherits(g, "segments"), logical(1)))[1]]]
+  list(y0 = as.numeric(seg$y0), y1 = as.numeric(seg$y1))
+}
+
+# Built (pre-transform) bracket-layer data.
+.bracket_data <- function(p) {
+  b <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p)))
+  li <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))[1]
+  b$data[[li]]
+}
+
+set.seed(1)
+bard <- data.frame(Q3 = sample(c("First", "Second", "Third"), 90, replace = TRUE))
+
+# ---- The fix: a single bracket over geom_bar() now draws visible tips ----
+
+test_that("single bracket over geom_bar draws tips of length tip.length (npc)", {
+  p <- ggplot(bard, aes(Q3)) + geom_bar() + coord_cartesian(ylim = c(0, 30)) +
+    geom_bracket(xmin = "First", xmax = "Second", y.position = 26,
+                 tip.length = 0.2, label = "**")
+  s <- .bracket_segments(p)
+  # rows: 1 = left tip, 2 = bar (flat), 3 = right tip. The bar npc is y at row 2.
+  bar <- s$y1[2]
+  expect_equal(s$y0[2], s$y1[2])                 # bar is flat
+  # left tip drops from bar down by tip.length in npc (axis reference)
+  expect_equal(bar - s$y0[1], 0.2, tolerance = 1e-6)
+  # right tip drops from bar down by tip.length in npc
+  expect_equal(bar - s$y1[3], 0.2, tolerance = 1e-6)
+  expect_lt(s$y0[1], bar)                         # visibly below the bar
+})
+
+test_that("the fix also works with scale_y_continuous(limits=) and geom_histogram", {
+  p1 <- ggplot(bard, aes(Q3)) + geom_bar() + scale_y_continuous(limits = c(0, 40)) +
+    geom_bracket(xmin = "First", xmax = "Second", y.position = 30, tip.length = 0.15, label = "*")
+  s1 <- .bracket_segments(p1)
+  expect_equal(s1$y1[2] - s1$y0[1], 0.15, tolerance = 1e-6)
+
+  dh <- data.frame(v = rnorm(300))
+  p2 <- ggplot(dh, aes(v)) + geom_histogram(bins = 20) +
+    geom_bracket(xmin = -1, xmax = 1, y.position = 30, tip.length = 0.1, label = "*")
+  s2 <- .bracket_segments(p2)
+  expect_equal(s2$y1[2] - s2$y0[1], 0.1, tolerance = 1e-6)
+})
+
+test_that("asymmetric tip.length is honored per side in the collapsed case", {
+  p <- ggplot(bard, aes(Q3)) + geom_bar() + coord_cartesian(ylim = c(0, 30)) +
+    geom_bracket(xmin = "First", xmax = "Second", y.position = 26,
+                 tip.length = c(0.05, 0.2), label = "**")
+  s <- .bracket_segments(p)
+  bar <- s$y1[2]
+  expect_equal(bar - s$y0[1], 0.05, tolerance = 1e-6)   # left
+  expect_equal(bar - s$y1[3], 0.2, tolerance = 1e-6)    # right
+})
+
+test_that("tip.length = 0 stays flat even in the collapsed case (intent respected)", {
+  p <- ggplot(bard, aes(Q3)) + geom_bar() + coord_cartesian(ylim = c(0, 30)) +
+    geom_bracket(xmin = "First", xmax = "Second", y.position = 26,
+                 tip.length = 0, label = "**")
+  s <- .bracket_segments(p)
+  expect_equal(s$y0[1], s$y1[2], tolerance = 1e-9)      # no tip
+  expect_equal(s$y1[3], s$y1[2], tolerance = 1e-9)
+})
+
+# ---- Characterization: normal brackets are unchanged (flag FALSE) ----
+
+test_that("StatBracket flags only the zero-width (collapsed) case", {
+  # collapsed: single bracket over geom_bar -> zero-width y range -> flag TRUE
+  d_bar <- .bracket_data(
+    ggplot(bard, aes(Q3)) + geom_bar() +
+      geom_bracket(xmin = "First", xmax = "Second", y.position = 26, label = "*")
+  )
+  expect_true(all(d_bar$.bracket.tip.zero.))
+
+  # normal: mapped y with a real range -> flag FALSE
+  df <- ToothGrowth; df$dose <- factor(df$dose)
+  d_box <- .bracket_data(
+    ggboxplot(df, "dose", "len") +
+      geom_bracket(xmin = "0.5", xmax = "1", y.position = 35, tip.length = 0.03, label = "p")
+  )
+  expect_false(any(d_box$.bracket.tip.zero.))
+})
+
+test_that("normal bracket tips are computed in the data range as before (unchanged)", {
+  df <- ToothGrowth; df$dose <- factor(df$dose)
+  p <- ggboxplot(df, "dose", "len") +
+    geom_bracket(xmin = "0.5", xmax = "1", y.position = 35, tip.length = 0.03, label = "p")
+  d <- .bracket_data(p)
+  # tips are baked into the built data (non-zero, computed against the data range);
+  # row 1 y (left tip bottom) sits below the bar at 35, and the fallback did NOT run.
+  expect_lt(d$y[1], 35)
+  expect_equal(d$y[2], 35)
+  expect_true(all(d$.bracket.tip.zero. == FALSE))
+})
+
+test_that("two brackets over geom_bar (already-working case) still render with tips", {
+  p <- ggplot(bard, aes(Q3)) + geom_bar() +
+    geom_bracket(xmin = "First", xmax = "Second", y.position = 19, tip.length = 0.2, label = "*") +
+    geom_bracket(xmin = "First", xmax = "Third",  y.position = 22, tip.length = 0.2, label = "*")
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+  # first (two-position) layer has a non-zero range -> not flagged
+  d <- .bracket_data(p)
+  expect_false(any(d$.bracket.tip.zero.))
+})
+
+test_that("stat_pvalue_manual (shared draw path) is unaffected and renders", {
+  df <- ToothGrowth; df$dose <- factor(df$dose)
+  stat.test <- data.frame(group1 = "0.5", group2 = "1", p.adj = 0.01, y.position = 35)
+  p <- ggboxplot(df, "dose", "len") +
+    stat_pvalue_manual(stat.test, label = "p.adj", tip.length = 0.03)
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+  d <- .bracket_data(p)
+  expect_false(any(d$.bracket.tip.zero.))   # mapped y, real range -> not flagged
+})


### PR DESCRIPTION
## Summary

A single `geom_bracket()` (or `stat_pvalue_manual()`) placed over a stat-computed `y` — such as `geom_bar()` or `geom_histogram()` — drew its tips as an invisible flat line. With a single bracket, the y-axis range is trained only on the bracket's own `y.position`, so the range has zero width and the tip length (a fraction of that range) comes out as zero. Adding a second bracket accidentally worked because two different `y.position`s give the range a non-zero width.

The tips are now sized against the fully-trained panel range at draw time, so a single bracket renders visible tips — including when the limits come from `coord_cartesian(ylim = ...)` (which previously could not help, since it only zooms).

## Example

```r
library(ggpubr)
set.seed(1)
data <- data.frame(Q3 = sample(c("First", "Second", "Third"), 90, replace = TRUE))

ggplot(data, aes(x = Q3)) +
  geom_bar(fill = 2, alpha = 0.5, color = 1) +
  coord_cartesian(ylim = c(0, 30)) +
  geom_bracket(xmin = "First", xmax = "Second", y.position = 26,
               label.size = 6, tip.length = 0.2, label = "**")
```

The bracket tips now point down toward the bars instead of collapsing.

## Notes

- Brackets that already had a non-zero y range (the usual `ggboxplot()` / `stat_compare_means()` / `geom_col()` / multi-bracket cases) are unchanged.
- `tip.length = 0` still draws no tips.
- Adds tests covering the single-bracket case over `geom_bar()`/`geom_histogram()`, asymmetric `tip.length`, and the unchanged normal paths.

Fixes #631.