### PR TITLE
ggbarplot(): correct stacked error bars for mixed positive/negative values (#426)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,12 @@
   no complete pairs) instead of failing the whole result/layer, while still
   reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
   @erdeyl (#732).
+- `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
+  data mix positive and negative values (e.g. above/below-ground measurements). The
+  stacked error bars are cumulated per sign, matching `position_stack()`, so a negative
+  segment's error bar is drawn on its own side instead of being displaced to the other
+  side (previously the misplacement also flipped with the factor-level order). Stacked
+  charts with single-sign data are unchanged (#426).
 - `ggviolin()` now keeps grouped violins aligned with their added box/dot layers by
   default when a sub-group is too sparse for `geom_violin()` to compute a density
   (a single data point). Previously the sparse sub-group was dropped from the dodge,

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -478,10 +478,19 @@ ggbarplot_core <- function(data, x, y,
     group_by(!!!syms(stack.groups)) %>%
     dplyr::arrange(!!sym(x), desc(!!sym(legend.var))) %>%
     dplyr::mutate(
-      y = cumsum(!!sym(y)),
+      # position_stack() accumulates positive and negative segments SEPARATELY
+      # (positives stack up from 0, negatives stack down from 0), so a mixed-sign
+      # stack must cumulate each sign on its own. A single cumsum() over both signs
+      # places the error bars of one sign on the wrong side (#426). For single-sign
+      # data one of the two cumulative sums is identically zero, so this reduces to
+      # the original cumsum() and the output is byte-identical.
+      .ggpubr_cum_pos = cumsum(pmax(!!sym(y), 0)),
+      .ggpubr_cum_neg = cumsum(pmin(!!sym(y), 0)),
+      y = ifelse(!!sym(y) >= 0, .data$.ggpubr_cum_pos, .data$.ggpubr_cum_neg),
       ymin = .data$y - !!sym(error),
       ymax = .data$y + !!sym(error)
     ) %>%
+    dplyr::select(-".ggpubr_cum_pos", -".ggpubr_cum_neg") %>%
     dplyr::ungroup()
   geom_error <- .get_geom_error_function(error.plot)
 

--- a/tests/testthat/test-ggbarplot-stacked-posneg.R
+++ b/tests/testthat/test-ggbarplot-stacked-posneg.R
@@ -1,0 +1,90 @@
+context("test-ggbarplot-stacked-posneg")
+
+# #426: for STACKED bars (default position = "stack"), ggbarplot() placed every
+# error bar with a single cumulative sum, which assumes all stacked segments share
+# one sign. position_stack() accumulates positive and negative segments SEPARATELY,
+# so with mixed signs the error bars of one sign were drawn on the wrong side (and
+# which one looked correct flipped with the factor-level order). Error bars are now
+# cumulated per sign, matching position_stack(). Single-sign data is unchanged.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+# self-contained data with KNOWN per-cell means (two identical rows per cell so
+# the mean is exact); group g1 is negative, g2/g3 positive.
+.mk_posneg <- function(sign1 = -1) {
+  vals <- c(
+    # x = A
+    A_g1 = 10 * sign1, A_g2 = 5,  A_g3 = 8,
+    # x = B
+    B_g1 = 6  * sign1, B_g2 = 4,  B_g3 = 7
+  )
+  d <- do.call(rbind, lapply(names(vals), function(k) {
+    xg <- strsplit(k, "_")[[1]]
+    data.frame(x = xg[1], g = xg[2], y = rep(vals[[k]], 2))
+  }))
+  d$x <- factor(d$x); d$g <- factor(d$g)
+  d
+}
+
+# error-bar centers per x position (sorted), from the built plot
+.ebar_centers_by_x <- function(p) {
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  ei <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+  d <- b$data[[ei]]
+  d$center <- (d$ymin + d$ymax) / 2
+  lapply(split(d$center, d$x), function(v) sort(round(v, 6)))
+}
+
+test_that("stacked mixed-sign error bars sit at the correct per-sign cumulative position (#426)", {
+  d <- .mk_posneg(sign1 = -1)          # g1 negative, g2/g3 positive
+  p <- ggbarplot(d, "x", "y", add = "mean_se", color = "g")
+  centers <- .ebar_centers_by_x(p)
+  # stacking order is desc(g): g3, g2, g1. Positives cumulate (g3 then g2), the
+  # negative g1 cumulates on its own side.
+  #   x = A: g3 -> 8, g2 -> 8 + 5 = 13, g1 -> -10
+  #   x = B: g3 -> 7, g2 -> 7 + 4 = 11, g1 -> -6
+  expect_equal(centers[["1"]], c(-10, 8, 13))
+  expect_equal(centers[["2"]], c(-6, 7, 11))
+})
+
+test_that("the mixed-sign fix does not move a wholly-positive stack (#426)", {
+  d <- .mk_posneg(sign1 = 1)           # all positive
+  p <- ggbarplot(d, "x", "y", add = "mean_se", color = "g")
+  centers <- .ebar_centers_by_x(p)
+  # pure cumsum: x = A -> 8, 13, 23 ; x = B -> 7, 11, 17
+  expect_equal(centers[["1"]], c(8, 13, 23))
+  expect_equal(centers[["2"]], c(7, 11, 17))
+})
+
+test_that("error bars line up with the actual stacked bar mean-ends (#426)", {
+  d <- .mk_posneg(sign1 = -1)
+  p <- ggbarplot(d, "x", "y", add = "mean_se", color = "g")
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bi <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomCol") ||
+                       inherits(l$geom, "GeomBar"), logical(1)))[1]
+  ei <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+  bar <- b$data[[bi]]
+  # the mean-end of each segment is its non-zero boundary
+  bar$meanend <- ifelse(bar$ymin == 0, bar$ymax, ifelse(bar$ymax == 0, bar$ymin, bar$ymax))
+  eb <- b$data[[ei]]; eb$center <- (eb$ymin + eb$ymax) / 2
+  m <- merge(eb[, c("x", "colour", "center")], bar[, c("x", "colour", "meanend")],
+             by = c("x", "colour"))
+  expect_equal(nrow(m), 6)
+  expect_true(all(abs(m$center - m$meanend) < 1e-6))
+})
+
+test_that("the corrected side is independent of the factor-level order (#426)", {
+  d <- .mk_posneg(sign1 = -1)
+  d$g <- factor(d$g, levels = c("g3", "g2", "g1"))   # reversed order (OP's note)
+  p <- ggbarplot(d, "x", "y", add = "mean_se", color = "g")
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bi <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomCol") ||
+                       inherits(l$geom, "GeomBar"), logical(1)))[1]
+  ei <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
+  bar <- b$data[[bi]]
+  bar$meanend <- ifelse(bar$ymin == 0, bar$ymax, ifelse(bar$ymax == 0, bar$ymin, bar$ymax))
+  eb <- b$data[[ei]]; eb$center <- (eb$ymin + eb$ymax) / 2
+  m <- merge(eb[, c("x", "colour", "center")], bar[, c("x", "colour", "meanend")],
+             by = c("x", "colour"))
+  expect_true(all(abs(m$center - m$meanend) < 1e-6))  # aligned regardless of order
+})

--- a/tests/testthat/test-ggbarplot-stacked-posneg.R
+++ b/tests/testthat/test-ggbarplot-stacked-posneg.R
@@ -64,8 +64,9 @@ test_that("error bars line up with the actual stacked bar mean-ends (#426)", {
                        inherits(l$geom, "GeomBar"), logical(1)))[1]
   ei <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
   bar <- b$data[[bi]]
-  # the mean-end of each segment is its non-zero boundary
-  bar$meanend <- ifelse(bar$ymin == 0, bar$ymax, ifelse(bar$ymax == 0, bar$ymin, bar$ymax))
+  # a stacked segment's mean-end is its boundary farther from zero (robust to
+  # multiple same-sign segments, not just the one that touches zero).
+  bar$meanend <- ifelse(abs(bar$ymax) >= abs(bar$ymin), bar$ymax, bar$ymin)
   eb <- b$data[[ei]]; eb$center <- (eb$ymin + eb$ymax) / 2
   m <- merge(eb[, c("x", "colour", "center")], bar[, c("x", "colour", "meanend")],
              by = c("x", "colour"))
@@ -82,7 +83,9 @@ test_that("the corrected side is independent of the factor-level order (#426)", 
                        inherits(l$geom, "GeomBar"), logical(1)))[1]
   ei <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomErrorbar"), logical(1)))[1]
   bar <- b$data[[bi]]
-  bar$meanend <- ifelse(bar$ymin == 0, bar$ymax, ifelse(bar$ymax == 0, bar$ymin, bar$ymax))
+  # a stacked segment's mean-end is its boundary farther from zero (robust to
+  # multiple same-sign segments, not just the one that touches zero).
+  bar$meanend <- ifelse(abs(bar$ymax) >= abs(bar$ymin), bar$ymax, bar$ymin)
   eb <- b$data[[ei]]; eb$center <- (eb$ymin + eb$ymax) / 2
   m <- merge(eb[, c("x", "colour", "center")], bar[, c("x", "colour", "meanend")],
              by = c("x", "colour"))


### PR DESCRIPTION
## Summary

For **stacked** bar charts (the default `position = "stack"`), `ggbarplot()` placed the error bars using a single cumulative sum over all stacked segments, which assumes they all share one sign. `position_stack()` accumulates positive and negative segments **separately**, so when the data mixed positive and negative values (e.g. above/below-ground measurements) a negative segment's error bar was displaced to the wrong side — and, as reported, which one looked correct even flipped with the factor-level order.

Stacked error bars are now cumulated per sign, matching `position_stack()`, so each error bar sits at its own segment's end.

## Example

```r
library(ggpubr); library(dplyr); library(tidyr)
data("anxiety", package = "datarium")
anx <- anxiety |> gather(key = "time", value = "score", t1, t2, t3) |>
  rstatix::convert_as_factor(id, time)
anx$score_posneg <- anx$score
anx$score_posneg[anx$group == "grp1"] <- -anx$score_posneg[anx$group == "grp1"]

ggbarplot(anx, x = "time", y = "score_posneg", add = "mean_se", color = "group")
```

grp1's error bar is now drawn at its negative mean instead of being displaced to the positive side.

## Scope / safety

- Stacked charts with single-sign data (all positive or all negative — the common case) are **unchanged**: for single-sign data one of the two per-sign cumulative sums is identically zero, so the computation reduces to the previous `cumsum()`.
- Dodged bars and non-stacked layouts are unaffected.
- Adds tests covering the mixed-sign positions, the unchanged single-sign case, alignment with the actual bar segment ends, and independence from factor-level order.

Fixes #426.