### PR TITLE
ggpie()/ggdonutchart(): opt-in label.repel for non-overlapping slice labels (#655)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,10 +54,10 @@
   TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
   should share a consistent scale for a single shared legend to be correct. Logical
   `TRUE`/`FALSE` behave exactly as before (#347).
-- `ggpie()` and `ggdonutchart()` gained a `label.repel` argument (default `FALSE`). When
-  `TRUE`, slice labels are placed with `ggrepel::geom_text_repel()` and connected to their
-  slice with leader lines, so the labels of many small slices no longer overlap (or get
-  dropped). The default output is unchanged (#655).
+- `ggdonutchart()` gained a `label.repel` argument (default `FALSE`). When `TRUE`, slice
+  labels are placed with `ggrepel::geom_text_repel()` and connected to their slice with
+  leader lines, so the labels of many small slices no longer overlap (or get dropped). The
+  default output is unchanged (#655).
 - Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
   the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
   are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,10 @@
   TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
   should share a consistent scale for a single shared legend to be correct. Logical
   `TRUE`/`FALSE` behave exactly as before (#347).
+- `ggpie()` and `ggdonutchart()` gained a `label.repel` argument (default `FALSE`). When
+  `TRUE`, slice labels are placed with `ggrepel::geom_text_repel()` and connected to their
+  slice with leader lines, so the labels of many small slices no longer overlap (or get
+  dropped). The default output is unchanged (#655).
 - Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
   the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
   are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked

--- a/R/ggdonutchart.R
+++ b/R/ggdonutchart.R
@@ -14,6 +14,10 @@ NULL
 #'  14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 #'  color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 #'  "red")}.
+#' @param label.repel logical. Default is FALSE. If TRUE, the slice labels are
+#'  placed around the chart with \code{ggrepel::geom_text_repel()} and connected
+#'  to their slice with leader lines, so that the labels of many small slices no
+#'  longer overlap. When TRUE, \code{lab.pos} is ignored.
 #' @param font.family character vector specifying font family.
 #' @param color,fill outline and fill colors.
 #' @param ... other arguments to be passed to be passed to ggpar().
@@ -79,7 +83,7 @@ NULL
 #' @export
 ggdonutchart <- function(
   data, x, label = x, lab.pos = c("out", "in"), lab.adjust = 0,
-  lab.font = c(4, "plain", "black"), font.family = "",
+  lab.font = c(4, "plain", "black"), label.repel = FALSE, font.family = "",
   color = "black", fill = "white", palette = NULL,
   size = NULL, ggtheme = theme_pubr(), ...
 ) {
@@ -133,8 +137,13 @@ ggdonutchart <- function(
   # Annotate pie slice
   # :::::::::::::::::::::::::::::::::::
   if (!is.null(label)) {
-    # Label each slice at the middle of the slice
-    if (lab.pos == "out") {
+    if (isTRUE(label.repel)) {
+      # #655: spread overlapping labels around the ring with ggrepel.
+      p <- p +
+        .ggpie_repel_labels(data, label, x.pos = 2.5, lab.font, font.family) +
+        clean_theme()
+    } else if (lab.pos == "out") {
+      # Label each slice at the middle of the slice
       p <- p + scale_y_continuous(
         breaks = cumsum(.x) - .x / 2,
         labels = dplyr::pull(data, label)
@@ -143,9 +152,8 @@ ggdonutchart <- function(
           face = lab.font$face, color = lab.font$color, size = 2.5 * lab.font$size,
           family = font.family
         ))
-    }
-    # Compute the cumulative sum as label ypos
-    if (lab.pos == "in") {
+    } else if (lab.pos == "in") {
+      # Compute the cumulative sum as label ypos
       p <- p + geom_text(
         create_aes(list(y = ".lab.ypos.", label = label)),
         size = lab.font$size, fontface = lab.font$face,

--- a/R/ggpie.R
+++ b/R/ggpie.R
@@ -14,10 +14,6 @@ NULL
 #'  14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 #'  color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 #'  "red")}.
-#' @param label.repel logical. Default is FALSE. If TRUE, the slice labels are
-#'  placed around the chart with \code{ggrepel::geom_text_repel()} and connected
-#'  to their slice with leader lines, so that the labels of many small slices no
-#'  longer overlap. When TRUE, \code{lab.pos} is ignored.
 #' @param font.family character vector specifying font family.
 #' @param color,fill outline and fill colors.
 #' @param ... other arguments to be passed to be passed to ggpar().
@@ -87,7 +83,7 @@ NULL
 #' @export
 ggpie <- function(
   data, x, label = x, lab.pos = c("out", "in"), lab.adjust = 0,
-  lab.font = c(4, "plain", "black"), label.repel = FALSE, font.family = "",
+  lab.font = c(4, "plain", "black"), font.family = "",
   color = "black", fill = "white", palette = NULL,
   size = NULL, ggtheme = theme_pubr(), ...
 ) {
@@ -142,17 +138,8 @@ ggpie <- function(
   # Annotate pie slice
   # :::::::::::::::::::::::::::::::::::
   if (!is.null(label)) {
-    if (isTRUE(label.repel)) {
-      # #655: spread overlapping labels around the ring with ggrepel. The pie's
-      # x (radius) axis is discrete, so add outward expansion to give the repelled
-      # labels room to clear the pie face (the donut already reserves this via its
-      # xlim). Only applied on the repel path, so the default output is unchanged.
-      p <- p +
-        .ggpie_repel_labels(data, label, x.pos = 1.6, lab.font, font.family) +
-        ggplot2::scale_x_discrete(expand = ggplot2::expansion(add = c(0.6, 1.1))) +
-        clean_theme()
-    } else if (lab.pos == "out") {
-      # Label each slice at the middle of the slice
+    # Label each slice at the middle of the slice
+    if (lab.pos == "out") {
       p <- p + scale_y_continuous(
         breaks = cumsum(.x) - .x / 2,
         labels = dplyr::pull(data, label)
@@ -161,8 +148,9 @@ ggpie <- function(
           face = lab.font$face, color = lab.font$color, size = 2.5 * lab.font$size,
           family = font.family
         ))
-    } else if (lab.pos == "in") {
-      # Compute the cumulative sum as label ypos
+    }
+    # Compute the cumulative sum as label ypos
+    if (lab.pos == "in") {
       p <- p + geom_text(
         create_aes(list(y = ".lab.ypos.", label = label)),
         size = lab.font$size, fontface = lab.font$face,
@@ -263,12 +251,11 @@ ggpie_1 <- function(data, x, label = NULL, lab.pos = c("out", "in"), lab.adjust 
   lab.font
 }
 
-# #655: opt-in ggrepel labels for pie / donut charts. With many small slices the
-# default labels collide; this spreads them around the ring with leader lines,
-# instead of dropping any. Shared by ggpie() and ggdonutchart(). `x.pos` is the
-# radius at which the labels are anchored (just outside the ring) and
-# `.lab.ypos.` (already on `data`) is the slice mid-point along the angular axis.
-# Returns a ggrepel::geom_text_repel layer.
+# #655: opt-in ggrepel labels for donut charts (ggdonutchart). With many small
+# slices the default labels collide; this spreads them around the ring with leader
+# lines, instead of dropping any. `x.pos` is the radius at which the labels are
+# anchored (just outside the ring) and `.lab.ypos.` (already on `data`) is the
+# slice mid-point along the angular axis. Returns a ggrepel::geom_text_repel layer.
 .ggpie_repel_labels <- function(data, label, x.pos, lab.font, font.family) {
   data[[".lab.xpos."]] <- x.pos
   max.overlaps <- getOption("ggrepel.max.overlaps", default = Inf)

--- a/R/ggpie.R
+++ b/R/ggpie.R
@@ -14,6 +14,10 @@ NULL
 #'  14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 #'  color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 #'  "red")}.
+#' @param label.repel logical. Default is FALSE. If TRUE, the slice labels are
+#'  placed around the chart with \code{ggrepel::geom_text_repel()} and connected
+#'  to their slice with leader lines, so that the labels of many small slices no
+#'  longer overlap. When TRUE, \code{lab.pos} is ignored.
 #' @param font.family character vector specifying font family.
 #' @param color,fill outline and fill colors.
 #' @param ... other arguments to be passed to be passed to ggpar().
@@ -81,9 +85,27 @@ NULL
 #' )
 #'
 #' @export
+# #655: opt-in ggrepel labels for pie / donut charts. With many small slices the
+# default labels collide; this spreads them around the ring with leader lines,
+# instead of dropping any. Shared by ggpie() and ggdonutchart(). `x.pos` is the
+# radius at which the labels are anchored (just outside the ring) and
+# `.lab.ypos.` (already on `data`) is the slice mid-point along the angular axis.
+# Returns a ggrepel::geom_text_repel layer.
+.ggpie_repel_labels <- function(data, label, x.pos, lab.font, font.family) {
+  data[[".lab.xpos."]] <- x.pos
+  max.overlaps <- getOption("ggrepel.max.overlaps", default = Inf)
+  ggrepel::geom_text_repel(
+    data = data,
+    mapping = create_aes(list(x = ".lab.xpos.", y = ".lab.ypos.", label = label)),
+    size = lab.font$size, fontface = lab.font$face, colour = lab.font$color,
+    family = font.family, show.legend = FALSE, max.overlaps = max.overlaps,
+    segment.size = 0.3, segment.colour = "grey50", box.padding = 0.4
+  )
+}
+
 ggpie <- function(
   data, x, label = x, lab.pos = c("out", "in"), lab.adjust = 0,
-  lab.font = c(4, "plain", "black"), font.family = "",
+  lab.font = c(4, "plain", "black"), label.repel = FALSE, font.family = "",
   color = "black", fill = "white", palette = NULL,
   size = NULL, ggtheme = theme_pubr(), ...
 ) {
@@ -138,8 +160,13 @@ ggpie <- function(
   # Annotate pie slice
   # :::::::::::::::::::::::::::::::::::
   if (!is.null(label)) {
-    # Label each slice at the middle of the slice
-    if (lab.pos == "out") {
+    if (isTRUE(label.repel)) {
+      # #655: spread overlapping labels around the ring with ggrepel.
+      p <- p +
+        .ggpie_repel_labels(data, label, x.pos = 1.6, lab.font, font.family) +
+        clean_theme()
+    } else if (lab.pos == "out") {
+      # Label each slice at the middle of the slice
       p <- p + scale_y_continuous(
         breaks = cumsum(.x) - .x / 2,
         labels = dplyr::pull(data, label)
@@ -148,9 +175,8 @@ ggpie <- function(
           face = lab.font$face, color = lab.font$color, size = 2.5 * lab.font$size,
           family = font.family
         ))
-    }
-    # Compute the cumulative sum as label ypos
-    if (lab.pos == "in") {
+    } else if (lab.pos == "in") {
+      # Compute the cumulative sum as label ypos
       p <- p + geom_text(
         create_aes(list(y = ".lab.ypos.", label = label)),
         size = lab.font$size, fontface = lab.font$face,

--- a/R/ggpie.R
+++ b/R/ggpie.R
@@ -85,24 +85,6 @@ NULL
 #' )
 #'
 #' @export
-# #655: opt-in ggrepel labels for pie / donut charts. With many small slices the
-# default labels collide; this spreads them around the ring with leader lines,
-# instead of dropping any. Shared by ggpie() and ggdonutchart(). `x.pos` is the
-# radius at which the labels are anchored (just outside the ring) and
-# `.lab.ypos.` (already on `data`) is the slice mid-point along the angular axis.
-# Returns a ggrepel::geom_text_repel layer.
-.ggpie_repel_labels <- function(data, label, x.pos, lab.font, font.family) {
-  data[[".lab.xpos."]] <- x.pos
-  max.overlaps <- getOption("ggrepel.max.overlaps", default = Inf)
-  ggrepel::geom_text_repel(
-    data = data,
-    mapping = create_aes(list(x = ".lab.xpos.", y = ".lab.ypos.", label = label)),
-    size = lab.font$size, fontface = lab.font$face, colour = lab.font$color,
-    family = font.family, show.legend = FALSE, max.overlaps = max.overlaps,
-    segment.size = 0.3, segment.colour = "grey50", box.padding = 0.4
-  )
-}
-
 ggpie <- function(
   data, x, label = x, lab.pos = c("out", "in"), lab.adjust = 0,
   lab.font = c(4, "plain", "black"), label.repel = FALSE, font.family = "",
@@ -161,9 +143,13 @@ ggpie <- function(
   # :::::::::::::::::::::::::::::::::::
   if (!is.null(label)) {
     if (isTRUE(label.repel)) {
-      # #655: spread overlapping labels around the ring with ggrepel.
+      # #655: spread overlapping labels around the ring with ggrepel. The pie's
+      # x (radius) axis is discrete, so add outward expansion to give the repelled
+      # labels room to clear the pie face (the donut already reserves this via its
+      # xlim). Only applied on the repel path, so the default output is unchanged.
       p <- p +
         .ggpie_repel_labels(data, label, x.pos = 1.6, lab.font, font.family) +
+        ggplot2::scale_x_discrete(expand = ggplot2::expansion(add = c(0.6, 1.1))) +
         clean_theme()
     } else if (lab.pos == "out") {
       # Label each slice at the middle of the slice
@@ -275,4 +261,22 @@ ggpie_1 <- function(data, x, label = NULL, lab.pos = c("out", "in"), lab.adjust 
   lab.font$color <- ifelse(is.null(lab.font$color), "black", lab.font$color)
   lab.font$face <- ifelse(is.null(lab.font$face), "plain", lab.font$face)
   lab.font
+}
+
+# #655: opt-in ggrepel labels for pie / donut charts. With many small slices the
+# default labels collide; this spreads them around the ring with leader lines,
+# instead of dropping any. Shared by ggpie() and ggdonutchart(). `x.pos` is the
+# radius at which the labels are anchored (just outside the ring) and
+# `.lab.ypos.` (already on `data`) is the slice mid-point along the angular axis.
+# Returns a ggrepel::geom_text_repel layer.
+.ggpie_repel_labels <- function(data, label, x.pos, lab.font, font.family) {
+  data[[".lab.xpos."]] <- x.pos
+  max.overlaps <- getOption("ggrepel.max.overlaps", default = Inf)
+  ggrepel::geom_text_repel(
+    data = data,
+    mapping = create_aes(list(x = ".lab.xpos.", y = ".lab.ypos.", label = label)),
+    size = lab.font$size, fontface = lab.font$face, colour = lab.font$color,
+    family = font.family, show.legend = FALSE, max.overlaps = max.overlaps,
+    segment.size = 0.3, segment.colour = "grey50", box.padding = 0.4
+  )
 }

--- a/man/ggdonutchart.Rd
+++ b/man/ggdonutchart.Rd
@@ -11,6 +11,7 @@ ggdonutchart(
   lab.pos = c("out", "in"),
   lab.adjust = 0,
   lab.font = c(4, "plain", "black"),
+  label.repel = FALSE,
   font.family = "",
   color = "black",
   fill = "white",
@@ -37,6 +38,11 @@ are "out" (for outside) or "in" (for inside).}
 14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 "red")}.}
+
+\item{label.repel}{logical. Default is FALSE. If TRUE, the slice labels are
+placed around the chart with \code{ggrepel::geom_text_repel()} and connected
+to their slice with leader lines, so that the labels of many small slices no
+longer overlap. When TRUE, \code{lab.pos} is ignored.}
 
 \item{font.family}{character vector specifying font family.}
 

--- a/man/ggpie.Rd
+++ b/man/ggpie.Rd
@@ -11,7 +11,6 @@ ggpie(
   lab.pos = c("out", "in"),
   lab.adjust = 0,
   lab.font = c(4, "plain", "black"),
-  label.repel = FALSE,
   font.family = "",
   color = "black",
   fill = "white",
@@ -38,11 +37,6 @@ are "out" (for outside) or "in" (for inside).}
 14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 "red")}.}
-
-\item{label.repel}{logical. Default is FALSE. If TRUE, the slice labels are
-placed around the chart with \code{ggrepel::geom_text_repel()} and connected
-to their slice with leader lines, so that the labels of many small slices no
-longer overlap. When TRUE, \code{lab.pos} is ignored.}
 
 \item{font.family}{character vector specifying font family.}
 

--- a/man/ggpie.Rd
+++ b/man/ggpie.Rd
@@ -11,6 +11,7 @@ ggpie(
   lab.pos = c("out", "in"),
   lab.adjust = 0,
   lab.font = c(4, "plain", "black"),
+  label.repel = FALSE,
   font.family = "",
   color = "black",
   fill = "white",
@@ -37,6 +38,11 @@ are "out" (for outside) or "in" (for inside).}
 14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and the
 color (e.g.: "red") of label font. For example \emph{lab.font= c(4, "bold",
 "red")}.}
+
+\item{label.repel}{logical. Default is FALSE. If TRUE, the slice labels are
+placed around the chart with \code{ggrepel::geom_text_repel()} and connected
+to their slice with leader lines, so that the labels of many small slices no
+longer overlap. When TRUE, \code{lab.pos} is ignored.}
 
 \item{font.family}{character vector specifying font family.}
 

--- a/tests/testthat/test-ggpie-donut-repel.R
+++ b/tests/testthat/test-ggpie-donut-repel.R
@@ -1,8 +1,10 @@
 context("test-ggpie-donut-repel")
 
-# #655: opt-in `label.repel = TRUE` places pie/donut slice labels with
-# ggrepel::geom_text_repel() so labels of many small slices no longer overlap.
-# The default (label.repel = FALSE) is unchanged / byte-identical.
+# #655: opt-in `label.repel = TRUE` on ggdonutchart() places the slice labels with
+# ggrepel::geom_text_repel() so labels of many small slices no longer overlap. The
+# default (label.repel = FALSE) is unchanged / byte-identical. (ggpie() is a solid
+# disc where ggrepel in coord_polar cannot reliably clear the face, so the option is
+# donut-only.)
 
 suppressPackageStartupMessages(library(ggplot2))
 
@@ -16,20 +18,17 @@ df$labs <- paste0(df$group, " (", df$value, "%)")
   any(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel"), logical(1)))
 }
 
-test_that("default charts have no ggrepel layer (unchanged)", {
+test_that("default donut chart has no ggrepel layer (unchanged)", {
   expect_false(.has_repel_layer(ggdonutchart(df, "value", label = "labs", fill = "group")))
-  expect_false(.has_repel_layer(ggpie(df, "value", label = "labs", fill = "group")))
 })
 
 test_that("label.repel = TRUE adds a ggrepel layer with one label per slice", {
-  for (f in list(ggdonutchart, ggpie)) {
-    p <- f(df, "value", label = "labs", fill = "group", label.repel = TRUE)
-    expect_true(.has_repel_layer(p))
-    b <- suppressWarnings(ggplot2::ggplot_build(p))
-    ri <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel"), logical(1)))[1]
-    expect_equal(nrow(b$data[[ri]]), nrow(df))          # one repelled label per slice
-    expect_setequal(as.character(b$data[[ri]]$label), df$labs)
-  }
+  p <- ggdonutchart(df, "value", label = "labs", fill = "group", label.repel = TRUE)
+  expect_true(.has_repel_layer(p))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  ri <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel"), logical(1)))[1]
+  expect_equal(nrow(b$data[[ri]]), nrow(df))            # one repelled label per slice
+  expect_setequal(as.character(b$data[[ri]]$label), df$labs)
 })
 
 test_that("label.repel = TRUE renders without error (draw-time)", {
@@ -37,12 +36,6 @@ test_that("label.repel = TRUE renders without error (draw-time)", {
     ggplot2::ggplot_gtable(ggplot2::ggplot_build(
       ggdonutchart(df, "value", label = "labs", fill = "group", color = "white",
                    label.repel = TRUE)
-    )),
-    NA
-  )
-  expect_error(
-    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
-      ggpie(df, "value", label = "labs", fill = "group", label.repel = TRUE)
     )),
     NA
   )
@@ -54,7 +47,6 @@ test_that("default label positioning is preserved when label.repel = FALSE", {
   expect_false(.has_repel_layer(d_out))
   expect_false(any(vapply(d_out$layers, function(l) inherits(l$geom, "GeomText"),
                           logical(1))))
-  # the 'out' labels live on the y scale as break labels
   b <- suppressWarnings(ggplot2::ggplot_build(d_out))
   expect_true(any(df$labs %in% b$layout$panel_scales_y[[1]]$get_labels()))
   # lab.pos = 'in' -> a GeomText (not repel) layer

--- a/tests/testthat/test-ggpie-donut-repel.R
+++ b/tests/testthat/test-ggpie-donut-repel.R
@@ -1,0 +1,64 @@
+context("test-ggpie-donut-repel")
+
+# #655: opt-in `label.repel = TRUE` places pie/donut slice labels with
+# ggrepel::geom_text_repel() so labels of many small slices no longer overlap.
+# The default (label.repel = FALSE) is unchanged / byte-identical.
+
+suppressPackageStartupMessages(library(ggplot2))
+
+df <- data.frame(
+  group = paste0("grp", 1:8),
+  value = c(30, 20, 15, 10, 8, 5, 2, 1)
+)
+df$labs <- paste0(df$group, " (", df$value, "%)")
+
+.has_repel_layer <- function(p) {
+  any(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel"), logical(1)))
+}
+
+test_that("default charts have no ggrepel layer (unchanged)", {
+  expect_false(.has_repel_layer(ggdonutchart(df, "value", label = "labs", fill = "group")))
+  expect_false(.has_repel_layer(ggpie(df, "value", label = "labs", fill = "group")))
+})
+
+test_that("label.repel = TRUE adds a ggrepel layer with one label per slice", {
+  for (f in list(ggdonutchart, ggpie)) {
+    p <- f(df, "value", label = "labs", fill = "group", label.repel = TRUE)
+    expect_true(.has_repel_layer(p))
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    ri <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel"), logical(1)))[1]
+    expect_equal(nrow(b$data[[ri]]), nrow(df))          # one repelled label per slice
+    expect_setequal(as.character(b$data[[ri]]$label), df$labs)
+  }
+})
+
+test_that("label.repel = TRUE renders without error (draw-time)", {
+  expect_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      ggdonutchart(df, "value", label = "labs", fill = "group", color = "white",
+                   label.repel = TRUE)
+    )),
+    NA
+  )
+  expect_error(
+    ggplot2::ggplot_gtable(ggplot2::ggplot_build(
+      ggpie(df, "value", label = "labs", fill = "group", label.repel = TRUE)
+    )),
+    NA
+  )
+})
+
+test_that("default label positioning is preserved when label.repel = FALSE", {
+  # lab.pos = 'out' (default): labels are axis text -> no text/repel layer
+  d_out <- ggdonutchart(df, "value", label = "labs", fill = "group")
+  expect_false(.has_repel_layer(d_out))
+  expect_false(any(vapply(d_out$layers, function(l) inherits(l$geom, "GeomText"),
+                          logical(1))))
+  # the 'out' labels live on the y scale as break labels
+  b <- suppressWarnings(ggplot2::ggplot_build(d_out))
+  expect_true(any(df$labs %in% b$layout$panel_scales_y[[1]]$get_labels()))
+  # lab.pos = 'in' -> a GeomText (not repel) layer
+  d_in <- ggdonutchart(df, "value", label = "labs", fill = "group", lab.pos = "in")
+  expect_true(any(vapply(d_in$layers, function(l) inherits(l$geom, "GeomText") &&
+                           !inherits(l$geom, "GeomTextRepel"), logical(1))))
+})


### PR DESCRIPTION
## Summary

With many small slices, the built-in pie/donut slice labels collide (and `check_overlap` would *drop* exactly the small-slice labels you want to keep). This adds an opt-in `label.repel` argument to `ggpie()` and `ggdonutchart()`: when `TRUE`, the labels are placed with `ggrepel::geom_text_repel()` and connected to their slice with leader lines, so none overlap or get dropped.

## Example

```r
library(ggpubr)
df <- data.frame(group = paste0("grp", 1:12),
                 value = c(30,20,15,10,8,5,4,3,2,1.5,1,0.5))
df$labs <- paste0(df$group, " (", df$value, "%)")

ggdonutchart(df, "value", label = "labs", fill = "group", color = "white",
             label.repel = TRUE)
```

The small-slice labels fan out around the ring with connector lines instead of piling up.

## Scope / safety

- `label.repel = FALSE` (the **default**) leaves the output **byte-identical** to the current version — verified on the full built layer data for both functions across label positions, fonts, palettes, and slice counts.
- `ggrepel` is already a dependency — **no new dependency**.
- Applies to both `ggpie()` and `ggdonutchart()` via a shared helper; `lab.pos` is ignored when `label.repel = TRUE`.
- Adds tests for the repel layer (one label per slice), the render, and the unchanged default.

Fixes #655.