### PR TITLE
ggbarplot(): support alpha grouping variable with error bars (#404)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,12 @@
 
 ## Robustness fixes
 
+- `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together
+  with a summary (e.g. `alpha = clarity, add = "mean_ci", position = position_dodge()`).
+  Previously this errored at draw time (`"alpha * 255": non-numeric argument to binary
+  operator`). The mean/CI is now computed per subgroup, the bars are faded per the `alpha`
+  variable, and the error bars are dodged to stay aligned with their bars. Bar plots
+  without an `alpha` grouping variable are unchanged (#404).
 - `ggpar()` no longer errors on `ggsurvplot` objects (or any plot whose theme uses
   `ggtext::element_markdown()`, e.g. survminer's risk-table strata labels). Such
   markdown label elements are now left intact instead of triggering an "Only elements

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -286,8 +286,26 @@ ggbarplot_core <- function(data, x, y,
   label <- as.vector(label)
   if ("none" %in% add) add <- "none"
 
-  grouping.vars <- intersect(c(x, color, fill, facet.by), names(data))
   . <- NULL
+
+  # #404: an `alpha` aesthetic mapped to a discrete data column defines an extra
+  # dodge subgroup (e.g. fill = cut, alpha = clarity -> 2 bars per cut). Detect it
+  # so the summary keeps that column and the error layer dodges by it too. Scoped
+  # to plain position_dodge(): the alpha subgroup adds a second dodge dimension,
+  # which position_stack()/position_dodge2() do not resolve here (they are left
+  # exactly as before, unchanged by this fix).
+  alpha.var <- list(...)[["alpha"]]   # [[ ]] avoids $ partial-matching a `...` arg
+  has.alpha.group <- !is.null(alpha.var) && length(alpha.var) == 1 &&
+    is.character(alpha.var) && alpha.var %in% names(data) &&
+    !is.numeric(.select_vec(data, alpha.var)) &&
+    inherits(position, "PositionDodge") && !inherits(position, "PositionDodge2")
+
+  grouping.vars <- intersect(c(x, color, fill, facet.by), names(data))
+  # Include the alpha subgroup in the summary grouping. Otherwise the summarized
+  # data drops the alpha column, which (a) makes geom_exec pass alpha as a static
+  # value -> the "alpha * 255" draw error (#404), and (b) collapses the mean/CI
+  # across the subgroups. Left unchanged when no discrete alpha var is mapped.
+  if (has.alpha.group) grouping.vars <- unique(c(grouping.vars, alpha.var))
 
   # static summaries for computing mean/median and adding errors
   if (is.null(add.params$fill)) add.params$fill <- "white"
@@ -295,6 +313,19 @@ ggbarplot_core <- function(data, x, y,
     if (fill %in% names(data)) {
       add.params$group <- fill
     } else if (color %in% names(data)) add.params$group <- color
+  }
+  # #404: the bars dodge by the interaction of fill/x and the alpha subgroup, so
+  # the error layer must dodge by that same interaction to stay aligned; otherwise
+  # the error bars are centered on each x while the bars are split (misaligned). We
+  # materialise the interaction as a real column with a safe name (rather than an
+  # "interaction(a, b)" mapping string), so it is robust to special characters in
+  # the variable names and to options(ggpubr.parse_aes = FALSE).
+  if (has.alpha.group) {
+    base.group <- add.params$group %||% x
+    data[[".ggpubr.alpha.group."]] <- interaction(
+      .select_vec(data, base.group), .select_vec(data, alpha.var), drop = TRUE
+    )
+    add.params$group <- ".ggpubr.alpha.group."
   }
   add.params <- .check_add.params(add, add.params, error.plot, data, color, fill, ...)
 

--- a/tests/testthat/test-ggbarplot-alpha-errorbar.R
+++ b/tests/testthat/test-ggbarplot-alpha-errorbar.R
@@ -1,0 +1,92 @@
+context("test-ggbarplot-alpha-errorbar")
+
+# #404: ggbarplot(alpha = <discrete var>, add = "mean_ci", position = position_dodge())
+# used to error at draw time ("alpha * 255": non-numeric argument) and, once that was
+# worked around, collapsed the summary across the alpha subgroup. The summary now groups
+# by the alpha variable too, so the bars are drawn per subgroup with the alpha aesthetic
+# preserved, and the error layer dodges by the same subgroup so error bars stay aligned.
+
+suppressPackageStartupMessages({
+  library(ggplot2)
+  library(dplyr)
+})
+
+# small, deterministic 2x2 grouped data
+df <- ToothGrowth
+df$dose <- factor(df$dose)
+df2 <- subset(df, dose %in% c("0.5", "1"))
+df2$dose <- droplevels(df2$dose)
+
+test_that("ggbarplot(alpha=var, add='mean_ci', dodge) renders without the alpha*255 error (#404)", {
+  p <- ggbarplot(df2, x = "dose", y = "len", fill = "dose", alpha = "supp",
+                 add = "mean_ci", position = position_dodge())
+  # full render (the crash was draw-time, not build-time)
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+})
+
+test_that("alpha subgroup gives per-subgroup bars, aligned error bars, and a real alpha aesthetic (#404)", {
+  p <- ggbarplot(df2, x = "dose", y = "len", fill = "dose", alpha = "supp",
+                 add = "mean_ci", position = position_dodge())
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bar <- b$data[[1]]
+  err <- b$data[[2]]
+  # 2 dose x 2 supp = 4 bars and 4 error bars
+  expect_equal(nrow(bar), 4)
+  expect_equal(nrow(err), 4)
+  # error bars sit exactly on the bar x-positions (aligned, not centered)
+  expect_equal(sort(round(bar$x, 6)), sort(round(err$x, 6)))
+  # x is genuinely dodged (not all at integer centers)
+  expect_false(all(bar$x %in% c(1, 2)))
+  # alpha is a mapped aesthetic (two distinct levels), not a static/NA value
+  expect_equal(length(unique(round(bar$alpha, 4))), 2)
+})
+
+test_that("bar heights equal the per-subgroup means and CIs bracket them (#404)", {
+  p <- ggbarplot(df2, x = "dose", y = "len", fill = "dose", alpha = "supp",
+                 add = "mean_ci", position = position_dodge())
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bar <- b$data[[1]][order(b$data[[1]]$x), ]
+  err <- b$data[[2]][order(b$data[[2]]$x), ]
+  expected <- df2 %>%
+    group_by(dose, supp) %>%
+    summarise(m = mean(len), .groups = "drop")
+  expect_equal(sort(round(bar$y, 6)), sort(round(expected$m, 6)))
+  # each CI brackets its bar's mean
+  expect_true(all(err$ymin < bar$y & bar$y < err$ymax))
+})
+
+test_that("no-regression: ggbarplot summaries without alpha are unchanged (#404)", {
+  # A plain grouped summary bar (no alpha) must be untouched by the fix: 2 dose x 2 supp
+  # bars, dodged, mean_se error bars centered on each bar as before.
+  p <- ggbarplot(df, x = "dose", y = "len", fill = "supp",
+                 add = "mean_se", position = position_dodge())
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_equal(nrow(b$data[[1]]), 6)                 # 3 dose x 2 supp
+  # bar heights are the per-(dose,supp) means
+  expected <- df %>% group_by(dose, supp) %>% summarise(m = mean(len), .groups = "drop")
+  expect_equal(sort(round(b$data[[1]]$y, 6)), sort(round(expected$m, 6)))
+  # error x aligns with bar x (this always worked for the single fill dimension)
+  expect_equal(sort(round(b$data[[1]]$x, 6)), sort(round(b$data[[2]]$x, 6)))
+})
+
+test_that("the alpha subgroup also aligns under options(ggpubr.parse_aes = FALSE) (#404)", {
+  # The error-layer dodge group is a real, safe-named column, so it works even when
+  # aes parsing is disabled (used for column names with special characters).
+  old <- options(ggpubr.parse_aes = FALSE)
+  on.exit(options(old), add = TRUE)
+  p <- ggbarplot(df2, x = "dose", y = "len", fill = "dose", alpha = "supp",
+                 add = "mean_ci", position = position_dodge())
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_error(ggplot2::ggplot_gtable(b), NA)
+  expect_equal(nrow(b$data[[1]]), 4)
+  expect_equal(sort(round(b$data[[1]]$x, 6)), sort(round(b$data[[2]]$x, 6)))
+})
+
+test_that("a static numeric alpha is still treated as a constant, not a grouping var (#404)", {
+  # alpha = 0.5 is a fixed transparency, not a column -> must NOT trigger subgrouping.
+  p <- ggbarplot(df, x = "dose", y = "len", fill = "supp", alpha = 0.5,
+                 add = "mean_se", position = position_dodge())
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_equal(nrow(b$data[[1]]), 6)                 # unchanged: 3 dose x 2 supp
+  expect_true(all(abs(b$data[[1]]$alpha - 0.5) < 1e-9))
+})


### PR DESCRIPTION
### Problem

`ggbarplot()` with `alpha` mapped to a discrete grouping variable **and** a summary (`add = "mean_ci"`, etc.) errored at draw time:

```r
ggbarplot(df, x = "cut", y = "price", fill = "cut", alpha = "clarity",
          add = "mean_ci", position = position_dodge())
#> Error in alpha * 255 : non-numeric argument to binary operator
```

With a summary `add`, the bars are drawn against a summarized data frame that did not include the `alpha` variable. So the `alpha` aesthetic was passed as a static character string, and the mean/CI collapsed across the subgroup.

### Fix

The summary now also groups by a discrete `alpha` variable, so:

- the bars are faded per subgroup, with correct **per-subgroup** mean/CI, and
- the error layer dodges by the same subgroup, so **error bars stay aligned** with their bars.

This gives the mean±CI equivalent of the working `ggboxplot(..., alpha = <var>)` behaviour. Scoped to plain `position_dodge()`.

### Notes

- No new dependency.
- Bar plots **without** an `alpha` grouping variable are unchanged (verified byte-identical).
- `position_stack()`/`position_dodge2()` with an `alpha` grouping variable are left exactly as before.
- Added regression + no-regression tests; `NEWS.md` updated.

Fixes #404.
