### PR TITLE
ggarrange(): choose/combine which plot(s) supply the shared legend (#347)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,14 +43,17 @@
   no complete pairs) instead of failing the whole result/layer, while still
   reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
   @erdeyl (#732).
-- `ggarrange()` gained the ability to choose which plot supplies the shared legend:
-  `common.legend` now also accepts a plot index (e.g. `common.legend = 2` uses the
-  second plot's legend). This helps when the first plot's legend is not representative
-  of the others (e.g. a group missing in the first plot). The documentation of
-  `common.legend` was also clarified: `common.legend = TRUE` keeps the first plot's
-  legend (it does not merge or validate legends), so plots should share a consistent
-  scale for the shared legend to be correct. Logical `TRUE`/`FALSE` behave exactly as
-  before (#347).
+- `ggarrange()` gained the ability to choose which plot(s) supply the shared legend:
+  `common.legend` now also accepts one or several plot indices. `common.legend = 2`
+  uses the second plot's legend (handy when the first plot's legend is not
+  representative, e.g. a group is missing in the first plot), and
+  `common.legend = c(1, 2)` keeps and combines the legends of the listed plots into a
+  single shared block (side by side for `legend = "top"`/`"bottom"`, stacked for
+  `"left"`/`"right"`) - useful when the arranged plots genuinely need different
+  legends. The documentation of `common.legend` was also clarified: `common.legend =
+  TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
+  should share a consistent scale for a single shared legend to be correct. Logical
+  `TRUE`/`FALSE` behave exactly as before (#347).
 - `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
   data mix positive and negative values (e.g. above/below-ground measurements). The
   stacked error bars are cumulated per sign, matching `position_stack()`, so a negative

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,14 @@
   no complete pairs) instead of failing the whole result/layer, while still
   reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
   @erdeyl (#732).
+- `ggarrange()` gained the ability to choose which plot supplies the shared legend:
+  `common.legend` now also accepts a plot index (e.g. `common.legend = 2` uses the
+  second plot's legend). This helps when the first plot's legend is not representative
+  of the others (e.g. a group missing in the first plot). The documentation of
+  `common.legend` was also clarified: `common.legend = TRUE` keeps the first plot's
+  legend (it does not merge or validate legends), so plots should share a consistent
+  scale for the shared legend to be correct. Logical `TRUE`/`FALSE` behave exactly as
+  before (#347).
 - `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
   data mix positive and negative values (e.g. above/below-ground measurements). The
   stacked error bars are cumulated per sign, matching `position_stack()`, so a negative

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -36,7 +36,7 @@ NULL
 #' @param legend character specifying legend position. Allowed values are one of
 #'   c("top", "bottom", "left", "right", "none"). To remove the legend use
 #'   legend = "none".
-#' @param common.legend logical value or a plot index. Default is FALSE. If
+#' @param common.legend logical value, or one or several plot indices. Default is FALSE. If
 #'   \code{TRUE}, a single shared legend is used for all the arranged plots.
 #'   Note that this legend is \strong{not} merged or validated across plots: it
 #'   is simply the legend of the \emph{first} plot, and the other legends are
@@ -49,7 +49,11 @@ NULL
 #'   \code{scale_color_continuous(limits = ...)}) so a single legend is valid,
 #'   and/or (ii) choose which plot's legend is shown by passing that plot's index,
 #'   e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
-#'   \code{legend.grob = get_legend(plots[[2]])}). Note that (ii) only changes
+#'   \code{legend.grob = get_legend(plots[[2]])}). You can also pass several indices,
+#'   e.g. \code{common.legend = c(1, 2)}, to keep and combine the legends of those
+#'   plots into a single shared block (side by side for \code{legend = "top"}/
+#'   \code{"bottom"}, stacked for \code{"left"}/\code{"right"}) - useful when the
+#'   plots genuinely need different legends. Note that (ii) only changes
 #'   \emph{which} legend is displayed; it does not re-map the other plots' color
 #'   scales, so for the legend keys to match every panel you still need a
 #'   consistent scale as in (i). When the plots genuinely cannot be described by a
@@ -124,25 +128,29 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   nrow <- page.layout$nrow
   nb.plots.per.page <- .nbplots_per_page(ncol, nrow)
 
-  # #347: `common.legend` may also be a single plot index, selecting which plot's
-  # legend is used as the shared one (useful when the first plot's legend is not
-  # representative, e.g. it is missing a group present in the other plots). Logical
+  # #347: `common.legend` may also be one or several plot indices, selecting which
+  # plot(s) supply the shared legend (useful when the first plot's legend is not
+  # representative, e.g. a group is missing in the first plot, or when the plots
+  # genuinely need several different legends). A single index uses that plot's
+  # legend; several indices combine those plots' legends into one block. Logical
   # TRUE/FALSE behave exactly as before: is.numeric(TRUE) is FALSE, so this branch
   # is skipped for them and the default output is unchanged.
   legend.plot.index <- NULL
   if (is.numeric(common.legend)) {
-    if (length(common.legend) != 1L || anyNA(common.legend) ||
-        !is.finite(common.legend) ||
-        common.legend != as.integer(common.legend) ||
-        common.legend < 1 || common.legend > nb.plots) {
-      stop("When numeric, `common.legend` must be a single whole number between 1 and ",
-           "the number of plots (", nb.plots, ").", call. = FALSE)
+    idx <- common.legend
+    if (length(idx) < 1L || anyNA(idx) || !all(is.finite(idx)) ||
+        !all(idx == as.integer(idx)) || any(idx < 1) || any(idx > nb.plots)) {
+      stop("When numeric, `common.legend` must be whole-number plot indices between ",
+           "1 and the number of plots (", nb.plots, ").", call. = FALSE)
     }
-    if (is.null(plots[[common.legend]])) {
-      stop("`common.legend = ", common.legend, "` points to an empty (NULL) plot.",
-           call. = FALSE)
+    idx <- as.integer(idx)
+    if (anyDuplicated(idx)) {
+      stop("`common.legend` plot indices must be unique.", call. = FALSE)
     }
-    legend.plot.index <- as.integer(common.legend)
+    if (any(vapply(plots[idx], is.null, logical(1)))) {
+      stop("`common.legend` points to an empty (NULL) plot.", call. = FALSE)
+    }
+    legend.plot.index <- idx
     common.legend <- TRUE
   }
 
@@ -165,7 +173,7 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   if (common.legend) {
     if (is.null(legend.grob)) {
       legend.grob <- if (!is.null(legend.plot.index)) {
-        get_legend(plots[[legend.plot.index]])
+        .combine_legends(plots, legend.plot.index, legend)
       } else {
         get_legend(plots)
       }
@@ -252,6 +260,35 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   purrr::map(plots, function(x) {
     if (inherits(x, "ggplot")) x + ggplot2::theme(plot.margin = margin) else x
   })
+}
+
+# #347: build the shared legend for a numeric `common.legend`. For a single index
+# this is simply that plot's legend (identical to the scalar path). For several
+# indices the selected plots' legends are combined into one grob: side by side for a
+# horizontal legend strip (legend = "top"/"bottom") and stacked for a vertical one
+# ("left"/"right"). gtable's cbind/rbind (dispatched via the base generics) keep the
+# result a gtable with the same $height/$width interface a single legend has, so
+# `.plot_grid` needs no change and the single-legend / TRUE / FALSE paths stay
+# byte-identical. Selected plots whose legend is empty are skipped; if none remain
+# the result is NULL (no shared legend, no error). The plots passed here already have
+# `legend.position` set to `legend`, so the extracted legends have the right
+# orientation for the strip.
+.combine_legends <- function(plots, index, legend = "top") {
+  legs <- lapply(index, function(i) get_legend(plots[[i]]))
+  legs <- Filter(function(g) !is.null(g) && !inherits(g, "zeroGrob"), legs)
+  if (length(legs) == 0) {
+    return(NULL)
+  }
+  if (length(legs) == 1) {
+    return(legs[[1]])
+  }
+  horizontal <- isTRUE(legend %in% c("top", "bottom"))
+  combine2 <- if (horizontal) {
+    function(a, b) cbind(a, b, size = "max")
+  } else {
+    function(a, b) rbind(a, b, size = "max")
+  }
+  Reduce(combine2, legs)
 }
 
 .plot_grid <- function(plotlist, legend = "top", common.legend.grob = NULL, ...) {

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -36,8 +36,20 @@ NULL
 #' @param legend character specifying legend position. Allowed values are one of
 #'   c("top", "bottom", "left", "right", "none"). To remove the legend use
 #'   legend = "none".
-#' @param common.legend logical value. Default is FALSE. If TRUE, a common
-#'   unique legend will be created for arranged plots.
+#' @param common.legend logical value or a plot index. Default is FALSE. If
+#'   \code{TRUE}, a single shared legend is used for all the arranged plots.
+#'   Note that this legend is \strong{not} merged or validated across plots: it
+#'   is simply the legend of the \emph{first} plot, and the other legends are
+#'   dropped. It is therefore only correct when every plot shares the same scale
+#'   (same groups/levels, order and color range). If the first plot's legend is
+#'   not representative - for example a group is missing in the first plot, or a
+#'   continuous color scale spans a different range - the shared legend will
+#'   misrepresent the other plots. In that case you can: (i) give the plots a
+#'   consistent scale yourself (e.g. \code{scale_fill_manual(limits = ...)} or
+#'   \code{scale_color_continuous(limits = ...)}) so a single legend is valid,
+#'   and/or (ii) choose which plot's legend to use by passing that plot's index,
+#'   e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
+#'   \code{legend.grob = get_legend(plots[[2]])}).
 #' @param legend.grob a legend grob as returned by the function
 #'   \code{\link{get_legend}()}. If provided, it will be used as the common
 #'   legend.
@@ -107,6 +119,27 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   nrow <- page.layout$nrow
   nb.plots.per.page <- .nbplots_per_page(ncol, nrow)
 
+  # #347: `common.legend` may also be a single plot index, selecting which plot's
+  # legend is used as the shared one (useful when the first plot's legend is not
+  # representative, e.g. it is missing a group present in the other plots). Logical
+  # TRUE/FALSE behave exactly as before: is.numeric(TRUE) is FALSE, so this branch
+  # is skipped for them and the default output is unchanged.
+  legend.plot.index <- NULL
+  if (is.numeric(common.legend)) {
+    if (length(common.legend) != 1L || anyNA(common.legend) ||
+        common.legend != as.integer(common.legend) ||
+        common.legend < 1 || common.legend > nb.plots) {
+      stop("When numeric, `common.legend` must be a single whole number between 1 and ",
+           "the number of plots (", nb.plots, ").", call. = FALSE)
+    }
+    if (is.null(plots[[common.legend]])) {
+      stop("`common.legend = ", common.legend, "` points to an empty (NULL) plot.",
+           call. = FALSE)
+    }
+    legend.plot.index <- as.integer(common.legend)
+    common.legend <- TRUE
+  }
+
   if (!is.null(legend.grob)) {
     common.legend <- TRUE
   }
@@ -125,7 +158,11 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
 
   if (common.legend) {
     if (is.null(legend.grob)) {
-      legend.grob <- get_legend(plots)
+      legend.grob <- if (!is.null(legend.plot.index)) {
+        get_legend(plots[[legend.plot.index]])
+      } else {
+        get_legend(plots)
+      }
     }
     plots <- purrr::map(
       plots,

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -132,6 +132,7 @@ ggarrange <- function(..., plotlist = NULL, ncol = NULL, nrow = NULL,
   legend.plot.index <- NULL
   if (is.numeric(common.legend)) {
     if (length(common.legend) != 1L || anyNA(common.legend) ||
+        !is.finite(common.legend) ||
         common.legend != as.integer(common.legend) ||
         common.legend < 1 || common.legend > nb.plots) {
       stop("When numeric, `common.legend` must be a single whole number between 1 and ",

--- a/R/ggarrange.R
+++ b/R/ggarrange.R
@@ -47,9 +47,14 @@ NULL
 #'   misrepresent the other plots. In that case you can: (i) give the plots a
 #'   consistent scale yourself (e.g. \code{scale_fill_manual(limits = ...)} or
 #'   \code{scale_color_continuous(limits = ...)}) so a single legend is valid,
-#'   and/or (ii) choose which plot's legend to use by passing that plot's index,
+#'   and/or (ii) choose which plot's legend is shown by passing that plot's index,
 #'   e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
-#'   \code{legend.grob = get_legend(plots[[2]])}).
+#'   \code{legend.grob = get_legend(plots[[2]])}). Note that (ii) only changes
+#'   \emph{which} legend is displayed; it does not re-map the other plots' color
+#'   scales, so for the legend keys to match every panel you still need a
+#'   consistent scale as in (i). When the plots genuinely cannot be described by a
+#'   single legend (e.g. a discrete fill in one plot and a continuous color bar in
+#'   another), use \code{common.legend = FALSE} to keep a separate legend per plot.
 #' @param legend.grob a legend grob as returned by the function
 #'   \code{\link{get_legend}()}. If provided, it will be used as the common
 #'   legend.

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -77,7 +77,7 @@ grid by row; set to \code{FALSE} to fill by column. Passed to
 c("top", "bottom", "left", "right", "none"). To remove the legend use
 legend = "none".}
 
-\item{common.legend}{logical value or a plot index. Default is FALSE. If
+\item{common.legend}{logical value, or one or several plot indices. Default is FALSE. If
 \code{TRUE}, a single shared legend is used for all the arranged plots.
 Note that this legend is \strong{not} merged or validated across plots: it
 is simply the legend of the \emph{first} plot, and the other legends are
@@ -90,7 +90,11 @@ consistent scale yourself (e.g. \code{scale_fill_manual(limits = ...)} or
 \code{scale_color_continuous(limits = ...)}) so a single legend is valid,
 and/or (ii) choose which plot's legend is shown by passing that plot's index,
 e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
-\code{legend.grob = get_legend(plots[[2]])}). Note that (ii) only changes
+\code{legend.grob = get_legend(plots[[2]])}). You can also pass several indices,
+e.g. \code{common.legend = c(1, 2)}, to keep and combine the legends of those
+plots into a single shared block (side by side for \code{legend = "top"}/
+\code{"bottom"}, stacked for \code{"left"}/\code{"right"}) - useful when the
+plots genuinely need different legends. Note that (ii) only changes
 \emph{which} legend is displayed; it does not re-map the other plots' color
 scales, so for the legend keys to match every panel you still need a
 consistent scale as in (i). When the plots genuinely cannot be described by a

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -77,8 +77,20 @@ grid by row; set to \code{FALSE} to fill by column. Passed to
 c("top", "bottom", "left", "right", "none"). To remove the legend use
 legend = "none".}
 
-\item{common.legend}{logical value. Default is FALSE. If TRUE, a common
-unique legend will be created for arranged plots.}
+\item{common.legend}{logical value or a plot index. Default is FALSE. If
+\code{TRUE}, a single shared legend is used for all the arranged plots.
+Note that this legend is \strong{not} merged or validated across plots: it
+is simply the legend of the \emph{first} plot, and the other legends are
+dropped. It is therefore only correct when every plot shares the same scale
+(same groups/levels, order and color range). If the first plot's legend is
+not representative - for example a group is missing in the first plot, or a
+continuous color scale spans a different range - the shared legend will
+misrepresent the other plots. In that case you can: (i) give the plots a
+consistent scale yourself (e.g. \code{scale_fill_manual(limits = ...)} or
+\code{scale_color_continuous(limits = ...)}) so a single legend is valid,
+and/or (ii) choose which plot's legend to use by passing that plot's index,
+e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
+\code{legend.grob = get_legend(plots[[2]])}).}
 
 \item{legend.grob}{a legend grob as returned by the function
 \code{\link{get_legend}()}. If provided, it will be used as the common

--- a/man/ggarrange.Rd
+++ b/man/ggarrange.Rd
@@ -88,9 +88,14 @@ continuous color scale spans a different range - the shared legend will
 misrepresent the other plots. In that case you can: (i) give the plots a
 consistent scale yourself (e.g. \code{scale_fill_manual(limits = ...)} or
 \code{scale_color_continuous(limits = ...)}) so a single legend is valid,
-and/or (ii) choose which plot's legend to use by passing that plot's index,
+and/or (ii) choose which plot's legend is shown by passing that plot's index,
 e.g. \code{common.legend = 2} to use the second plot's legend (equivalent to
-\code{legend.grob = get_legend(plots[[2]])}).}
+\code{legend.grob = get_legend(plots[[2]])}). Note that (ii) only changes
+\emph{which} legend is displayed; it does not re-map the other plots' color
+scales, so for the legend keys to match every panel you still need a
+consistent scale as in (i). When the plots genuinely cannot be described by a
+single legend (e.g. a discrete fill in one plot and a continuous color bar in
+another), use \code{common.legend = FALSE} to keep a separate legend per plot.}
 
 \item{legend.grob}{a legend grob as returned by the function
 \code{\link{get_legend}()}. If provided, it will be used as the common

--- a/tests/testthat/test-ggarrange-common-legend.R
+++ b/tests/testthat/test-ggarrange-common-legend.R
@@ -1,0 +1,51 @@
+context("test-ggarrange-common-legend")
+
+# #347: common.legend = TRUE keeps only the FIRST plot's legend (it is not merged
+# or validated). A numeric common.legend now selects WHICH plot's legend to use as
+# the shared one, e.g. common.legend = 2 uses the second plot's legend. Logical
+# TRUE/FALSE are unchanged.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+# p1 has 2 species, p2 has all 3 -> their legends genuinely differ.
+p1 <- ggboxplot(subset(iris, Species != "virginica"), "Species", "Sepal.Length", fill = "Species")
+p2 <- ggboxplot(iris, "Species", "Sepal.Width", fill = "Species")
+
+# md5 of the rendered arrangement (same machine -> deterministic; fonts identical).
+.arr_hash <- function(p) {
+  f <- tempfile(fileext = ".png")
+  on.exit(unlink(f))
+  suppressMessages(ggplot2::ggsave(f, p, width = 6, height = 3, dpi = 72, device = "png"))
+  unname(tools::md5sum(f))
+}
+
+test_that("numeric common.legend selects that plot's legend", {
+  h_true <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = TRUE))
+  h_i1   <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = 1))
+  h_i2   <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = 2))
+  # index 1 is exactly the historical behavior (first plot's legend)
+  expect_identical(h_i1, h_true)
+  # index 2 picks a DIFFERENT (representative) legend -> different output
+  expect_false(identical(h_i2, h_i1))
+  # equivalent to supplying that legend via legend.grob
+  h_grob <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = TRUE,
+                                legend.grob = get_legend(p2)))
+  expect_identical(h_i2, h_grob)
+})
+
+test_that("common.legend = TRUE / FALSE are unchanged and render", {
+  expect_error(cowplot::as_grob(ggarrange(p1, p2, ncol = 2, common.legend = TRUE)), NA)
+  expect_error(cowplot::as_grob(ggarrange(p1, p2, ncol = 2, common.legend = FALSE)), NA)
+})
+
+test_that("invalid numeric common.legend is rejected with a clear error", {
+  expect_error(ggarrange(p1, p2, common.legend = 5), "between 1 and")   # out of range
+  expect_error(ggarrange(p1, p2, common.legend = 0), "between 1 and")   # < 1
+  expect_error(ggarrange(p1, p2, common.legend = 1.5), "whole number")  # non-integer
+  expect_error(ggarrange(p1, p2, common.legend = c(1, 2)))              # length > 1
+  expect_error(ggarrange(p1, p2, common.legend = NA_real_))            # NA
+})
+
+test_that("common.legend index pointing to a NULL plot errors clearly", {
+  expect_error(ggarrange(p1, NULL, p2, common.legend = 2), "NULL")
+})

--- a/tests/testthat/test-ggarrange-common-legend.R
+++ b/tests/testthat/test-ggarrange-common-legend.R
@@ -39,13 +39,48 @@ test_that("common.legend = TRUE / FALSE are unchanged and render", {
 })
 
 test_that("invalid numeric common.legend is rejected with a clear error", {
-  expect_error(ggarrange(p1, p2, common.legend = 5), "between 1 and")   # out of range
-  expect_error(ggarrange(p1, p2, common.legend = 0), "between 1 and")   # < 1
-  expect_error(ggarrange(p1, p2, common.legend = 1.5), "whole number")  # non-integer
-  expect_error(ggarrange(p1, p2, common.legend = c(1, 2)))              # length > 1
-  expect_error(ggarrange(p1, p2, common.legend = NA_real_))            # NA
+  expect_error(ggarrange(p1, p2, common.legend = 5), "between")     # out of range
+  expect_error(ggarrange(p1, p2, common.legend = 0), "between")     # < 1
+  expect_error(ggarrange(p1, p2, common.legend = 1.5), "whole")     # non-integer
+  expect_error(ggarrange(p1, p2, common.legend = NA_real_))         # NA
 })
 
 test_that("common.legend index pointing to a NULL plot errors clearly", {
   expect_error(ggarrange(p1, NULL, p2, common.legend = 2), "NULL")
+})
+
+# ---- D3: several indices combine the selected plots' legends ----
+
+# a third plot with a DIFFERENT (continuous) legend
+p3 <- ggscatter(mtcars, "wt", "mpg", color = "cyl")
+
+test_that("a vector common.legend combines the selected plots' legends", {
+  # combining two DIFFERENT legends must differ from either single legend alone
+  h_1   <- .arr_hash(ggarrange(p2, p3, ncol = 2, common.legend = 1))
+  h_3   <- .arr_hash(ggarrange(p2, p3, ncol = 2, common.legend = 2))
+  h_13  <- .arr_hash(ggarrange(p2, p3, ncol = 2, common.legend = c(1, 2)))
+  expect_false(identical(h_13, h_1))
+  expect_false(identical(h_13, h_3))
+})
+
+test_that("vector common.legend renders for every legend position", {
+  for (pos in c("top", "bottom", "left", "right")) {
+    expect_error(
+      cowplot::as_grob(ggarrange(p2, p3, ncol = 2, common.legend = c(1, 2), legend = pos)),
+      NA
+    )
+  }
+})
+
+test_that("vector common.legend validation: duplicates and out-of-range are rejected", {
+  expect_error(ggarrange(p1, p2, common.legend = c(1, 1)), "unique")       # duplicate index
+  expect_error(ggarrange(p1, p2, common.legend = c(1, 9)), "between")      # out of range
+  expect_error(ggarrange(p1, p2, common.legend = c(1, 2.5)))               # non-integer element
+  expect_error(ggarrange(p1, p2, common.legend = c(1, NA)))                # NA element
+})
+
+test_that("single-element vector behaves like the scalar index", {
+  h_scalar <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = 2))
+  h_vec1   <- .arr_hash(ggarrange(p1, p2, ncol = 2, common.legend = c(2)))
+  expect_identical(h_vec1, h_scalar)
 })


### PR DESCRIPTION
## Summary

`ggarrange(common.legend = TRUE)` keeps only the **first** plot's legend and drops the others — it does not merge or validate legends. When the plots' legends genuinely differ (a group missing in the first plot, a different colour range, or entirely different legends), the shared legend misrepresents the other plots. This PR makes `common.legend` more capable, while leaving `TRUE`/`FALSE` byte-identical.

`common.legend` now also accepts **plot indices**:

```r
ggarrange(p1, p2, common.legend = 2)        # use plot 2's legend as the shared one
ggarrange(p1, p2, p3, common.legend = c(1, 2))  # keep & combine plot 1's and plot 2's legends
```

- A single index selects that plot's legend (equivalent to `legend.grob = get_legend(plots[[i]])`, but discoverable).
- Several indices combine those plots' legends into one shared block — side by side for `legend = "top"`/`"bottom"`, stacked for `"left"`/`"right"` — for arrangements that genuinely need different legends.

The `@param common.legend` documentation is rewritten to state plainly that `TRUE` keeps the first plot's legend (not a merged one), to point users to consistent scales for colour/range harmony, and to describe the index/vector selectors.

## Scope / safety

- Logical `common.legend = TRUE`/`FALSE` and a single index behave **exactly** as before — rendered output is byte-identical to master across FALSE/TRUE/`legend.grob`/legend-position/multi-plot variants.
- The multi-legend block is composed with gtable `cbind`/`rbind`, so the shared-legend layout path (`.plot_grid`) is unchanged.
- Invalid indices (out of range, non-integer, `NA`, duplicated, or pointing to a `NULL` plot) are rejected with a clear error; plots without a legend are skipped.
- Tests cover single- and multi-index selection, all four legend positions, the validation, and the unchanged logical paths.

Note: this addresses selecting/keeping legends. Automatically *merging* several scales into one validated legend is not possible in general (it would require re-rendering panels on a harmonized scale); the correct approach for that case — giving the plots a consistent scale — is documented.

Refs #347.