### PR TITLE
ggviolin(): align grouped violins with other layers by default when a sub-group is too sparse for a density (#381)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,14 @@
   no complete pairs) instead of failing the whole result/layer, while still
   reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
   @erdeyl (#732).
+- `ggviolin()` now keeps grouped violins aligned with their added box/dot layers by
+  default when a sub-group is too sparse for `geom_violin()` to compute a density
+  (a single data point). Previously the sparse sub-group was dropped from the dodge,
+  so the remaining violin re-centered and no longer lined up. When `drop`/`position`
+  are left at their defaults and such a one-point grouped cell is present, the empty
+  dodge lane is now reserved automatically. Balanced, ungrouped, faceted, and
+  legitimately-unbalanced plots are unchanged, and an explicit `drop`/`position`
+  still takes precedence (#381).
 - `geom_bracket()` (and `stat_pvalue_manual()`) now draw visible tips for a single
   bracket placed over a stat-computed `y` such as `geom_bar()`/`geom_histogram()`.
   Previously the bracket tips collapsed into a flat line because the y-axis range

--- a/R/ggviolin.R
+++ b/R/ggviolin.R
@@ -6,16 +6,17 @@ NULL
 #' data at different values.
 #' @inheritParams ggboxplot
 #' @param width violin width.
-#' @param drop logical, passed to \code{\link[ggplot2]{geom_violin}()}. When
-#'  \code{TRUE} (the default, unchanged behavior), grouped sub-samples with fewer
-#'  than two data points (for which no density can be computed) are dropped,
-#'  including from the dodge position, so the remaining violins re-center and no
-#'  longer line up with other layers (e.g. added boxplots or dot plots). Set
-#'  \code{drop = FALSE} \emph{together with} a "preserve single" dodge, i.e.
-#'  \code{position = position_dodge(0.8, preserve = "single")}, to reserve the
-#'  empty dodge lane so the violins stay aligned with the other geoms. Both are
-#'  needed: \code{drop = FALSE} keeps the sparse group and \code{preserve =
-#'  "single"} keeps its lane width (#381).
+#' @param drop logical, passed to \code{\link[ggplot2]{geom_violin}()}, controlling
+#'  whether grouped sub-samples with fewer than two data points (for which no
+#'  density can be computed) are dropped from the plot and the dodge position. By
+#'  default \code{ggviolin()} keeps grouped violins aligned with their other layers
+#'  (e.g. added boxplots or dot plots) automatically: when you do not set \code{drop}
+#'  or \code{position} and a grouped sub-group has a single data point, the empty
+#'  dodge lane is reserved (equivalent to \code{drop = FALSE} together with
+#'  \code{position = position_dodge(0.8, preserve = "single")}) so the violins stay
+#'  aligned. Balanced, ungrouped, and faceted plots are unaffected. Setting
+#'  \code{drop} or \code{position} explicitly turns off this automatic handling and
+#'  uses exactly what you supply (#381).
 #' @param alpha color transparency. Values should be between 0 and 1.
 #' @param linewidth constant value specifying the line width.
 #' @param quantiles numeric vector of quantiles to draw on the violin.
@@ -195,10 +196,33 @@ ggviolin <- function(data, x, y, combine = FALSE, merge = FALSE,
 }
 
 
+# #381: TRUE when a grouped (dodged) violin has a color/fill x x cell that
+# contains exactly ONE non-missing y value - geom_violin's density-drop trigger
+# (ggplot2 >= 4.0 drops groups with fewer than two points from the plot AND from
+# position adjustment, so the remaining violins re-center and misalign). Used to
+# decide whether to auto-reserve the empty dodge lane. Returns FALSE when there
+# is no grouping aesthetic (no dodge in play), so ungrouped violins never change.
+# A genuinely-absent cell (0 points, e.g. a legitimately-unbalanced design) has
+# Freq 0 and is deliberately NOT treated as a trigger, keeping that case
+# byte-identical to ggplot2's default centered position.
+.violin_has_singleton_group <- function(data, x, color = NULL, fill = NULL, y = NULL) {
+  group.vars <- unique(c(color, fill))
+  group.vars <- group.vars[!is.na(group.vars)]
+  group.vars <- setdiff(intersect(group.vars, colnames(data)), x)
+  if (length(group.vars) == 0) return(FALSE)          # no dodge -> never trigger
+  key.cols <- c(x, group.vars)
+  keep <- if (!is.null(y) && y %in% colnames(data)) !is.na(data[[y]]) else rep(TRUE, nrow(data))
+  df <- data[keep, key.cols, drop = FALSE]
+  if (nrow(df) == 0) return(FALSE)
+  df[] <- lapply(df, function(col) factor(as.character(col)))
+  counts <- table(df)
+  any(counts == 1)                                     # an OBSERVED 1-point cell
+}
+
 ggviolin_core <- function(data, x, y,
                           color = "black", fill = "white", palette = NULL, alpha = 1,
                           title = NULL, xlab = NULL, ylab = NULL,
-                          linetype = "solid", trim = FALSE, drop = TRUE, size = NULL, linewidth = NULL, width = 1,
+                          linetype = "solid", trim = FALSE, drop = NULL, size = NULL, linewidth = NULL, width = 1,
                           quantiles = NULL, quantile.linetype = NULL, quantile.type = NULL,
                           quantile.alpha = NULL, quantile.colour = NULL, quantile.color = NULL,
                           quantile.linewidth = NULL, quantile.size = NULL,
@@ -206,7 +230,7 @@ ggviolin_core <- function(data, x, y,
                           add = "mean_se", add.params = list(),
                           error.plot = "pointrange",
                           ggtheme = theme_pubr(),
-                          position = position_dodge(0.8),
+                          position = NULL,
                           ...) {
   line_width <- .resolve_linewidth_args(
     size = size, linewidth = linewidth, default_linewidth = NULL
@@ -215,6 +239,21 @@ ggviolin_core <- function(data, x, y,
   linewidth <- line_width$linewidth
 
   if (!is.factor(data[[x]])) data[[x]] <- as.factor(data[[x]])
+
+  # #381: keep grouped violins aligned with their box/dot layers by default when a
+  # sub-group is too sparse for geom_violin to compute a density. `drop`/`position`
+  # arrive as NULL when the user did not set them; only then (and only when the data
+  # actually has a grouped one-point cell) do we reserve the empty dodge lane via
+  # `drop = FALSE` + a "preserve single" dodge - both are needed together. Any other
+  # input keeps the historical default (drop = TRUE, position = position_dodge(0.8)),
+  # so balanced / ungrouped / faceted / legitimately-unbalanced plots are unchanged.
+  auto.align <- is.null(drop) && is.null(position)
+  if (is.null(drop)) drop <- TRUE
+  if (is.null(position)) position <- position_dodge(0.8)
+  if (auto.align && .violin_has_singleton_group(data, x, color = color, fill = fill, y = y)) {
+    drop <- FALSE
+    position <- position_dodge(0.8, preserve = "single")
+  }
 
   if (!is.null(quantile.color) && is.null(quantile.colour)) {
     quantile.colour <- quantile.color

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -107,16 +107,17 @@ labelled only by variable grouping levels.}
 \item{trim}{If \code{TRUE} (default), trim the tails of the violins
 to the range of the data. If \code{FALSE}, don't trim the tails.}
 
-\item{drop}{logical, passed to \code{\link[ggplot2]{geom_violin}()}. When
-\code{TRUE} (the default, unchanged behavior), grouped sub-samples with fewer
-than two data points (for which no density can be computed) are dropped,
-including from the dodge position, so the remaining violins re-center and no
-longer line up with other layers (e.g. added boxplots or dot plots). Set
-\code{drop = FALSE} \emph{together with} a "preserve single" dodge, i.e.
-\code{position = position_dodge(0.8, preserve = "single")}, to reserve the
-empty dodge lane so the violins stay aligned with the other geoms. Both are
-needed: \code{drop = FALSE} keeps the sparse group and \code{preserve =
-"single"} keeps its lane width (#381).}
+\item{drop}{logical, passed to \code{\link[ggplot2]{geom_violin}()}, controlling
+whether grouped sub-samples with fewer than two data points (for which no
+density can be computed) are dropped from the plot and the dodge position. By
+default \code{ggviolin()} keeps grouped violins aligned with their other layers
+(e.g. added boxplots or dot plots) automatically: when you do not set \code{drop}
+or \code{position} and a grouped sub-group has a single data point, the empty
+dodge lane is reserved (equivalent to \code{drop = FALSE} together with
+\code{position = position_dodge(0.8, preserve = "single")}) so the violins stay
+aligned. Balanced, ungrouped, and faceted plots are unaffected. Setting
+\code{drop} or \code{position} explicitly turns off this automatic handling and
+uses exactly what you supply (#381).}
 
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}

--- a/tests/testthat/test-ggviolin-align.R
+++ b/tests/testthat/test-ggviolin-align.R
@@ -1,0 +1,96 @@
+context("test-ggviolin-align")
+
+# #381: grouped ggviolin() violins failed to line up with their box/dot layers
+# when a sub-group was too sparse for geom_violin() to compute a density
+# (ggplot2 >= 4.0 drops groups with fewer than two points from BOTH the plot and
+# the dodge, so the remaining violin re-centers). ggviolin() now reserves the
+# empty dodge lane automatically - but ONLY when the user set neither `drop` nor
+# `position` AND the data actually has a grouped one-point cell. Every other input
+# keeps the historical default (drop = TRUE, position = position_dodge(0.8)), so
+# balanced / ungrouped / faceted / legitimately-unbalanced plots are byte-identical.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+# sorted violin lane centers (npc-free, in data x units)
+.violin_lane_centers <- function(p) {
+  b <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p)))
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomViolin"), logical(1)))[1]
+  d <- b$data[[i]]
+  sort(unname(vapply(split(d, d$group), function(g) mean(range(g$x)), numeric(1))))
+}
+
+tg <- ToothGrowth; tg$dose <- factor(tg$dose)
+
+# data from the issue: dose = 1 / OJ has a single point (no density)
+sparse <- rbind(
+  subset(ToothGrowth, dose == 0.5),
+  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "VC", ][1:6, ],
+  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "OJ", ][1, ],
+  subset(ToothGrowth, dose == 2)
+)
+sparse$dose <- factor(sparse$dose)
+
+# ---- The helper: precise trigger ----
+
+test_that(".violin_has_singleton_group triggers only on an observed 1-point cell", {
+  # sparse: dose=1/OJ has exactly one point -> TRUE
+  expect_true(.violin_has_singleton_group(sparse, "dose", color = "supp", y = "len"))
+  # balanced ToothGrowth -> FALSE
+  expect_false(.violin_has_singleton_group(tg, "dose", color = "supp", y = "len"))
+  # legitimately-unbalanced (dose=2 has ZERO OJ, all present cells >= 2) -> FALSE
+  d2 <- tg[!(tg$dose == "2" & tg$supp == "OJ"), ]
+  expect_false(.violin_has_singleton_group(d2, "dose", color = "supp", y = "len"))
+  # no grouping aesthetic (color is a constant, not a column) -> FALSE
+  expect_false(.violin_has_singleton_group(tg, "dose", color = "black", y = "len"))
+})
+
+# ---- The fix: sparse grouped violin aligns by default ----
+
+test_that("grouped violin with a sparse sub-group aligns by default (no manual args)", {
+  centers <- .violin_lane_centers(ggviolin(sparse, "dose", "len", color = "supp", add = "boxplot"))
+  # all six dodge lanes present and aligned like a fully balanced design
+  expect_equal(centers, c(0.8, 1.2, 1.8, 2.2, 2.8, 3.2))
+})
+
+test_that("the auto-fix renders without error", {
+  p <- ggviolin(sparse, "dose", "len", color = "supp", add = "boxplot")
+  # geom_violin still emits its usual "cannot compute density for < 2 points"
+  # message for the single-point sub-group; we only assert it does not ERROR.
+  expect_error(
+    suppressWarnings(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))), NA
+  )
+})
+
+# ---- No trigger: unchanged behavior ----
+
+test_that("balanced and ungrouped violins keep their default positions", {
+  expect_equal(.violin_lane_centers(ggviolin(tg, "dose", "len", color = "supp")),
+               c(0.8, 1.2, 1.8, 2.2, 2.8, 3.2))
+  expect_equal(.violin_lane_centers(ggviolin(tg, "dose", "len")), c(1, 2, 3))
+})
+
+test_that("a legitimately-unbalanced design keeps the lone violin centered (ggplot2 default)", {
+  d2 <- tg[!(tg$dose == "2" & tg$supp == "OJ"), ]
+  centers <- .violin_lane_centers(ggviolin(d2, "dose", "len", color = "supp"))
+  # dose=2 has only VC -> its violin stays at the slot center (3.0), NOT the lane (2.8)
+  expect_true(3.0 %in% centers)
+  expect_false(2.8 %in% centers)
+})
+
+# ---- Explicit user arguments turn the auto-handling off ----
+
+test_that("an explicit position= is respected (auto-handling disabled)", {
+  centers <- .violin_lane_centers(
+    ggviolin(sparse, "dose", "len", color = "supp", add = "boxplot",
+             position = position_dodge(0.8))
+  )
+  # historical behavior: the sparse group is dropped from the dodge -> NOT all six aligned
+  expect_false(isTRUE(all.equal(centers, c(0.8, 1.2, 1.8, 2.2, 2.8, 3.2))))
+})
+
+test_that("an explicit drop= is respected (auto-handling disabled)", {
+  centers <- .violin_lane_centers(
+    ggviolin(sparse, "dose", "len", color = "supp", add = "boxplot", drop = TRUE)
+  )
+  expect_false(isTRUE(all.equal(centers, c(0.8, 1.2, 1.8, 2.2, 2.8, 3.2))))
+})

--- a/tests/testthat/test-ggviolin.R
+++ b/tests/testthat/test-ggviolin.R
@@ -78,22 +78,38 @@ test_that("ggviolin warns when quantiles are provided without linetype", {
   sort(unique(round(s$x, 3)))
 }
 
-test_that("ggviolin forwards drop to geom_violin", {
+test_that("ggviolin forwards an explicit drop to geom_violin", {
   p <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot", drop = FALSE)
   expect_false(p$layers[[1]]$stat_params$drop)
-  p2 <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot")
+  # An explicit drop = TRUE is respected (it turns the automatic alignment off).
+  p2 <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot", drop = TRUE)
   expect_true(p2$layers[[1]]$stat_params$drop)
 })
 
-test_that("ggviolin default (drop = TRUE) is byte-identical to omitting drop (#381)", {
-  omitted  <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot")
+test_that("ggviolin auto-aligns a sparse grouped violin by default (#381)", {
+  # Omitting drop/position now reserves the empty dodge lane for the single-point
+  # sub-group, so the sparse dose = 1 keeps TWO aligned lanes and the auto-applied
+  # drop is FALSE.
+  omitted <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot")
+  expect_length(.violin_lanes(omitted, 1), 2)
+  expect_false(omitted$layers[[1]]$stat_params$drop)
+  # Explicit drop = TRUE opts out -> historical behavior: the sparse lane is dropped
+  # and the remaining violin re-centers (a single lane at dose = 1).
   explicit <- ggviolin(.viol_sparse, "dose", "len", color = "supp", add = "boxplot", drop = TRUE)
+  expect_length(.violin_lanes(explicit, 1), 1)
+})
+
+test_that("omitting drop is byte-identical to drop = TRUE for balanced data (#381)", {
+  # The automatic alignment only fires on a sparse one-point cell; for balanced
+  # grouped data the default is unchanged, so omitting drop equals drop = TRUE.
+  bal <- ToothGrowth
+  bal$dose <- factor(bal$dose)
+  omitted  <- ggviolin(bal, "dose", "len", color = "supp", add = "boxplot")
+  explicit <- ggviolin(bal, "dose", "len", color = "supp", add = "boxplot", drop = TRUE)
   expect_equal(
     suppressWarnings(ggplot2::ggplot_build(omitted))$data[[1]],
     suppressWarnings(ggplot2::ggplot_build(explicit))$data[[1]]
   )
-  # default drops the sparse group's lane -> violin is centered (single lane)
-  expect_length(.violin_lanes(omitted, 1), 1)
 })
 
 test_that("drop = FALSE + preserve = 'single' aligns violins with added boxplots (#381)", {


### PR DESCRIPTION
## Summary

Grouped `ggviolin()` violins did not line up with their added box/dot layers when one sub-group was too sparse for `geom_violin()` to compute a density (a single data point; on ggplot2 >= 4.0 such groups are dropped from the plot *and* from the dodge). The remaining violin re-centered in its slot and detached from its boxplot.

`ggviolin()` now reserves the empty dodge lane automatically in that case, so the violins stay aligned — without the user having to pass `drop = FALSE` plus a `preserve = "single"` dodge by hand.

## Example

```r
library(ggpubr)
# dose = 1 / OJ has a single observation (no density can be drawn)
d <- rbind(
  subset(ToothGrowth, dose == 0.5),
  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "VC", ][1:6, ],
  ToothGrowth[ToothGrowth$dose == 1 & ToothGrowth$supp == "OJ", ][1, ],
  subset(ToothGrowth, dose == 2)
)
d$dose <- factor(d$dose)

ggviolin(d, "dose", "len", color = "supp", add = "boxplot")
```

The `dose = 1` boxplots now sit in their correct dodge lanes instead of overlapping.

## Scope / safety

- The automatic handling applies **only** when `drop` and `position` are both left at their defaults **and** the data actually contains a grouped one-point cell.
- Balanced, ungrouped, faceted, and legitimately-unbalanced grouped violins (a sub-group genuinely absent at some x) render exactly as before — the latter keeps ggplot2's default centered position.
- Passing `drop` or `position` explicitly turns the automatic handling off and uses exactly what you supply.
- Adds tests covering the auto-alignment, the trigger precision, and the unchanged paths; docs updated.

Fixes #381.