### PR TITLE
ggmaplot(): add optional facet.by for multi-panel MA plots (#498)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,12 @@
 - Relaxed minimum `ggrepel` dependency to `>= 0.9.2` to keep Ubuntu oldrel
   (`R 4.4.x`) CI dependency resolution working.
 
+## New features
+
+- `ggmaplot()` gains an optional `facet.by` argument to split the MA plot into
+  multiple panels (e.g. one per contrast or species). The top genes and point
+  colors are computed per panel. Default output (no `facet.by`) is unchanged (#498).
+
 ## Robustness fixes
 
 - `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -52,6 +52,11 @@ NULL
 #'  values include "padj" and "fc" for selecting by adjusted p values or fold
 #'  changes, respectively.
 #' @param label.select character vector specifying some labels to show.
+#' @param facet.by character vector, of length 1 or 2, specifying grouping
+#'   variables for faceting the plot into multiple panels (one MA plot per group).
+#'   The variable(s) must be columns of \code{data} (supplied as a data frame). The
+#'   top genes and the point colors are computed \emph{per panel}. Default is NULL
+#'   (no faceting), in which case the output is unchanged.
 #' @param line.color color of the horizontal threshold lines (the central line
 #'   at 0 and the two fold-change cutoff lines). Default is "black".
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
@@ -102,7 +107,7 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
                      font.label = c(12, "plain", "black"), label.rectangle = FALSE,
                      palette = c("#B31B21", "#1465AC", "darkgray"),
                      top = 15, select.top.method = c("padj", "fc"),
-                     label.select = NULL,
+                     label.select = NULL, facet.by = NULL,
                      main = NULL, xlab = "Log2 mean expression", ylab = "Log2 fold change",
                      line.color = "black",
                      ggtheme = theme_classic(), ...) {
@@ -144,6 +149,21 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
     stop("genenames should be of length nrow(data).")
   }
 
+  # #498: an optional facet.by builds a faceted MA plot. Capture the faceting
+  # column(s) now - before the data frame is rebuilt below - so they can be
+  # carried into the plotted layers; the top genes are then selected per facet.
+  if (!is.null(facet.by)) {
+    facet.by <- as.character(facet.by)
+    miss <- base::setdiff(facet.by, colnames(data))
+    if (length(miss) > 0) {
+      stop("facet.by column(s) not found in data: ", paste(miss, collapse = ", "),
+           ". Provide 'data' as a data frame containing the faceting variable(s).")
+    }
+    facet_data <- as.data.frame(data)[, facet.by, drop = FALSE]
+  } else {
+    facet_data <- NULL
+  }
+
   sig <- rep(3, nrow(data))
   sig[which(data$padj <= fdr & data$log2FoldChange < 0 & abs(data$log2FoldChange) >= log2(fc) & detection_call == 1)] <- 2
   sig[which(data$padj <= fdr & data$log2FoldChange > 0 & abs(data$log2FoldChange) >= log2(fc) & detection_call == 1)] <- 1
@@ -151,17 +171,27 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
     name = genenames, mean = data$baseMean, lfc = data$log2FoldChange,
     padj = data$padj, sig = sig
   )
+  # #498: carry the faceting column(s) into the plotted data (only when faceting,
+  # so an external facet() without facet.by still errors honestly instead of
+  # silently using globally-selected top genes). Row order is preserved above.
+  if (!is.null(facet_data)) data <- cbind(data, facet_data)
 
   # Change level labels
   . <- NULL
   data$sig <- as.factor(data$sig)
   .lev <- .levels(data$sig) %>% as.numeric()
   palette <- palette[.lev]
-  new.levels <- c(
-    paste0("Up: ", sum(sig == 1)),
-    paste0("Down: ", sum(sig == 2)),
-    "NS"
-  ) %>% .[.lev]
+  if (is.null(facet.by)) {
+    new.levels <- c(
+      paste0("Up: ", sum(sig == 1)),
+      paste0("Down: ", sum(sig == 2)),
+      "NS"
+    ) %>% .[.lev]
+  } else {
+    # #498: the Up/Down counts are global and cannot be shown per-panel in one
+    # shared legend, so use plain labels when faceting to avoid misleading counts.
+    new.levels <- c("Up", "Down", "NS") %>% .[.lev]
+  }
 
   data$sig <- factor(data$sig, labels = new.levels)
 
@@ -174,7 +204,18 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
   # select data for top genes
   complete_data <- stats::na.omit(data)
   labs_data <- subset(complete_data, padj <= fdr & name != "" & abs(lfc) >= log2(fc))
-  labs_data <- utils::head(labs_data, top)
+  if (is.null(facet.by)) {
+    labs_data <- utils::head(labs_data, top)
+  } else {
+    # #498: select the top genes PER facet. `data` is already ordered by the
+    # select.top.method key, so taking the first `top` rows within each facet
+    # group keeps that ordering.
+    labs_data <- labs_data %>%
+      dplyr::group_by(dplyr::across(dplyr::all_of(facet.by))) %>%
+      dplyr::slice_head(n = top) %>%
+      dplyr::ungroup() %>%
+      as.data.frame()
+  }
   # Select some specific labels to show
   if (!is.null(label.select)) {
     selected_labels <- complete_data %>%
@@ -230,12 +271,24 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
   }
 
   p <- p + scale_x_continuous(breaks = seq(0, max(data$mean), 2)) +
-    labs(x = xlab, y = ylab, title = main, color = "") + # to remove legend title use color = ""
-    geom_hline(
+    labs(x = xlab, y = ylab, title = main, color = "") # to remove legend title use color = ""
+  if (is.null(facet.by)) {
+    p <- p + geom_hline(
       yintercept = c(0, -log2(fc), log2(fc)), linetype = c(1, 2, 2),
       color = line.color
     )
+  } else {
+    # #498: a single geom_hline with a vectorised linetype breaks under faceting
+    # (the yintercept recycles per panel but the linetype does not), so draw the
+    # solid zero line and the two dashed threshold lines as separate facet-safe
+    # layers. The rendered result is the same three lines.
+    p <- p +
+      geom_hline(yintercept = 0, linetype = 1, color = line.color) +
+      geom_hline(yintercept = c(-log2(fc), log2(fc)), linetype = 2, color = line.color)
+  }
 
   p <- ggpar(p, palette = palette, ggtheme = ggtheme, ...)
+  # #498: split into one panel per facet.by group
+  if (!is.null(facet.by)) p <- facet(p, facet.by = facet.by)
   p
 }

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -19,6 +19,7 @@ ggmaplot(
   top = 15,
   select.top.method = c("padj", "fc"),
   label.select = NULL,
+  facet.by = NULL,
   main = NULL,
   xlab = "Log2 mean expression",
   ylab = "Log2 fold change",
@@ -91,6 +92,12 @@ values include "padj" and "fc" for selecting by adjusted p values or fold
 changes, respectively.}
 
 \item{label.select}{character vector specifying some labels to show.}
+
+\item{facet.by}{character vector, of length 1 or 2, specifying grouping
+variables for faceting the plot into multiple panels (one MA plot per group).
+The variable(s) must be columns of \code{data} (supplied as a data frame). The
+top genes and the point colors are computed \emph{per panel}. Default is NULL
+(no faceting), in which case the output is unchanged.}
 
 \item{main}{plot main title.}
 

--- a/tests/testthat/test-ggmaplot-facet.R
+++ b/tests/testthat/test-ggmaplot-facet.R
@@ -1,0 +1,80 @@
+context("test-ggmaplot-facet")
+
+# #498: ggmaplot() gains an opt-in `facet.by`. ggmaplot() rebuilds its own plotting
+# data (dropping the user's columns) and selects the top genes / Up-Down counts
+# globally, so faceting used to fail ("At least one layer must contain all faceting
+# variables"). With facet.by set, the grouping column is carried into the plotted
+# layers and the top genes are selected PER panel. Without facet.by, output is
+# unchanged.
+
+suppressPackageStartupMessages({
+  library(ggplot2)
+})
+
+# deterministic 2-group DE-like data
+set.seed(42)
+mk <- function(sp, shift) data.frame(
+  baseMean = 10^runif(600, 0, 5),
+  log2FoldChange = rnorm(600, shift, 1.2),
+  padj = runif(600)^3,
+  gene = paste0(sp, "_g", seq_len(600)),
+  species = sp
+)
+df <- rbind(mk("A", 0), mk("B", 0.4))
+
+.label_layer_index <- function(p) {
+  which(vapply(p$layers, function(l) inherits(l$geom, "GeomTextRepel") ||
+                inherits(l$geom, "GeomLabelRepel"), logical(1)))[1]
+}
+
+test_that("faceted ggmaplot renders at draw time (#498)", {
+  p <- ggmaplot(df, fdr = 0.1, fc = 2, top = 8, genenames = df$gene,
+                facet.by = "species")
+  expect_true(inherits(p$facet, "FacetWrap"))
+  # the crash was at draw time, not build time -> render the full gtable
+  expect_error(ggplot2::ggplot_gtable(ggplot2::ggplot_build(p)), NA)
+})
+
+test_that("top genes are selected PER facet, not globally (#498)", {
+  top <- 8
+  p <- ggmaplot(df, fdr = 0.1, fc = 2, top = top, genenames = df$gene,
+                facet.by = "species")
+  li <- .label_layer_index(p)
+  ld <- p$layers[[li]]$data
+  expect_true("species" %in% names(ld))
+  # each panel gets up to `top` labels, and its labels belong to that species
+  per <- table(ld$species)
+  expect_true(all(per <= top))
+  expect_true(all(per > 0))
+  expect_true(all(grepl("^A_", ld$gene[ld$species == "A"])))
+  expect_true(all(grepl("^B_", ld$gene[ld$species == "B"])))
+})
+
+test_that("facet.by naming a non-existent column errors informatively (#498)", {
+  expect_error(
+    ggmaplot(df, genenames = df$gene, facet.by = "nope"),
+    "facet.by column"
+  )
+})
+
+test_that("facet.by = NULL leaves ggmaplot output unchanged (no-regression, #498)", {
+  p <- ggmaplot(df, fdr = 0.1, fc = 2, top = 10, genenames = df$gene)
+  # unchanged structure: single vectorised threshold-line layer, counted legend
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  # the hline layer keeps its 3 rows (0 and +/- log2(fc)) as a single layer
+  hl <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomHline"), logical(1)))
+  expect_length(hl, 1)
+  # legend keeps the "Up: n" / "Down: n" counted labels
+  labs <- levels(b$plot$data$sig)
+  expect_true(any(grepl("^Up: [0-9]", labs)))
+  expect_true(any(grepl("^Down: [0-9]", labs)))
+  expect_false(inherits(p$facet, "FacetWrap"))
+})
+
+test_that("faceted legend uses plain Up/Down/NS labels (no global counts) (#498)", {
+  p <- ggmaplot(df, fdr = 0.1, fc = 2, top = 8, genenames = df$gene,
+                facet.by = "species")
+  labs <- levels(p$data$sig)
+  expect_true(all(labs %in% c("Up", "Down", "NS")))
+  expect_false(any(grepl(":", labs)))   # no "Up: 123" counts under faceting
+})


### PR DESCRIPTION
### New `facet.by` for `ggmaplot()`

`ggmaplot()` builds its own summarized plotting data (the M/A values and the Up/Down/NS categories) and selects the top genes + Up/Down counts **globally**, so the user's grouping columns were dropped and faceting failed:

```
facet(ggmaplot(...), facet.by = "species")
#> Error: At least one layer must contain all faceting variables: `species`.
```

This adds an opt-in `facet.by` that splits the plot into one MA panel per group, with the top genes selected **per panel**:

```r
ggmaplot(MA_data, fdr = 0.1, fc = 2, top = 20,
         genenames = MA_data$gene, facet.by = "species")
```

### Notes

- No new dependency.
- Default output (no `facet.by`) is **unchanged** (verified byte-identical).
- When faceting: the legend uses plain `Up`/`Down`/`NS` labels (the global counts can't be shown per panel), and the threshold lines are drawn as facet-safe layers. Point colors are per-row (unchanged).
- Added regression + no-regression tests.

Fixes #498.
