### PR TITLE
ggpar(): don't error on plots using element_markdown labels (#382)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@
 
 ## Robustness fixes
 
+- `ggpar()` no longer errors on `ggsurvplot` objects (or any plot whose theme uses
+  `ggtext::element_markdown()`, e.g. survminer's risk-table strata labels). Such
+  markdown label elements are now left intact instead of triggering an "Only elements
+  of the same class can be merged" error; output for all other plots is unchanged (#382).
 - Hardened sparse-group handling in `stat_compare_means()` and `geom_pwc()`.
 - Non-comparable grouped subsets (insufficient levels/observations) are now skipped
   while preserving valid inferential comparisons in the same layer.

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -198,7 +198,7 @@ ggpar <- function(p, palette = NULL, gradient.cols = NULL,
       if (!is.null(ggtheme)) p <- p + ggtheme # labs_pubr() +
       if (!is.null(gradient.cols)) p <- p + .gradient_col(gradient.cols)
 
-      p <- p + .set_ticks(ticks, tickslab, font.tickslab,
+      p <- .set_ticks(p, ticks, tickslab, font.tickslab,
         xtickslab.rt, ytickslab.rt,
         font.xtickslab = font.xtickslab, font.ytickslab = font.ytickslab
       )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -236,45 +236,34 @@ keep_only_tbl_df_classes <- function(x) {
   }
 
   if (!is.null(font.main)) {
-    p <-
-      p + theme(
-        plot.title = element_text(
-          size = font.main$size,
-          lineheight = 1.0, face = font.main$face, colour = font.main$color
-        )
-      )
+    p <- .add_text_theme(p, "plot.title", element_text(
+      size = font.main$size,
+      lineheight = 1.0, face = font.main$face, colour = font.main$color
+    ))
   }
   if (!is.null(font.submain)) {
-    p <-
-      p + theme(
-        plot.subtitle = element_text(
-          size = font.submain$size,
-          lineheight = 1.0, face = font.submain$face, colour = font.submain$color
-        )
-      )
+    p <- .add_text_theme(p, "plot.subtitle", element_text(
+      size = font.submain$size,
+      lineheight = 1.0, face = font.submain$face, colour = font.submain$color
+    ))
   }
   if (!is.null(font.caption)) {
-    p <-
-      p + theme(
-        plot.caption = element_text(
-          size = font.caption$size,
-          lineheight = 1.0, face = font.caption$face, colour = font.caption$color
-        )
-      )
+    p <- .add_text_theme(p, "plot.caption", element_text(
+      size = font.caption$size,
+      lineheight = 1.0, face = font.caption$face, colour = font.caption$color
+    ))
   }
   if (!is.null(font.x)) {
-    p <-
-      p + theme(axis.title.x = element_text(
-        size = font.x$size,
-        face = font.x$face, colour = font.x$color
-      ))
+    p <- .add_text_theme(p, "axis.title.x", element_text(
+      size = font.x$size,
+      face = font.x$face, colour = font.x$color
+    ))
   }
   if (!is.null(font.y)) {
-    p <-
-      p + theme(axis.title.y = element_text(
-        size = font.y$size,
-        face = font.y$face, colour = font.y$color
-      ))
+    p <- .add_text_theme(p, "axis.title.y", element_text(
+      size = font.y$size,
+      face = font.y$face, colour = font.y$color
+    ))
   }
 
 
@@ -282,10 +271,26 @@ keep_only_tbl_df_classes <- function(x) {
 }
 
 
+# Merge a text theme element into a single theme slot, unless the plot already
+# carries a markdown element there. ggtext's element_markdown()/element_textbox()
+# (used e.g. by survminer on risk-table strata labels) cannot be merged with a
+# plain element_text(): ggplot2 errors "Only elements of the same class can be
+# merged". For such slots we leave the existing element untouched, so ggpar() no
+# longer crashes on ggsurvplot objects. Normal element_text/element_blank/NULL
+# slots are handled exactly as before (p + theme(...)), so output is unchanged
+# (#382).
+.add_text_theme <- function(p, slot, element) {
+  existing <- p$theme[[slot]]
+  if (inherits(existing, c("element_markdown", "element_textbox"))) {
+    return(p)
+  }
+  p + do.call(ggplot2::theme, stats::setNames(list(element), slot))
+}
+
 # ticks
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 .set_ticks <-
-  function(ticks = TRUE, tickslab = TRUE, font.tickslab = NULL,
+  function(p, ticks = TRUE, tickslab = TRUE, font.tickslab = NULL,
            xtickslab.rt = NULL, ytickslab.rt = NULL,
            font.xtickslab = font.tickslab, font.ytickslab = font.tickslab) {
     . <- xhjust <- xvjust <- NULL
@@ -314,6 +319,7 @@ keep_only_tbl_df_classes <- function(x) {
       font.y <- .parse_font(font.ytickslab)
     }
 
+    p <- p + theme(axis.ticks = ticks)
     if (tickslab) {
       xtickslab <- font.x %>%
         .add_item(hjust = xhjust, vjust = xvjust, angle = xtickslab.rt) %>%
@@ -321,13 +327,13 @@ keep_only_tbl_df_classes <- function(x) {
       ytickslab <- font.y %>%
         .add_item(angle = ytickslab.rt) %>%
         do.call(element_text, .)
+      # Skip a slot whose existing element is markdown (see .add_text_theme, #382)
+      p <- .add_text_theme(p, "axis.text.x", xtickslab)
+      p <- .add_text_theme(p, "axis.text.y", ytickslab)
     } else {
-      xtickslab <- element_blank()
-      ytickslab <- element_blank()
+      p <- p + theme(axis.text.x = element_blank(), axis.text.y = element_blank())
     }
-    theme(
-      axis.ticks = ticks, axis.text.x = xtickslab, axis.text.y = ytickslab
-    )
+    p
   }
 
 
@@ -427,16 +433,14 @@ keep_only_tbl_df_classes <- function(x) {
   }
 
   if (!is.null(font)) {
-    p <- p + theme(
-      legend.text = element_text(
-        size = font$size,
-        face = font$face, colour = font$color
-      ),
-      legend.title = element_text(
-        size = font$size,
-        face = font$face, colour = font$color
-      )
-    )
+    p <- .add_text_theme(p, "legend.text", element_text(
+      size = font$size,
+      face = font$face, colour = font$color
+    ))
+    p <- .add_text_theme(p, "legend.title", element_text(
+      size = font$size,
+      face = font$face, colour = font$color
+    ))
   }
 
   p

--- a/tests/testthat/test-ggpar-element-markdown.R
+++ b/tests/testthat/test-ggpar-element-markdown.R
@@ -1,0 +1,93 @@
+context("test-ggpar-element-markdown")
+
+# #382 / survminer #520: ggpar() re-themes a plot by adding element_text() to theme
+# slots. When a slot already holds a ggtext::element_markdown() (survminer sets one
+# on the risk-table strata labels), ggplot2 errored "Only elements of the same class
+# can be merged" / "Can't merge the `<slot>` theme element". ggpar() now leaves such
+# markdown slots untouched instead of crashing; normal element_text slots are handled
+# exactly as before.
+#
+# The tests build a markdown-classed element WITHOUT depending on ggtext, so they run
+# everywhere: an element carrying the same "element_markdown" class signature triggers
+# the identical merge path (dispatch/assertion in ggplot2 is class-based).
+
+suppressPackageStartupMessages(library(ggplot2))
+
+# Synthetic ggtext::element_markdown()-classed element (no ggtext dependency).
+.fake_markdown_element <- function() {
+  el <- ggplot2::element_text()
+  class(el) <- c("element_markdown", class(el))
+  el
+}
+
+test_that("ggpar() does not crash and renders when a slot is element_markdown (#382)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len") +
+    theme(axis.text.y = .fake_markdown_element())
+  expect_error(
+    q <- ggpar(p, font.tickslab = c(14, "bold"), font.x = c(16), font.main = c(18)),
+    NA
+  )
+  # full render must also succeed (draw-time, not just build)
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(q)), NA)
+})
+
+test_that("ggpar() leaves the markdown slot intact but restyles other slots (#382)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len") +
+    theme(axis.text.y = .fake_markdown_element())
+  q <- ggpar(p, font.tickslab = c(14, "bold"), font.x = c(16))
+  # markdown slot preserved (not overwritten with element_text)
+  expect_true(inherits(q$theme[["axis.text.y"]], "element_markdown"))
+  # a normal slot is still restyled as requested
+  expect_true(inherits(q$theme[["axis.text.x"]], "element_text"))
+  expect_false(inherits(q$theme[["axis.text.x"]], "element_markdown"))
+  expect_equal(q$theme[["axis.text.x"]]$size, 14)
+  expect_equal(q$theme[["axis.title.x"]]$size, 16)
+})
+
+test_that("ggpar() handles a list of ggplots, guarding each markdown slot (#382, survminer #520)", {
+  # Mimic a ggsurvplot: a list holding two ggplots, one with a markdown element on
+  # the risk-table-like component (as survminer sets on its strata labels). ggpar()
+  # must iterate the list, not crash, and preserve the markdown element.
+  p_plot <- ggboxplot(ToothGrowth, "dose", "len")
+  p_tab <- ggboxplot(ToothGrowth, "dose", "len") +
+    theme(axis.text.y = .fake_markdown_element())
+  lst <- list(plot = p_plot, table = p_tab)
+  expect_error(res <- ggpar(lst, font.title = c(16, "bold"), font.x = c(14),
+                            font.tickslab = c(12)), NA)
+  expect_true(is.list(res))
+  # markdown slot on the "table" is preserved, curve component restyled
+  expect_true(inherits(res$table$theme[["axis.text.y"]], "element_markdown"))
+  expect_equal(res$plot$theme[["axis.title.x"]]$size, 14)
+  # both components render
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(res$plot)), NA)
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(res$table)), NA)
+})
+
+test_that("ggpar() output is unchanged for a normal plot (no-regression, #382)", {
+  # For a plot with no markdown element, ggpar() must behave exactly as before:
+  # every requested font slot is applied as an element_text with the given values.
+  p <- ggboxplot(ToothGrowth, "dose", "len", color = "supp")
+  q <- ggpar(p, main = "M", xlab = "X", ylab = "Y",
+             font.main = c(20, "bold", "red"), font.x = c(14, "bold", "blue"),
+             font.y = c(14), font.tickslab = c(11, "plain", "darkgreen"),
+             font.legend = c(9), legend.title = "Supp",
+             xtickslab.rt = 45, ytickslab.rt = 90)
+  expect_equal(q$theme[["plot.title"]]$size, 20)
+  expect_equal(q$theme[["plot.title"]]$colour, "red")
+  expect_equal(q$theme[["axis.title.x"]]$size, 14)
+  expect_equal(q$theme[["axis.title.x"]]$colour, "blue")
+  expect_equal(q$theme[["axis.text.x"]]$size, 11)
+  expect_equal(q$theme[["axis.text.x"]]$colour, "darkgreen")
+  expect_equal(q$theme[["axis.text.x"]]$angle, 45)
+  expect_equal(q$theme[["axis.text.y"]]$angle, 90)
+  expect_equal(q$theme[["legend.text"]]$size, 9)
+  # ticks still applied
+  expect_true(inherits(q$theme[["axis.ticks"]], "element_line"))
+})
+
+test_that("ggpar(tickslab = FALSE) still blanks the tick labels (#382)", {
+  p <- ggboxplot(ToothGrowth, "dose", "len")
+  q <- ggpar(p, tickslab = FALSE)
+  expect_true(inherits(q$theme[["axis.text.x"]], "element_blank"))
+  expect_true(inherits(q$theme[["axis.text.y"]], "element_blank"))
+})


### PR DESCRIPTION
### Problem

`ggpar()` styles a plot by adding `element_text()` to theme slots. When a slot already holds a `ggtext::element_markdown()` — as **survminer** sets on the risk-table strata labels of a `ggsurvplot` — ggplot2 cannot merge the two elements and raises `Error: Only elements of the same class can be merged`. So `ggpar(ggsurvplot_object, ...)` errored (reported in survminer #520, tracked here as #382).

### Fix

`ggpar()` now leaves markdown label elements untouched instead of trying to merge an `element_text()` onto them. The plot renders and the markdown labels are preserved. For plots that do **not** use `element_markdown()`, output is unchanged.

### Notes

- No new dependency.
- Added regression tests plus a no-regression test confirming normal plots are styled exactly as before.
- `NEWS.md` updated.

Fixes #382.
