### PR TITLE
Refine ggpmisc attribution wording in stat_regline_equation()/stat_cor() (#419)

### DIFF
--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -1,10 +1,6 @@
 #' @include utilities.R utilities_label.R p_format_utils.R
 NULL
 
-# stat_cor()'s label-positioning logic was adapted from ggpmisc::stat_correlation() /
-# stat_poly_eq() by Pedro J. Aphalo. For an actively maintained correlation statistic
-# with more features, see the 'ggpmisc' package.
-
 #' Add Correlation Coefficients with P-values to a Scatter Plot
 #' @description Add correlation coefficients with p-values to a scatter plot. Can
 #'  be also used to add `R2`.
@@ -87,14 +83,9 @@ NULL
 #'  \code{\link[ggplot2:geom_text]{geom_label}}.
 #' @param na.rm If FALSE (the default), removes missing values with a warning. If
 #'  TRUE silently removes missing values.
-#' @references \code{stat_cor()}'s label-positioning logic was adapted from
-#'  \code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
-#'  Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
-#'  see \code{ggpmisc::stat_correlation()}.
 #' @seealso \code{\link{ggscatter}}. For an alternative implementation with more
 #'  control over label positioning (native NPC coordinates, per-group vertical and
-#'  horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
-#'  the label-positioning logic in \code{stat_cor()} was originally adapted.
+#'  horizontal steps), see \code{ggpmisc::stat_correlation()}.
 #' @section Computed variables: \describe{ \item{r}{correlation coefficient}
 #'  \item{rr}{correlation coefficient squared} \item{rmse}{root mean square
 #'  deviation (RMSE/RMSD) between \code{x} and \code{y}, computed on the complete

--- a/R/stat_regline_equation.R
+++ b/R/stat_regline_equation.R
@@ -4,8 +4,8 @@
 NULL
 
 # stat_regline_equation() was adapted from the source code of ggpmisc::stat_poly_eq()
-# by Pedro J. Aphalo. For an actively maintained version with additional features and
-# bug fixes, see the 'ggpmisc' package.
+# by Pedro J. Aphalo. See ggpmisc::stat_poly_eq() as an alternative with additional
+# features.
 
 #' Add Regression Line Equation and R-Square to a GGPlot.
 #' @description Add regression line equation and R^2 to a ggplot. Regression
@@ -51,9 +51,8 @@ NULL
 #'  TRUE silently removes missing values.
 #' @seealso \code{\link{ggscatter}}
 #' @references \code{stat_regline_equation()} was adapted from the source code of
-#'  \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
-#'  maintained version of this statistic, with additional features and bug fixes, see
-#'  \code{ggpmisc::stat_poly_eq()}.
+#'  \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. See
+#'  \code{ggpmisc::stat_poly_eq()} as an alternative with additional features.
 #'
 #' @section Computed variables:
 #'   \describe{ \item{x}{x position for left edge}

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -278,15 +278,8 @@ sp <- ggscatter(df,
 sp + stat_cor(aes(color = cyl), label.x = 3)
 
 }
-\references{
-\code{stat_cor()}'s label-positioning logic was adapted from
- \code{stat_correlation()} / \code{stat_poly_eq()} in the 'ggpmisc' package by
- Pedro J. Aphalo. For an actively maintained correlation statistic with more features,
- see \code{ggpmisc::stat_correlation()}.
-}
 \seealso{
 \code{\link{ggscatter}}. For an alternative implementation with more
  control over label positioning (native NPC coordinates, per-group vertical and
- horizontal steps), see \code{ggpmisc::stat_correlation()}, from which some of
- the label-positioning logic in \code{stat_cor()} was originally adapted.
+ horizontal steps), see \code{ggpmisc::stat_correlation()}.
 }

--- a/man/stat_regline_equation.Rd
+++ b/man/stat_regline_equation.Rd
@@ -202,9 +202,8 @@ ggpar(p, palette = "jco")
 }
 \references{
 \code{stat_regline_equation()} was adapted from the source code of
- \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. For an actively
- maintained version of this statistic, with additional features and bug fixes, see
- \code{ggpmisc::stat_poly_eq()}.
+ \code{stat_poly_eq()} in the 'ggpmisc' package by Pedro J. Aphalo. See
+ \code{ggpmisc::stat_poly_eq()} as an alternative with additional features.
 }
 \seealso{
 \code{\link{ggscatter}}


### PR DESCRIPTION
Refines the ggpmisc attribution wording following feedback from the ggpmisc author (Pedro J. Aphalo) on #419.

- **`stat_regline_equation()`** — keeps the acknowledgement that it was adapted from `ggpmisc::stat_poly_eq()`, but now describes `stat_poly_eq()` as *"an alternative with additional features"* rather than *"the actively maintained version with additional features and bug fixes"* (the two implementations have diverged over the years).
- **`stat_cor()`** — removes the "adapted from" acknowledgement. Only the label-positioning logic was inspired by `stat_poly_eq()`, and `ggpmisc::stat_correlation()` was written more recently than `stat_cor()`; a neutral see-also pointer to `stat_correlation()` as an alternative implementation is kept.

Documentation-only change (roxygen comments + matching `.Rd`); no code or behaviour change.

Addresses #419.
