### PR TITLE
docs(ggbarplot): facet summarized bar plots with facet.by=, not manual + facet_wrap() (#739)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,10 @@
   TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
   should share a consistent scale for a single shared legend to be correct. Logical
   `TRUE`/`FALSE` behave exactly as before (#347).
+- Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
+  the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
+  are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked
+  bars, the error bars) across all panels (#739).
 - `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
   data mix positive and negative values (e.g. above/below-ground measurements). The
   stacked error bars are cumulated per sign, matching `position_stack()`, so a negative

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -171,6 +171,16 @@ NULL
 #' )
 #' #
 #'
+#' @section Faceting a summarized bar plot:
+#' When the bars show a computed summary (e.g. \code{add = "mean_se"}), facet the
+#' plot with the \code{facet.by} argument - \strong{not} by appending
+#' \code{+ facet_wrap()} / \code{+ facet_grid()}. The summaries are pre-computed,
+#' grouping by \code{x}, \code{color}/\code{fill} and \code{facet.by}; a facet added
+#' afterwards is not part of that grouping, so the bars (and, for stacked bars, the
+#' error bars) are pooled over the whole data set and repeated identically in every
+#' panel. Use \code{ggbarplot(..., facet.by = "group")} for correct per-panel
+#' summaries.
+#'
 #' @export
 ggbarplot <- function(data, x, y, combine = FALSE, merge = FALSE,
                       color = "black", fill = "white", palette = NULL,

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -170,6 +170,18 @@ The plot can be easily customized using the function ggpar(). Read
   labels and position: legend = "right" \item plot orientation : orientation
   = c("vertical", "horizontal", "reverse") }
 }
+\section{Faceting a summarized bar plot}{
+
+When the bars show a computed summary (e.g. \code{add = "mean_se"}), facet the
+plot with the \code{facet.by} argument - \strong{not} by appending
+\code{+ facet_wrap()} / \code{+ facet_grid()}. The summaries are pre-computed,
+grouping by \code{x}, \code{color}/\code{fill} and \code{facet.by}; a facet added
+afterwards is not part of that grouping, so the bars (and, for stacked bars, the
+error bars) are pooled over the whole data set and repeated identically in every
+panel. Use \code{ggbarplot(..., facet.by = "group")} for correct per-panel
+summaries.
+}
+
 \examples{
 # Data
 df <- data.frame(

--- a/tests/testthat/test-ggbarplot-facet-summary.R
+++ b/tests/testthat/test-ggbarplot-facet-summary.R
@@ -1,0 +1,44 @@
+context("test-ggbarplot-facet-summary")
+
+# #739: a summarized ggbarplot (add = "mean_se") must be faceted with the
+# `facet.by=` argument, which pre-computes the summaries per panel. This test
+# locks that correct behavior: with facet.by=, panels with different data get
+# DIFFERENT (per-panel) bar heights - they are not pooled across the whole data.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+.bar_by_panel <- function(p) {
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bi <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBar") ||
+                       inherits(l$geom, "GeomCol"), logical(1)))[1]
+  d <- b$data[[bi]]
+  split(round(d$y, 6), d$PANEL)
+}
+
+test_that("facet.by= gives correct per-panel summaries (not pooled) (#739)", {
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  # two blocks with deliberately different level: 'high' block shifted up by 20
+  tg$blk <- ifelse(tg$len < stats::median(tg$len), "low", "high")
+
+  p <- ggbarplot(tg, "dose", "len", add = "mean_se", fill = "supp", facet.by = "blk")
+  panels <- .bar_by_panel(p)
+
+  expect_length(panels, 2)                       # two panels
+  # the two panels summarize different data -> their bar heights must differ
+  expect_false(isTRUE(all.equal(panels[[1]], panels[[2]])))
+})
+
+test_that("facet.by= panels reflect their own subset means (#739)", {
+  # construct data where panel means are known and different
+  d <- rbind(
+    data.frame(g = "p1", x = c("a", "a", "b", "b"), y = c(2, 2, 4, 4)),
+    data.frame(g = "p2", x = c("a", "a", "b", "b"), y = c(10, 10, 20, 20))
+  )
+  d$x <- factor(d$x)
+  p <- ggbarplot(d, "x", "y", add = "mean_se", facet.by = "g")
+  panels <- .bar_by_panel(p)
+  # p1 bars = 2,4 ; p2 bars = 10,20 (each panel its own means, not pooled 6,12)
+  expect_equal(sort(unname(panels[["1"]])), c(2, 4))
+  expect_equal(sort(unname(panels[["2"]])), c(10, 20))
+})


### PR DESCRIPTION
## Summary

Documents the correct way to facet a **summarized** `ggbarplot()` (e.g. `add = "mean_se"`), and adds a regression test locking that behavior.

A summarized `ggbarplot()` pre-computes its summaries with `desc_statby()`, grouping by `x`, `color`/`fill` and `facet.by`. If the plot is faceted **manually** by appending `+ facet_wrap()` / `+ facet_grid()`, that facet is invisible to the summary step, so the bars (and, for stacked bars, the error bars) are pooled over the whole data set and drawn identically in every panel. Using the `facet.by=` argument produces correct per-panel summaries.

## Changes

- Adds a `@section Faceting a summarized bar plot` to `?ggbarplot` explaining that `facet.by=` must be used (not manual `+ facet_wrap()`).
- Adds a regression test that locks the correct `facet.by=` behavior (each panel summarizes its own subset; values are not pooled).
- NEWS note.

Docs + test only — **no functional code change**, output is byte-identical.

Refs #739.