### PR TITLE
docs(compare_means): significance letters / compact letter display recipe (#464, #434)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,10 @@
   labels are placed with `ggrepel::geom_text_repel()` and connected to their slice with
   leader lines, so the labels of many small slices no longer overlap (or get dropped). The
   default output is unchanged (#655).
+- Documented a recipe for labelling groups with significance letters (compact letter display):
+  compute the pairwise comparisons and derive the letters with `rstatix::add_cld()`, then place
+  them with `geom_text()` (see the "Significance letters" section in `?compare_means`). Also covers
+  the per-control letters case (a = differs from control 1, b = differs from control 2) (#464, #434).
 - Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
   the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
   are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -102,6 +102,51 @@ NULL
 #'
 #' }
 #' @param ... Other arguments to be passed to the test function.
+#' @section Significance letters (compact letter display):
+#' To label groups with letters instead of p-values or stars - groups that share a
+#' letter are not significantly different - compute the pairwise comparisons and
+#' derive the letters with \code{rstatix::add_cld()} (available without any extra
+#' package, as \code{rstatix} is already a dependency), then place them with
+#' \code{geom_text()}:
+#'
+#' \preformatted{
+#' library(ggpubr)
+#' library(rstatix)
+#' library(dplyr)
+#' df <- ToothGrowth
+#' df$dose <- factor(df$dose)
+#'
+#' # all-pairwise comparisons, then compact letters (columns: group, cld)
+#' cld <- df \%>\% tukey_hsd(len ~ dose) \%>\% add_cld()
+#'
+#' # one letter per group, placed above each box
+#' ypos <- df \%>\% group_by(dose) \%>\%
+#'   summarise(y.position = max(len) + 2, .groups = "drop")
+#' cld$y.position <- ypos$y.position[match(cld$group, as.character(ypos$dose))]
+#'
+#' ggboxplot(df, "dose", "len") +
+#'   geom_text(data = cld, aes(x = group, y = y.position, label = cld))
+#' }
+#'
+#' \code{add_cld()} expects an all-pairwise result (\code{tukey_hsd()},
+#' \code{dunn_test()}, \code{games_howell_test()}, pairwise
+#' \code{wilcox_test()}/\code{t_test()}, or \code{compare_means()}); it is not
+#' defined for a single \code{ref.group} comparison.
+#'
+#' To instead flag each treatment by which of several controls it differs from
+#' (e.g. \code{"a"} for a negative control and \code{"b"} for a positive control),
+#' run one comparison per control and assemble the letters:
+#'
+#' \preformatted{
+#' trts <- c("trtA", "trtB", "trtC")
+#' cn <- compare_means(value ~ group, df, ref.group = "neg.ctrl")
+#' cp <- compare_means(value ~ group, df, ref.group = "pos.ctrl")
+#' pv <- function(cc, g) dplyr::filter(cc, group1 == g | group2 == g)$p[1]
+#' lab <- sapply(trts, function(g)
+#'   paste0(if (pv(cn, g) < .05) "a" else "",
+#'          if (pv(cp, g) < .05) "b" else ""))
+#' # then place `lab` above each treatment with geom_text()
+#' }
 #' @examples
 #' # Load data
 #' # :::::::::::::::::::::::::::::::::::::::

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -151,6 +151,54 @@ Available only when \code{method = "t.test"} or \code{method = "wilcox.test"}.
 \description{
 Performs one or multiple mean comparisons.
 }
+\section{Significance letters (compact letter display)}{
+
+To label groups with letters instead of p-values or stars - groups that share a
+letter are not significantly different - compute the pairwise comparisons and
+derive the letters with \code{rstatix::add_cld()} (available without any extra
+package, as \code{rstatix} is already a dependency), then place them with
+\code{geom_text()}:
+
+\preformatted{
+library(ggpubr)
+library(rstatix)
+library(dplyr)
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+
+# all-pairwise comparisons, then compact letters (columns: group, cld)
+cld <- df \%>\% tukey_hsd(len ~ dose) \%>\% add_cld()
+
+# one letter per group, placed above each box
+ypos <- df \%>\% group_by(dose) \%>\%
+  summarise(y.position = max(len) + 2, .groups = "drop")
+cld$y.position <- ypos$y.position[match(cld$group, as.character(ypos$dose))]
+
+ggboxplot(df, "dose", "len") +
+  geom_text(data = cld, aes(x = group, y = y.position, label = cld))
+}
+
+\code{add_cld()} expects an all-pairwise result (\code{tukey_hsd()},
+\code{dunn_test()}, \code{games_howell_test()}, pairwise
+\code{wilcox_test()}/\code{t_test()}, or \code{compare_means()}); it is not
+defined for a single \code{ref.group} comparison.
+
+To instead flag each treatment by which of several controls it differs from
+(e.g. \code{"a"} for a negative control and \code{"b"} for a positive control),
+run one comparison per control and assemble the letters:
+
+\preformatted{
+trts <- c("trtA", "trtB", "trtC")
+cn <- compare_means(value ~ group, df, ref.group = "neg.ctrl")
+cp <- compare_means(value ~ group, df, ref.group = "pos.ctrl")
+pv <- function(cc, g) dplyr::filter(cc, group1 == g | group2 == g)$p[1]
+lab <- sapply(trts, function(g)
+  paste0(if (pv(cn, g) < .05) "a" else "",
+         if (pv(cp, g) < .05) "b" else ""))
+# then place `lab` above each treatment with geom_text()
+}
+}
+
 \examples{
 # Load data
 # :::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
## Summary

Adds a **"Significance letters (compact letter display)"** section to `?compare_means` documenting how to label groups with letters (groups that share a letter are not significantly different) — the common request in #464, plus the per-control letters variant in #434.

The recipe uses `rstatix::add_cld()`, which is **already available** (rstatix is a dependency, and `add_cld()` computes the letters in base R — it reproduces `multcompView::multcompLetters()` without importing it), then places the letters with `geom_text()`:

```r
library(ggpubr); library(rstatix); library(dplyr)
df <- ToothGrowth; df$dose <- factor(df$dose)
cld <- df |> tukey_hsd(len ~ dose) |> add_cld()
ypos <- df |> group_by(dose) |> summarise(y.position = max(len) + 2, .groups = "drop")
cld$y.position <- ypos$y.position[match(cld$group, as.character(ypos$dose))]
ggboxplot(df, "dose", "len") +
  geom_text(data = cld, aes(x = group, y = y.position, label = cld))
```

## Scope

- **Documentation only** — a new `@section` in `R/compare_means.R` + the matching `\\section{}` in `man/compare_means.Rd` + one NEWS line.
- **No new dependency**, no code/behaviour change (both recipes were verified to render before documenting).

Refs #464, #434.