### PR TITLE
Prepare ggpubr 1.0.0 release (#747)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggpubr
 Type: Package
 Title: 'ggplot2' Based Publication Ready Plots
-Version: 0.6.3.999
-Date: 2026-02-27
+Version: 1.0.0
+Date: 2026-07-06
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com"),
     person("Laszlo", "Erdey", role = "ctb", email = "erdey.laszlo@econ.unideb.hu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,10 +16,10 @@ Description: The 'ggplot2' package is excellent and flexible for elegant data
     with no advanced R programming skills. 'ggpubr' provides some easy-to-use
     functions for creating and customizing 'ggplot2'-based publication ready plots.
     This version includes modern R ecosystem compatibility updates and customizable
-    p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication
-    workflows, plus robust sparse-subset handling in statistical annotation layers
-    such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group
-    skip diagnostics for non-comparable subsets.
+    p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad, and scientific
+    notation) for publication workflows, plus robust sparse-subset handling in
+    statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()',
+    with informative per-group skip diagnostics for non-comparable subsets.
 License: GPL (>= 2)
 LazyData: TRUE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 ### New arguments, computed variables, and input support
 
 - `ggmaplot()` gains an optional `facet.by` argument to split the MA plot into
-  multiple panels (e.g. one per contrast or species). The top genes and point
-  colors are computed per panel. Default output (no `facet.by`) is unchanged (#498).
+  multiple panels (e.g. one per contrast or species). Top genes are selected per
+  panel, while point colors use the same significance thresholds in every panel.
+  Default output (no `facet.by`) is unchanged (#498).
 
 - `stat_cor()` and `stat_regline_equation()` gain a `label.anchor` argument.
   With `label.anchor = "panel"` the label is placed at the true panel-relative
@@ -267,6 +268,10 @@
   the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
   are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked
   bars, the error bars) across all panels (#739).
+- Clarified documentation to match existing behavior: the `ggtheme` default per
+  function, the p-value threshold/precision defaults, the `stat_compare_means()`
+  label separator (test method name, not correlation coefficient), and the
+  package Description's list of p-value formatting styles. Thanks to @erdeyl (#749).
 - Expanded test coverage for formatting helpers and compatibility paths.
 - Regenerated manuals and package documentation after source sync.
 - Closes #663 (`stat_compare_means()` fatal warning/error in sparse grouped subsets with modern `tidyr`).
@@ -311,6 +316,9 @@
 
 ## Bug fixes
 
+- `stat_welch_anova_test(label = "as_detailed_italic")` and
+  `stat_welch_anova_test(label = "as_detailed_expression")` now display the numeric
+  F statistic instead of `FALSE`. Thanks to @erdeyl (#749).
 - `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together
   with a summary (e.g. `alpha = clarity, add = "mean_ci", position = position_dodge()`).
   Previously this errored at draw time (`"alpha * 255": non-numeric argument to binary

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,158 +1,17 @@
-# ggpubr 0.6.3.999
-
-## Compatibility updates
-
-- Added compatibility updates for modern `ggplot2`, `dplyr`, and `tidyr`.
-- Updated legacy `size` usage to `linewidth` where required by recent `ggplot2`.
-- Completed the `size` -> `linewidth` migration for the remaining line layers that
-  still passed the deprecated `size` argument: the mean/median reference line added
-  by `gghistogram(add = ...)` and `ggdensity(add = ...)`, and the connector segments
-  of `ggdotchart(add = "segments")`. These no longer emit ggplot2's "`size` aesthetic
-  for lines was deprecated" or "Ignoring empty aesthetic: `size`" warnings, and the
-  requested line width is now applied via `linewidth`.
-- `ggmaplot()` no longer emits an "Ignoring empty aesthetic: `size`" warning on its
-  default call; the point layer sets `size` only when the user supplies a value.
-- Replaced deprecated tidyverse APIs in affected helper functions.
-- Added package startup lock-file checks and `clean_lock_files()` helper.
-- Relaxed minimum `ggrepel` dependency to `>= 0.9.2` to keep Ubuntu oldrel
-  (`R 4.4.x`) CI dependency resolution working.
+# ggpubr 1.0.0
 
 ## New features
+
+### New functions
+
+- Added `format_p_value()`, `get_p_format_style()`, and `list_p_format_styles()`.
+- Added style presets (`default`, `apa`, `nejm`, `lancet`, `ama`, `graphpad`, `scientific`).
+
+### New arguments, computed variables, and input support
 
 - `ggmaplot()` gains an optional `facet.by` argument to split the MA plot into
   multiple panels (e.g. one per contrast or species). The top genes and point
   colors are computed per panel. Default output (no `facet.by`) is unchanged (#498).
-
-## Robustness fixes
-
-- `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together
-  with a summary (e.g. `alpha = clarity, add = "mean_ci", position = position_dodge()`).
-  Previously this errored at draw time (`"alpha * 255": non-numeric argument to binary
-  operator`). The mean/CI is now computed per subgroup, the bars are faded per the `alpha`
-  variable, and the error bars are dodged to stay aligned with their bars. Bar plots
-  without an `alpha` grouping variable are unchanged (#404).
-- `ggpar()` no longer errors on `ggsurvplot` objects (or any plot whose theme uses
-  `ggtext::element_markdown()`, e.g. survminer's risk-table strata labels). Such
-  markdown label elements are now left intact instead of triggering an "Only elements
-  of the same class can be merged" error; output for all other plots is unchanged (#382).
-- Hardened sparse-group handling in `stat_compare_means()` and `geom_pwc()`.
-- Non-comparable grouped subsets (insufficient levels/observations) are now skipped
-  while preserving valid inferential comparisons in the same layer.
-- Added per-group skip diagnostics in `geom_pwc()` so users can see which grouped
-  subsets were skipped and why (e.g., missing `ref.group` or insufficient levels).
-- Added regression tests for mixed comparable/non-comparable subsets and fully sparse
-  subsets.
-- `geom_pwc()` with an explicit list of `comparisons` no longer drops a whole facet/panel
-  when a single requested pair cannot be tested (e.g. a group that is entirely `NA` or has
-  fewer than two observations). The untestable comparison is skipped (with a message) and
-  the remaining valid comparisons are still drawn (#542).
-- `geom_pwc()` now detects an absent `ref.group` in a grouped subset via the
-  `rstatix_missing_ref_group` condition class raised by recent `rstatix`
-  (walking the parent chain with `rlang::cnd_inherits()`), in addition to
-  matching the error message. This keeps the "skip ref-less subsets" behaviour
-  working after `rstatix` made that error message clearer (rstatix #153); older
-  `rstatix` versions are still handled via the message fallback.
-- `compare_means()` and `stat_compare_means()` now forward extra test options
-  (e.g. `alternative = "greater"`) to the paired tests aligned by subject `id`,
-  which were previously ignored on that path. Grouped and faceted paired-`id`
-  comparisons also skip a subset that cannot be tested (fewer than two groups or
-  no complete pairs) instead of failing the whole result/layer, while still
-  reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
-  @erdeyl (#732).
-- `ggarrange()` gained the ability to choose which plot(s) supply the shared legend:
-  `common.legend` now also accepts one or several plot indices. `common.legend = 2`
-  uses the second plot's legend (handy when the first plot's legend is not
-  representative, e.g. a group is missing in the first plot), and
-  `common.legend = c(1, 2)` keeps and combines the legends of the listed plots into a
-  single shared block (side by side for `legend = "top"`/`"bottom"`, stacked for
-  `"left"`/`"right"`) - useful when the arranged plots genuinely need different
-  legends. The documentation of `common.legend` was also clarified: `common.legend =
-  TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
-  should share a consistent scale for a single shared legend to be correct. Logical
-  `TRUE`/`FALSE` behave exactly as before (#347).
-- `ggdonutchart()` gained a `label.repel` argument (default `FALSE`). When `TRUE`, slice
-  labels are placed with `ggrepel::geom_text_repel()` and connected to their slice with
-  leader lines, so the labels of many small slices no longer overlap (or get dropped). The
-  default output is unchanged (#655).
-- Documented a recipe for labelling groups with significance letters (compact letter display):
-  compute the pairwise comparisons and derive the letters with `rstatix::add_cld()`, then place
-  them with `geom_text()` (see the "Significance letters" section in `?compare_means`). Also covers
-  the per-control letters case (a = differs from control 1, b = differs from control 2) (#464, #434).
-- Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
-  the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
-  are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked
-  bars, the error bars) across all panels (#739).
-- `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
-  data mix positive and negative values (e.g. above/below-ground measurements). The
-  stacked error bars are cumulated per sign, matching `position_stack()`, so a negative
-  segment's error bar is drawn on its own side instead of being displaced to the other
-  side (previously the misplacement also flipped with the factor-level order). Stacked
-  charts with single-sign data are unchanged (#426).
-- `ggviolin()` now keeps grouped violins aligned with their added box/dot layers by
-  default when a sub-group is too sparse for `geom_violin()` to compute a density
-  (a single data point). Previously the sparse sub-group was dropped from the dodge,
-  so the remaining violin re-centered and no longer lined up. When `drop`/`position`
-  are left at their defaults and such a one-point grouped cell is present, the empty
-  dodge lane is now reserved automatically. Balanced, ungrouped, faceted, and
-  legitimately-unbalanced plots are unchanged, and an explicit `drop`/`position`
-  still takes precedence (#381).
-- `geom_bracket()` (and `stat_pvalue_manual()`) now draw visible tips for a single
-  bracket placed over a stat-computed `y` such as `geom_bar()`/`geom_histogram()`.
-  Previously the bracket tips collapsed into a flat line because the y-axis range
-  was trained only on the bracket's single `y.position`; the tips are now sized
-  against the fully-trained panel range at draw time, so they render correctly even
-  with `coord_cartesian(ylim = ...)`. Brackets with an already non-zero y range are
-  unchanged (#631).
-
-## P-value formatting
-
-- Added `format_p_value()`, `get_p_format_style()`, and `list_p_format_styles()`.
-- Added style presets (`default`, `apa`, `nejm`, `lancet`, `ama`, `graphpad`, `scientific`).
-- Added formatting parameters to statistical helpers:
-  - `p.format.style`
-  - `p.digits`
-  - `p.leading.zero`
-  - `p.min.threshold`
-  - `p.decimal.mark`
-- Added `p.format.signif` support and related label handling paths.
-- `stat_pvalue_manual()` gains a `p.digits` argument (default `3`) that formats
-  **numeric** p-value label columns for display (e.g. `label = "p"` or
-  `label = "p.adj"`), using the same `format_p_value()` engine as
-  `stat_anova_test()`. This restores clean labels (e.g. `0.0156` instead of
-  `0.015625`) with rstatix `>= 1.0.0`, which now returns full-precision pairwise
-  p-values. Character labels (significance symbols, pre-formatted strings, glue
-  expressions) are unaffected. Set `p.digits = NULL` to print the raw value.
-- `stat_pvalue_manual()` additionally gains `p.format.style`, `p.leading.zero`,
-  `p.min.threshold` and `p.decimal.mark`, matching the p-value formatting
-  arguments already available in `stat_compare_means()`, `geom_pwc()` and
-  `stat_anova_test()`. These are opt-in and default so that the rendered labels
-  are unchanged; for example `p.min.threshold = 0.001` displays very small
-  p-values as `< 0.001`, and `p.format.style = "nejm"` applies a journal style.
-- `stat_cor()` gains two label-formatting arguments:
-  - `r.leading.zero` — set to `FALSE` to drop the leading zero of the
-    correlation coefficient (e.g. `.73` instead of `0.73`), completing
-    APA-style reporting together with `p.leading.zero` (#540). The dropped
-    leading zero is preserved through plotmath rendering (the value is quoted
-    so it is not silently re-normalized back to `0.73` in the default
-    `expression` output).
-  - `p.coef.name` — symbol for the p-value label; use `"P"` for an uppercase
-    p-value (#541).
-- `stat_cor()` exposes two new computed variables, `rmse` and `rmse.label`, for
-  the root mean square deviation (RMSE/RMSD) between `x` and `y` — useful for
-  reporting agreement between paired measurements on the same scale (e.g.
-  predicted vs. reference values). Display it with
-  `aes(label = after_stat(rmse.label))`, or combine it with the correlation
-  coefficient using `paste()`. The default label is unchanged (#458).
-
-- `stat_cor()` can now display the confidence interval of the correlation
-  coefficient, via the new computed variables `conf.int.low`, `conf.int.high`
-  and `conf.int.label` (e.g. `"95% CI [0.21, 0.75]"`) and a `conf.level` argument
-  (default `0.95`). Show it with `aes(label = after_stat(conf.int.label))`, or
-  combine it with the coefficient using `paste()`. The confidence interval is
-  available for `method = "pearson"` only; it is `NA` for Spearman/Kendall. The
-  default label is unchanged (#418).
-
-## New features
 
 - `stat_cor()` and `stat_regline_equation()` gain a `label.anchor` argument.
   With `label.anchor = "panel"` the label is placed at the true panel-relative
@@ -184,13 +43,6 @@
   `select`/`remove` and are computed per facet. Default is `show.n = FALSE`, so
   existing plots are unchanged (#598, #627).
 
-- Passing `ggtheme = NULL` to the plotting functions (e.g. `ggscatter()`,
-  `ggboxplot()`, `ggline()`, `gghistogram()`, ...) now skips applying a ggpubr
-  theme, so the plot keeps ggplot2's default theme or the theme set globally with
-  `theme_set()`. Previously an explicit `ggtheme = NULL` was treated like an unset
-  argument and `theme_pubr()` was still applied. Calls that omit `ggtheme` or pass
-  a specific theme are unchanged (#561).
-
 - `ggarrange()` gains a `spacing` argument to increase the gap between the
   arranged plots (a long-requested option). It adds a uniform margin, in
   text-line units, around each plot. Default is `0` (no extra space; each plot
@@ -211,10 +63,6 @@
   stat_compare_means(paired = TRUE, id = "subject")`), displaying the correct
   p-value even when the data are not sorted by subject. Plots without `id` are
   unchanged (#560).
-
-- The minimum required `rstatix` version is now `>= 1.0.0` (the version that
-  introduced the `id` argument used by `compare_means(id = )`, and the
-  full-precision pairwise p-values relied on by the p-value formatting).
 
 - `geom_pwc()` and `stat_pwc()` gain a `p.adjust.n` argument giving the number of
   comparisons to use for the p-value adjustment (passed as `n` to
@@ -271,29 +119,22 @@
   `drop = FALSE` together with `position = position_dodge(0.8, preserve = "single")`
   now reserves the empty dodge lane so all geoms stay aligned (#381).
 
-## Bug fixes
+- `ggarrange()` gained the ability to choose which plot(s) supply the shared legend:
+  `common.legend` now also accepts one or several plot indices. `common.legend = 2`
+  uses the second plot's legend (handy when the first plot's legend is not
+  representative, e.g. a group is missing in the first plot), and
+  `common.legend = c(1, 2)` keeps and combines the legends of the listed plots into a
+  single shared block (side by side for `legend = "top"`/`"bottom"`, stacked for
+  `"left"`/`"right"`) - useful when the arranged plots genuinely need different
+  legends. The documentation of `common.legend` was also clarified: `common.legend =
+  TRUE` keeps the first plot's legend (it does not merge or validate legends), so plots
+  should share a consistent scale for a single shared legend to be correct. Logical
+  `TRUE`/`FALSE` behave exactly as before (#347).
 
-- `ggline()` now dodges the jittered points together with the line and error
-  bars. Previously, in a grouped line plot with `add = "jitter"` and
-  `position = position_dodge()`, only the line and summary (e.g. `mean_se`) were
-  dodged while the jittered points stayed centered, so they no longer sat under
-  their group. The jitter now dodges by the same width. Plots without a
-  `position_dodge()` (the default `position = "identity"`) are unchanged (#436).
-
-- `ggbarplot()` now lines the error bars up with the bars when
-  `position = position_dodge2()` is used. `position_dodge2()` places elements
-  according to their own width, so the thin error bars did not sit on the centre
-  of the wider bars they belong to (most visible with `preserve = "single"` when
-  one x group has fewer bars than another). The error bars are now drawn at the
-  actual bar positions. Other positions (`identity`, `position_dodge()`,
-  `position_stack()`) are unchanged (#363).
-
-- `geom_bracket()` and `stat_pvalue_manual()` now place brackets correctly on a
-  transformed y axis (e.g. `scale_y_log10()`). `y.position` is given in data units
-  but was previously used directly in the scale's transformed space, so brackets
-  landed far off (e.g. at `10^30`) and squashed the plot. The bracket `y.position`
-  is now run through the scale's transformation; on an untransformed (identity)
-  scale this is a no-op, so existing plots are unchanged (#342).
+- `ggdonutchart()` gained a `label.repel` argument (default `FALSE`). When `TRUE`, slice
+  labels are placed with `ggrepel::geom_text_repel()` and connected to their slice with
+  leader lines, so the labels of many small slices no longer overlap (or get dropped). The
+  default output is unchanged (#655).
 
 - `ggboxplot()` now accepts a `position` argument (e.g.
   `position = position_dodge(0.9)`), like `ggviolin()`/`ggdotplot()` already do.
@@ -301,6 +142,236 @@
   multiple actual arguments`) because the dodge was hardcoded; the default is
   unchanged (`position_dodge(0.8)`), so grouped box plots look the same unless
   you set it (#615).
+
+- `ggsummarytable()` gains an `angle` argument to rotate the summary-table text;
+  default (`angle = 0`) is unchanged (#595).
+
+- `ggmaplot()` gains a `line.color` argument to set the threshold line color;
+  default ("black") is unchanged (#322).
+
+- `ggarrange()` gains a `byrow` argument (default `TRUE`) to fill the plot grid
+  by column (`byrow = FALSE`) instead of by row; forwarded to
+  `cowplot::plot_grid()` (#225).
+
+- `stat_regline_equation()` gains `coef.digits` and `rr.digits` arguments to
+  control the number of significant digits shown for the regression-equation
+  coefficients and R2; defaults (`2`) reproduce the previous output (#312).
+
+- Added formatting parameters to statistical helpers:
+  - `p.format.style`
+  - `p.digits`
+  - `p.leading.zero`
+  - `p.min.threshold`
+  - `p.decimal.mark`
+- Added `p.format.signif` support and related label handling paths.
+
+- `stat_pvalue_manual()` gains a `p.digits` argument (default `3`) that formats
+  **numeric** p-value label columns for display (e.g. `label = "p"` or
+  `label = "p.adj"`), using the same `format_p_value()` engine as
+  `stat_anova_test()`. This restores clean labels (e.g. `0.0156` instead of
+  `0.015625`) with rstatix `>= 1.0.0`, which now returns full-precision pairwise
+  p-values. Character labels (significance symbols, pre-formatted strings, glue
+  expressions) are unaffected. Set `p.digits = NULL` to print the raw value.
+
+- `stat_pvalue_manual()` additionally gains `p.format.style`, `p.leading.zero`,
+  `p.min.threshold` and `p.decimal.mark`, matching the p-value formatting
+  arguments already available in `stat_compare_means()`, `geom_pwc()` and
+  `stat_anova_test()`. These are opt-in and default so that the rendered labels
+  are unchanged; for example `p.min.threshold = 0.001` displays very small
+  p-values as `< 0.001`, and `p.format.style = "nejm"` applies a journal style.
+
+- `stat_cor()` gains two label-formatting arguments:
+  - `r.leading.zero` — set to `FALSE` to drop the leading zero of the
+    correlation coefficient (e.g. `.73` instead of `0.73`), completing
+    APA-style reporting together with `p.leading.zero` (#540). The dropped
+    leading zero is preserved through plotmath rendering (the value is quoted
+    so it is not silently re-normalized back to `0.73` in the default
+    `expression` output).
+  - `p.coef.name` — symbol for the p-value label; use `"P"` for an uppercase
+    p-value (#541).
+
+- `stat_cor()` exposes two new computed variables, `rmse` and `rmse.label`, for
+  the root mean square deviation (RMSE/RMSD) between `x` and `y` — useful for
+  reporting agreement between paired measurements on the same scale (e.g.
+  predicted vs. reference values). Display it with
+  `aes(label = after_stat(rmse.label))`, or combine it with the correlation
+  coefficient using `paste()`. The default label is unchanged (#458).
+
+- `stat_cor()` can now display the confidence interval of the correlation
+  coefficient, via the new computed variables `conf.int.low`, `conf.int.high`
+  and `conf.int.label` (e.g. `"95% CI [0.21, 0.75]"`) and a `conf.level` argument
+  (default `0.95`). Show it with `aes(label = after_stat(conf.int.label))`, or
+  combine it with the coefficient using `paste()`. The confidence interval is
+  available for `method = "pearson"` only; it is `NA` for Spearman/Kendall. The
+  default label is unchanged (#418).
+
+## Main changes
+
+### Compatibility
+
+- Added compatibility updates for modern `ggplot2`, `dplyr`, and `tidyr`.
+- Updated legacy `size` usage to `linewidth` where required by recent `ggplot2`.
+- Completed the `size` -> `linewidth` migration for the remaining line layers that
+  still passed the deprecated `size` argument: the mean/median reference line added
+  by `gghistogram(add = ...)` and `ggdensity(add = ...)`, and the connector segments
+  of `ggdotchart(add = "segments")`. These no longer emit ggplot2's "`size` aesthetic
+  for lines was deprecated" or "Ignoring empty aesthetic: `size`" warnings, and the
+  requested line width is now applied via `linewidth`.
+- `ggmaplot()` no longer emits an "Ignoring empty aesthetic: `size`" warning on its
+  default call; the point layer sets `size` only when the user supplies a value.
+- Replaced deprecated tidyverse APIs in affected helper functions.
+- Added package startup lock-file checks and `clean_lock_files()` helper.
+- Relaxed minimum `ggrepel` dependency to `>= 0.9.2` to keep Ubuntu oldrel
+  (`R 4.4.x`) CI dependency resolution working.
+- `geom_pwc()` now detects an absent `ref.group` in a grouped subset via the
+  `rstatix_missing_ref_group` condition class raised by recent `rstatix`
+  (walking the parent chain with `rlang::cnd_inherits()`), in addition to
+  matching the error message. This keeps the "skip ref-less subsets" behaviour
+  working after `rstatix` made that error message clearer (rstatix #153); older
+  `rstatix` versions are still handled via the message fallback.
+- The minimum required `rstatix` version is now `>= 1.0.0` (the version that
+  introduced the `id` argument used by `compare_means(id = )`, and the
+  full-precision pairwise p-values relied on by the p-value formatting).
+
+### Validation and messaging
+
+- Hardened sparse-group handling in `stat_compare_means()` and `geom_pwc()`.
+- Non-comparable grouped subsets (insufficient levels/observations) are now skipped
+  while preserving valid inferential comparisons in the same layer.
+- Added per-group skip diagnostics in `geom_pwc()` so users can see which grouped
+  subsets were skipped and why (e.g., missing `ref.group` or insufficient levels).
+- Added regression tests for mixed comparable/non-comparable subsets and fully sparse
+  subsets.
+- Passing `ggtheme = NULL` to the plotting functions (e.g. `ggscatter()`,
+  `ggboxplot()`, `ggline()`, `gghistogram()`, ...) now skips applying a ggpubr
+  theme, so the plot keeps ggplot2's default theme or the theme set globally with
+  `theme_set()`. Previously an explicit `ggtheme = NULL` was treated like an unset
+  argument and `theme_pubr()` was still applied. Calls that omit `ggtheme` or pass
+  a specific theme are unchanged (#561).
+- `compare_means()` now adjusts p-values **within** each `group.by` level (and
+  response) rather than pooling all groups together, so a grouped adjustment
+  matches filtering to one group and adjusting there. This changes `p.adj` values
+  for calls that use `group.by`; ungrouped calls are unchanged (#200).
+- `stat_compare_means(comparisons = )` now emits a one-time message (and the docs
+  note) clarifying that the displayed pairwise p-values are **not** adjusted for
+  multiple comparisons, pointing to `geom_pwc()` / `stat_pvalue_manual()` +
+  `compare_means(p.adjust.method = )` for corrected p-values (#293).
+
+### Documentation
+
+- Documented a recipe for labelling groups with significance letters (compact letter display):
+  compute the pairwise comparisons and derive the letters with `rstatix::add_cld()`, then place
+  them with `geom_text()` (see the "Significance letters" section in `?compare_means`). Also covers
+  the per-control letters case (a = differs from control 1, b = differs from control 2) (#464, #434).
+- Documented that a summarized `ggbarplot()` (e.g. `add = "mean_se"`) must be faceted with
+  the `facet.by=` argument, not by appending `+ facet_wrap()`/`+ facet_grid()`: the summaries
+  are pre-computed over `facet.by`, so a manually added facet pools the bars (and, for stacked
+  bars, the error bars) across all panels (#739).
+- Expanded test coverage for formatting helpers and compatibility paths.
+- Regenerated manuals and package documentation after source sync.
+- Closes #663 (`stat_compare_means()` fatal warning/error in sparse grouped subsets with modern `tidyr`).
+- Closes #334 (`stat_compare_means(label = "p.format")` rounding and formatting control).
+- Related: #540, #626.
+
+### Credits
+
+- Contributor: Laszlo Erdey (Faculty of Economics and Business, University of Debrecen, Hungary).
+- Thanks to @gumeo (#418), @byzheng (#608) and @JulesROBIN15 (#625) whose pull
+  requests proposed features shipped in this release: the `stat_cor()`
+  confidence interval, the `stat_cor()` RMSE label, and a manual number of
+  comparisons for p-value adjustment in `geom_pwc()`/`stat_pwc()`.
+
+## Minor changes
+
+- Fixed ColorBrewer sequential palette parsing in `.get_brewer_pal()` so
+  `"YlOrBr"` is recognized correctly.
+- Updated `ggexport()` to respect `verbose = FALSE` by suppressing filename
+  `print()` output in multi-file raster/vector exports.
+- Hardened `format_p_value()` by validating non-NULL `p.min.threshold` as a
+  single positive finite number.
+- Updated `create_p_label()` to preserve `NA` values in `p.format` (returning
+  `NA_character_` instead of stringifying to `"p = NA"`).
+- `theme_pubr()` now draws the axis tick marks in black with linewidth `0.5`,
+  matching the axis lines; previously the ticks inherited a lighter grey/thinner
+  style, visibly inconsistent when zoomed (#668).
+- `theme_pubr()` now sets `strip.clip = "off"` so the facet strip background
+  border renders at its full `linewidth`. With the `ggplot2` (>= 3.5.0) default
+  (`strip.clip = "on"`) the border was clipped to the strip area, cutting the
+  outer half of the stroke so it looked thinner and misaligned with the panel
+  when zoomed (follow-up to #668). Note: a facet label wider than its panel now
+  overflows the strip instead of being truncated; restore clipping with
+  `+ theme(strip.clip = "on")` if needed.
+- `xticks.by`/`yticks.by` now anchor the axis breaks to round multiples of the
+  step (e.g. 0, 100, 200) instead of the slightly-negative expanded axis minimum,
+  which produced odd labels such as `-20, 80, 180` on bar plots with
+  `ylim = c(0, 400)` (#313).
+- Import the `%||%` operator from `rlang`; it is used in `geom_bracket()` and
+  `geom_pwc()` but base R only provides it since R 4.4, so it could be unresolved
+  on the R (>= 4.1) versions the package supports (#665).
+
+## Bug fixes
+
+- `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together
+  with a summary (e.g. `alpha = clarity, add = "mean_ci", position = position_dodge()`).
+  Previously this errored at draw time (`"alpha * 255": non-numeric argument to binary
+  operator`). The mean/CI is now computed per subgroup, the bars are faded per the `alpha`
+  variable, and the error bars are dodged to stay aligned with their bars. Bar plots
+  without an `alpha` grouping variable are unchanged (#404).
+- `ggpar()` no longer errors on `ggsurvplot` objects (or any plot whose theme uses
+  `ggtext::element_markdown()`, e.g. survminer's risk-table strata labels). Such
+  markdown label elements are now left intact instead of triggering an "Only elements
+  of the same class can be merged" error; output for all other plots is unchanged (#382).
+- `geom_pwc()` with an explicit list of `comparisons` no longer drops a whole facet/panel
+  when a single requested pair cannot be tested (e.g. a group that is entirely `NA` or has
+  fewer than two observations). The untestable comparison is skipped (with a message) and
+  the remaining valid comparisons are still drawn (#542).
+- `compare_means()` and `stat_compare_means()` now forward extra test options
+  (e.g. `alternative = "greater"`) to the paired tests aligned by subject `id`,
+  which were previously ignored on that path. Grouped and faceted paired-`id`
+  comparisons also skip a subset that cannot be tested (fewer than two groups or
+  no complete pairs) instead of failing the whole result/layer, while still
+  reporting genuinely ambiguous data (e.g. duplicated ids). Thanks to
+  @erdeyl (#732).
+- `ggbarplot()` now places the error bars of a **stacked** bar chart correctly when the
+  data mix positive and negative values (e.g. above/below-ground measurements). The
+  stacked error bars are cumulated per sign, matching `position_stack()`, so a negative
+  segment's error bar is drawn on its own side instead of being displaced to the other
+  side (previously the misplacement also flipped with the factor-level order). Stacked
+  charts with single-sign data are unchanged (#426).
+- `ggviolin()` now keeps grouped violins aligned with their added box/dot layers by
+  default when a sub-group is too sparse for `geom_violin()` to compute a density
+  (a single data point). Previously the sparse sub-group was dropped from the dodge,
+  so the remaining violin re-centered and no longer lined up. When `drop`/`position`
+  are left at their defaults and such a one-point grouped cell is present, the empty
+  dodge lane is now reserved automatically. Balanced, ungrouped, faceted, and
+  legitimately-unbalanced plots are unchanged, and an explicit `drop`/`position`
+  still takes precedence (#381).
+- `geom_bracket()` (and `stat_pvalue_manual()`) now draw visible tips for a single
+  bracket placed over a stat-computed `y` such as `geom_bar()`/`geom_histogram()`.
+  Previously the bracket tips collapsed into a flat line because the y-axis range
+  was trained only on the bracket's single `y.position`; the tips are now sized
+  against the fully-trained panel range at draw time, so they render correctly even
+  with `coord_cartesian(ylim = ...)`. Brackets with an already non-zero y range are
+  unchanged (#631).
+- `ggline()` now dodges the jittered points together with the line and error
+  bars. Previously, in a grouped line plot with `add = "jitter"` and
+  `position = position_dodge()`, only the line and summary (e.g. `mean_se`) were
+  dodged while the jittered points stayed centered, so they no longer sat under
+  their group. The jitter now dodges by the same width. Plots without a
+  `position_dodge()` (the default `position = "identity"`) are unchanged (#436).
+- `ggbarplot()` now lines the error bars up with the bars when
+  `position = position_dodge2()` is used. `position_dodge2()` places elements
+  according to their own width, so the thin error bars did not sit on the centre
+  of the wider bars they belong to (most visible with `preserve = "single"` when
+  one x group has fewer bars than another). The error bars are now drawn at the
+  actual bar positions. Other positions (`identity`, `position_dodge()`,
+  `position_stack()`) are unchanged (#363).
+- `geom_bracket()` and `stat_pvalue_manual()` now place brackets correctly on a
+  transformed y axis (e.g. `scale_y_log10()`). `y.position` is given in data units
+  but was previously used directly in the scale's transformed space, so brackets
+  landed far off (e.g. at `10^30`) and squashed the plot. The bracket `y.position`
+  is now run through the scale's transformation; on an untransformed (identity)
+  scale this is a no-op, so existing plots are unchanged (#342).
 - The core plotting functions (`ggscatter()`, `ggboxplot()`, `ggviolin()`,
   `ggline()`, `ggbarplot()`, `gghistogram()`, `ggdensity()`, `ggdotplot()`,
   `ggstripchart()`, `ggerrorplot()`, `ggecdf()`, `ggdotchart()`, `ggpaired()`,
@@ -326,20 +397,8 @@
   which shifted the remaining brackets left. The bracket positions are now
   anchored to the discrete x scale so they stay aligned with the plotted groups
   (#575).
-- Fixed ColorBrewer sequential palette parsing in `.get_brewer_pal()` so
-  `"YlOrBr"` is recognized correctly.
-- Updated `ggexport()` to respect `verbose = FALSE` by suppressing filename
-  `print()` output in multi-file raster/vector exports.
-- Hardened `format_p_value()` by validating non-NULL `p.min.threshold` as a
-  single positive finite number.
-- Updated `create_p_label()` to preserve `NA` values in `p.format` (returning
-  `NA_character_` instead of stringifying to `"p = NA"`).
 - `ggballoonplot()` now honors user-supplied `xlab`/`ylab` instead of always
   blanking the axis titles; axis titles are still blank by default (#639).
-- `ggsummarytable()` gains an `angle` argument to rotate the summary-table text;
-  default (`angle = 0`) is unchanged (#595).
-- `ggmaplot()` gains a `line.color` argument to set the threshold line color;
-  default ("black") is unchanged (#322).
 - `ggpar(legend.title = )` now also titles `size` and `alpha` legends, not just
   `colour`/`fill`/`linetype`/`shape` (#412).
 - `facet()`/`panel.labs`: a NAMED `panel.labs` vector is now matched to the data
@@ -377,45 +436,14 @@
   when a formula variable name contains a space (e.g. ``len ~ `spa ced` ``); the
   backticks that R adds to non-syntactic term names are now stripped before
   matching data columns (#385).
-- `ggarrange()` gains a `byrow` argument (default `TRUE`) to fill the plot grid
-  by column (`byrow = FALSE`) instead of by row; forwarded to
-  `cowplot::plot_grid()` (#225).
-- `stat_regline_equation()` gains `coef.digits` and `rr.digits` arguments to
-  control the number of significant digits shown for the regression-equation
-  coefficients and R2; defaults (`2`) reproduce the previous output (#312).
 - `table_cell_font()` and `table_cell_bg()` can now style an individual header
   cell (`row = 1`), not only body cells; they previously matched only the
   `core-*` grobs and silently did nothing for the header (#535).
-- `theme_pubr()` now draws the axis tick marks in black with linewidth `0.5`,
-  matching the axis lines; previously the ticks inherited a lighter grey/thinner
-  style, visibly inconsistent when zoomed (#668).
-- `theme_pubr()` now sets `strip.clip = "off"` so the facet strip background
-  border renders at its full `linewidth`. With the `ggplot2` (>= 3.5.0) default
-  (`strip.clip = "on"`) the border was clipped to the strip area, cutting the
-  outer half of the stroke so it looked thinner and misaligned with the panel
-  when zoomed (follow-up to #668). Note: a facet label wider than its panel now
-  overflows the strip instead of being truncated; restore clipping with
-  `+ theme(strip.clip = "on")` if needed.
-- `xticks.by`/`yticks.by` now anchor the axis breaks to round multiples of the
-  step (e.g. 0, 100, 200) instead of the slightly-negative expanded axis minimum,
-  which produced odd labels such as `-20, 80, 180` on bar plots with
-  `ylim = c(0, 400)` (#313).
 - `ggmaplot()` now draws the non-significant ("NS") points behind the significant
   ones, so the up/down-regulated hits are no longer hidden under the grey NS
   cloud; the legend order (Up, Down, NS) is unchanged (#365).
-- `compare_means()` now adjusts p-values **within** each `group.by` level (and
-  response) rather than pooling all groups together, so a grouped adjustment
-  matches filtering to one group and adjusting there. This changes `p.adj` values
-  for calls that use `group.by`; ungrouped calls are unchanged (#200).
-- `stat_compare_means(comparisons = )` now emits a one-time message (and the docs
-  note) clarifying that the displayed pairwise p-values are **not** adjusted for
-  multiple comparisons, pointing to `geom_pwc()` / `stat_pvalue_manual()` +
-  `compare_means(p.adjust.method = )` for corrected p-values (#293).
 - `ggboxplot()` now forwards `coef` to `geom_boxplot()`, so `coef = 0` can be used
   to omit the whiskers; it was previously dropped by `geom_exec()` (#517).
-- Import the `%||%` operator from `rlang`; it is used in `geom_bracket()` and
-  `geom_pwc()` but base R only provides it since R 4.4, so it could be unresolved
-  on the R (>= 4.1) versions the package supports (#665).
 - `tab_add_title()` / `tab_add_footnote()`: the `just` argument now actually
   positions the text — `"center"`/`"right"` anchor the title/footnote across the
   table width instead of around a fixed point — and the text is no longer clipped
@@ -424,25 +452,6 @@
   horizontal justification, so labels of different lengths keep the same anchor
   and captions align across figures; previously a longer label was shifted away
   from the corner (#185).
-
-## Tests and docs
-
-- Expanded test coverage for formatting helpers and compatibility paths.
-- Regenerated manuals and package documentation after source sync.
-
-## Issue closures
-
-- Closes #663 (`stat_compare_means()` fatal warning/error in sparse grouped subsets with modern `tidyr`).
-- Closes #334 (`stat_compare_means(label = "p.format")` rounding and formatting control).
-- Related: #540, #626.
-
-## Credits
-
-- Contributor: Laszlo Erdey (Faculty of Economics and Business, University of Debrecen, Hungary).
-- Thanks to @gumeo (#418), @byzheng (#608) and @JulesROBIN15 (#625) whose pull
-  requests proposed features shipped in this release: the `stat_cor()`
-  confidence interval, the `stat_cor()` RMSE label, and a manual number of
-  comparisons for p-value adjustment in `geom_pwc()`/`stat_pwc()`.
 
 # ggpubr 0.6.3
 

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -83,8 +83,9 @@ NULL
 #' @param p.leading.zero logical indicating whether to include leading zero before
 #'  decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 #' @param p.min.threshold numeric specifying the minimum p-value to display exactly.
-#'  Values below this threshold are shown as "< threshold". Set to NULL to always
-#'  show exact values. If provided, overrides the style default.
+#'  Values below this threshold are shown as "< threshold". If NULL, the selected
+#'  style's default threshold is used; styles without a threshold show exact
+#'  values. If provided, overrides the style default.
 #' @param p.decimal.mark character string to use as the decimal mark. If NULL,
 #'  uses \code{getOption("OutDec")}.
 #' @return a data frame with the following columns:

--- a/R/ggballoonplot.R
+++ b/R/ggballoonplot.R
@@ -38,6 +38,10 @@
 #'   "bold", "red"). To specify only the size and the style, use font.label =
 #'   c(14, "plain").
 #' @param rotate.x.text logical. If TRUE (default), rotate the x axis text.
+#' @param ggtheme function, ggplot2 theme name. Default value is
+#'   \code{theme_minimal()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+#'   theme, so the plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #' @param ... other arguments passed to the function \code{\link{ggpar}}
 #'
 #' @examples

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -55,10 +55,15 @@ NULL
 #' @param facet.by character vector, of length 1 or 2, specifying grouping
 #'   variables for faceting the plot into multiple panels (one MA plot per group).
 #'   The variable(s) must be columns of \code{data} (supplied as a data frame). The
-#'   top genes and the point colors are computed \emph{per panel}. Default is NULL
-#'   (no faceting), in which case the output is unchanged.
+#'   top genes are selected \emph{per panel}; point colors use the same
+#'   significance thresholds in every panel. Default is NULL (no faceting), in
+#'   which case the output is unchanged.
 #' @param line.color color of the horizontal threshold lines (the central line
 #'   at 0 and the two fold-change cutoff lines). Default is "black".
+#' @param ggtheme function, ggplot2 theme name. Default value is
+#'   \code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+#'   theme, so the plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
 #' @return a ggplot.
 #' @examples
@@ -124,8 +129,6 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
     detection_call <- rep(1, nrow(data))
   }
 
-  # Legend position
-  if (is.null(list(...)$legend)) legend <- c(0.12, 0.9)
   # If basemean logged, we'll leave it as is, otherwise log2 transform
   is.basemean.logged <- "baseMeanLog2" %in% colnames(data)
   if (is.basemean.logged) {

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -67,7 +67,11 @@ NULL
 #'   orientation to horizontal.
 #' @param orientation change the orientation of the plot. Allowed values are one
 #'   of c( "vertical", "horizontal", "reverse"). Partial match is allowed.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+#' @param ggtheme function, ggplot2 theme name. The default is set by each
+#'   function's \code{ggtheme} argument; see the function usage for the actual
+#'   default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+#'   plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #'   Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'   theme_minimal(), theme_classic(), theme_void(), ....
 #' @param ... not used

--- a/R/p_format_utils.R
+++ b/R/p_format_utils.R
@@ -146,7 +146,8 @@ list_p_format_styles <- function() {
 #'   decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 #' @param min.threshold Numeric specifying the minimum p-value to display exactly.
 #'   Values below this threshold are shown as "< threshold" (e.g., "< 0.001").
-#'   Set to NULL to always show exact values. If provided, overrides the style default.
+#'   If NULL, the selected style's default threshold is used; styles without a
+#'   threshold show exact values. If provided, overrides the style default.
 #'   Must be a single positive finite number.
 #' @param decimal.mark Character string to use as the decimal mark. If NULL,
 #'   uses \code{getOption("OutDec")}.

--- a/R/stat_anova_test.R
+++ b/R/stat_anova_test.R
@@ -58,8 +58,9 @@ NULL
 #'  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
 #'  \item \code{****}:  p <= 0.0001 }
 #'
-#'  Note: \code{significance} is kept for backward compatibility. If provided,
-#'  it takes precedence over \code{signif.cutoffs} and related parameters.
+#'  Note: \code{significance} is kept for backward compatibility. For functions
+#'  that also expose \code{signif.cutoffs} and related parameters,
+#'  \code{significance} takes precedence when provided.
 #' @param signif.cutoffs numeric vector of p-value cutoffs in descending order
 #'  for assigning significance symbols. For example, \code{c(0.10, 0.05, 0.01)}
 #'  means p < 0.10 gets "*", p < 0.05 gets "**", p < 0.01 gets "***".

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -64,7 +64,7 @@ NULL
 #'  using \code{label = "p.format.signif"}. If FALSE, falls back to showing only
 #'  the p-value (equivalent to \code{label = "p.format"}) with a warning.
 #' @param label.sep a character string to separate the terms. Default is ", ", to
-#'  separate the correlation coefficient and the p.value.
+#'  separate the test method name and the p-value.
 #' @param label.x.npc,label.y.npc can be \code{numeric} or \code{character}
 #'  vector of the same length as the number of groups and/or panels. If too
 #'  short they will be recycled. \itemize{ \item If \code{numeric}, value should

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -49,7 +49,10 @@ NULL
 #' @param output.type character One of "expression", "latex", "tex" or "text".
 #' @param digits,r.digits,p.digits integer indicating the number of decimal
 #'  places (round) or significant digits (signif) to be used for the correlation
-#'  coefficient and the p-value, respectively..
+#'  coefficient and the p-value, respectively. In the default p-value label style,
+#'  the displayed p-value keeps the legacy raw value unless \code{p.accuracy} is
+#'  set; \code{p.digits} is used by non-default \code{p.format.style} outputs and
+#'  the computed \code{p} variable.
 #' @param r.accuracy a real value specifying the number of decimal places of
 #'  precision for the correlation coefficient. Default is NULL. Use (e.g.) 0.01
 #'  to show 2 decimal places of precision. If specified, then \code{r.digits} is

--- a/R/stat_welch_anova_test.R
+++ b/R/stat_welch_anova_test.R
@@ -122,8 +122,8 @@ get_welch_anova_test_label_template <- function(label) {
   switch(label,
     as_italic = "{method}, italic(p) = {p.format}",
     as_detailed = "{method}, F({DFn}, {DFd}) = {statistic}, p = {p.format}, n = {n}",
-    as_detailed_italic = "{method}, italic(F)({DFn}, {DFd}) = {F}, italic(p) = {p.format}, italic(n) = {n}",
-    as_detailed_expression = "{method}, italic(F)({DFn}, {DFd}) = {F}, italic(p) = {p.format}, italic(n) = {n}",
+    as_detailed_italic = "{method}, italic(F)({DFn}, {DFd}) = {statistic}, italic(p) = {p.format}, italic(n) = {n}",
+    as_detailed_expression = "{method}, italic(F)({DFn}, {DFd}) = {statistic}, italic(p) = {p.format}, italic(n) = {n}",
     label
   )
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,33 @@
+## Release summary
+- ggpubr 1.0.0: a large feature release (new p-value formatting system and many new
+  arguments/computed variables across the plotting and statistical helpers), plus
+  numerous bug fixes. See NEWS.md. The version was moved to 1.0.0 to mark a stable
+  milestone; nearly all changes are additive/opt-in with unchanged default output.
+- Last CRAN version: 0.6.3.
+
 ## Test environments
-- macOS Tahoe 26.5.2, R 4.6.0 (aarch64-apple-darwin25.4.0)
+- macOS Tahoe 26.x, R 4.6.0 (aarch64-apple-darwin, local)
+- GitHub Actions: Ubuntu (devel/release/oldrel-1), macOS (release), Windows (release)
+- win-builder (devel and release)
 
 ## R CMD check results
 - 0 errors | 0 warnings | 1 note
-- NOTE: The Date field is over a month old.
+- The only NOTE is "checking for future file timestamps ... unable to verify
+  current time", a transient artifact of the check host being unable to reach the
+  time server; it is not related to the package.
+
+## Reverse dependencies
+- ggpubr has 316 reverse dependencies (Depends/Imports/Suggests).
+- Only one change in this release alters default output: `compare_means(group.by = )`
+  now adjusts p-values within each group rather than pooling across groups (#200).
+- We scanned the sources of all 316 reverse dependencies for use of the changed
+  functions. Only 3 packages call the behavior-changing path `compare_means(group.by = )`
+  (easynem, immunarch, UCSCXenaShiny), and none of them pin the adjusted p-values in
+  code that `R CMD check` evaluates (tests, examples, or vignettes). All remaining
+  changes are additive/opt-in with unchanged defaults, so callers using existing
+  arguments obtain identical output.
+- Conclusion: no new problems expected in reverse dependencies.
 
 ## Additional comments
-- The package metadata requires ggplot2 >= 3.5.2. This check was run with
+- The package metadata requires ggplot2 >= 3.5.2; this check was also run against
   ggplot2 4.0.3.
-- The previous cran-comments note incorrectly stated that this release requires
-  ggplot2 >= 4.0.0; DESCRIPTION and NEWS.md keep the ggplot2 floor at >= 3.5.2.
-- Added paired-id comparison tests and refreshed p-value formatting documentation.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -31,3 +31,7 @@
 ## Additional comments
 - The package metadata requires ggplot2 >= 3.5.2; this check was also run against
   ggplot2 4.0.3.
+- win-builder (R-devel and R-release) flags "APA", "NEJM" and "GraphPad" in the
+  Description as possibly misspelled. These are journal / style names used by the new
+  p-value formatting presets (APA, NEJM, Lancet, AMA, GraphPad styles), not
+  misspellings.

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -105,8 +105,9 @@ If provided, overrides the style default.}
 decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.}
 
 \item{p.min.threshold}{numeric specifying the minimum p-value to display exactly.
-Values below this threshold are shown as "< threshold". Set to NULL to always
-show exact values. If provided, overrides the style default.}
+Values below this threshold are shown as "< threshold". If NULL, the selected
+style's default threshold is used; styles without a threshold show exact
+values. If provided, overrides the style default.}
 
 \item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
 uses \code{getOption("OutDec")}.}

--- a/man/format_p_value.Rd
+++ b/man/format_p_value.Rd
@@ -36,7 +36,8 @@ decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 
 \item{min.threshold}{Numeric specifying the minimum p-value to display exactly.
 Values below this threshold are shown as "< threshold" (e.g., "< 0.001").
-Set to NULL to always show exact values. If provided, overrides the style default.
+If NULL, the selected style's default threshold is used; styles without a
+threshold show exact values. If provided, overrides the style default.
 Must be a single positive finite number.}
 
 \item{decimal.mark}{Character string to use as the decimal mark. If NULL,

--- a/man/ggballoonplot.Rd
+++ b/man/ggballoonplot.Rd
@@ -66,9 +66,10 @@ c(14, "plain").}
 
 \item{rotate.x.text}{logical. If TRUE (default), rotate the x axis text.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
+\item{ggtheme}{function, ggplot2 theme name. Default value is
+\code{theme_minimal()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+theme, so the plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.}
 
 \item{...}{other arguments passed to the function \code{\link{ggpar}}}
 }

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -174,16 +174,16 @@ text, making it easier to read.}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
+theme_minimal(), theme_classic(), theme_void(), ....}
+
 \item{show.n}{logical. If TRUE, displays the number of observations
 (\code{"n = <count>"}) at the top of each group. Off by default. When the
 groups are dodged (a \code{color}/\code{fill} grouping with a dodging
 \code{position}), one count is shown per group; otherwise a single count is
 shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
 computed per facet.}
-
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
 
 \item{...}{other arguments to be passed to
 \code{\link[ggplot2]{geom_boxplot}}, \code{\link{ggpar}} and

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -96,8 +96,9 @@ changes, respectively.}
 \item{facet.by}{character vector, of length 1 or 2, specifying grouping
 variables for faceting the plot into multiple panels (one MA plot per group).
 The variable(s) must be columns of \code{data} (supplied as a data frame). The
-top genes and the point colors are computed \emph{per panel}. Default is NULL
-(no faceting), in which case the output is unchanged.}
+top genes are selected \emph{per panel}; point colors use the same
+significance thresholds in every panel. Default is NULL (no faceting), in
+which case the output is unchanged.}
 
 \item{main}{plot main title.}
 
@@ -110,9 +111,10 @@ hide ylab.}
 \item{line.color}{color of the horizontal threshold lines (the central line
 at 0 and the two fold-change cutoff lines). Default is "black".}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
+\item{ggtheme}{function, ggplot2 theme name. Default value is
+\code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+theme, so the plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.}
 
 \item{...}{other arguments to be passed to \code{\link{ggpar}}.}
 }

--- a/man/ggpaired.Rd
+++ b/man/ggpaired.Rd
@@ -65,15 +65,6 @@ scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
 
 \item{point.size, line.size}{point and line size, respectively.}
 
-\item{jitter}{numeric value (default 0, no jitter) giving the amount of
-horizontal jitter added to the paired points to reduce overlap. Points are
-nudged sideways within \code{[-jitter, jitter]}; each subject (\code{id})
-gets a single offset so its two points move together and the connecting
-line stays intact. Only the horizontal positions change (the values are
-never moved). Typical values are small relative to the box \code{width}
-(e.g. \code{jitter = 0.05} to \code{0.1}). \code{jitter = 0} leaves the plot
-unchanged.}
-
 \item{line.color}{line color.}
 
 \item{linetype}{line type.}
@@ -126,6 +117,15 @@ text, making it easier to read.}
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
+
+\item{jitter}{numeric value (default 0, no jitter) giving the amount of
+horizontal jitter added to the paired points to reduce overlap. Points are
+nudged sideways within \code{[-jitter, jitter]}; each subject (\code{id})
+gets a single offset so its two points move together and the connecting
+line stays intact. Only the horizontal positions change (the values are
+never moved). Typical values are small relative to the box \code{width}
+(e.g. \code{jitter = 0.05} to \code{0.1}). \code{jitter = 0} leaves the plot
+unchanged.}
 
 \item{...}{other arguments to be passed to be passed to \link{ggpar}().}
 }

--- a/man/ggpar.Rd
+++ b/man/ggpar.Rd
@@ -141,7 +141,11 @@ orientation to horizontal.}
 \item{orientation}{change the orientation of the plot. Allowed values are one
 of c( "vertical", "horizontal", "reverse"). Partial match is allowed.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpubr-package.Rd
+++ b/man/ggpubr-package.Rd
@@ -6,7 +6,7 @@
 \alias{ggpubr-package}
 \title{ggpubr: 'ggplot2' Based Publication Ready Plots}
 \description{
-The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
+The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad, and scientific notation) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
 }
 \details{
 General resources:

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -145,16 +145,16 @@ text, making it easier to read.}
 call to a position adjustment function. Used to adjust position for
 multiple groups.}
 
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
+theme_minimal(), theme_classic(), theme_void(), ....}
+
 \item{show.n}{logical. If TRUE, displays the number of observations
 (\code{"n = <count>"}) at the top of each group. Off by default. When the
 groups are dodged (a \code{color}/\code{fill} grouping with a dodging
 \code{position}), one count is shown per group; otherwise a single count is
 shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
 computed per facet.}
-
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
 
 \item{...}{other arguments to be passed to
 \code{\link[ggplot2]{geom_jitter}}, \code{\link{ggpar}} and

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -189,16 +189,16 @@ text, making it easier to read.}
 call to a position adjustment function (e.g. \code{position_dodge(0.8)}).
 Used to control the spacing between grouped elements.}
 
+\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
+theme_minimal(), theme_classic(), theme_void(), ....}
+
 \item{show.n}{logical. If TRUE, displays the number of observations
 (\code{"n = <count>"}) at the top of each group. Off by default. When the
 groups are dodged (a \code{color}/\code{fill} grouping with a dodging
 \code{position}), one count is shown per group; otherwise a single count is
 shown per x-axis tick. Counts respect \code{select}/\code{remove} and are
 computed per facet.}
-
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
 
 \item{...}{other arguments to be passed to
 \code{\link[ggplot2]{geom_violin}}, \code{\link{ggpar}} and

--- a/man/stat_anova_test.Rd
+++ b/man/stat_anova_test.Rd
@@ -154,8 +154,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{signif.cutoffs}{numeric vector of p-value cutoffs in descending order
 for assigning significance symbols. For example, \code{c(0.10, 0.05, 0.01)}

--- a/man/stat_anova_test.Rd
+++ b/man/stat_anova_test.Rd
@@ -247,7 +247,7 @@ text up or down. }}
 }
 \description{
 Adds automatically one-way and two-way ANOVA test p-values to a
-ggplot, such as box plots, dot plots and stripcharts.
+ ggplot, such as box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{ \item{DFn}: Degrees of Freedom in the

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -103,7 +103,7 @@ for wilcoxon test.}
 significance levels.}
 
 \item{label.sep}{a character string to separate the terms. Default is ", ", to
-separate the correlation coefficient and the p.value.}
+separate the test method name and the p-value.}
 
 \item{label}{character string specifying label type. Allowed values include
 \code{"p.signif"} (shows the significance levels), \code{"p.format"} (shows

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -110,7 +110,10 @@ separate plots combined with \code{\link{ggarrange}()}. An explicit
 
 \item{digits, r.digits, p.digits}{integer indicating the number of decimal
 places (round) or significant digits (signif) to be used for the correlation
-coefficient and the p-value, respectively..}
+coefficient and the p-value, respectively. In the default p-value label style,
+the displayed p-value keeps the legacy raw value unless \code{p.accuracy} is
+set; \code{p.digits} is used by non-default \code{p.format.style} outputs and
+the computed \code{p} variable.}
 
 \item{r.accuracy}{a real value specifying the number of decimal places of
 precision for the correlation coefficient. Default is NULL. Use (e.g.) 0.01

--- a/man/stat_friedman_test.Rd
+++ b/man/stat_friedman_test.Rd
@@ -68,7 +68,11 @@ test is performed between the x-groups for each legend level. }}
 "p.adj"), where \code{p} is the p-value. Can be also an expression that can
 be formatted by the \code{\link[glue]{glue}()} package. For example, when
 specifying label = "t-test, p = \{p\}", the expression \{p\} will be
-replaced by its value.}
+replaced by its value. Values inserted through a glue expression are taken
+from the raw data column and are \strong{not} rounded by \code{p.digits}; to
+round within a glue expression, wrap the value, e.g.
+\code{label = "p = \{signif(p, 3)\}"} (or \code{\{format_p_value(p)\}} for the
+p-value house style).}
 
 \item{label.x.npc, label.y.npc}{can be \code{numeric} or \code{character}
 vector of the same length as the number of groups and/or panels. If too
@@ -105,25 +109,42 @@ value (not recommended), use p.adjust.method = "none".}
  Note: \code{significance} is kept for backward compatibility. If provided,
  it takes precedence over \code{signif.cutoffs} and related parameters.}
 
-\item{p.format.style}{character string specifying the p-value formatting style.
+\item{p.format.style}{character string specifying the p-value formatting style
+applied to recognized numeric p-value label columns (see \code{p.digits}).
 One of: \code{"default"} (backward compatible, uses scientific notation),
 \code{"apa"} (APA style, no leading zero), \code{"nejm"} (NEJM style),
 \code{"lancet"} (Lancet style), \code{"ama"} (AMA style), \code{"graphpad"}
-(GraphPad style), or \code{"scientific"} (scientific notation for GWAS).
-See \code{\link{list_p_format_styles}} for details.}
+(GraphPad style), or \code{"scientific"} (scientific notation for GWAS). See
+\code{\link{list_p_format_styles}} for details. Default is \code{"default"},
+which leaves the rendered p-value labels unchanged.}
 
-\item{p.digits}{integer specifying the number of decimal places for p-values.
-If provided, overrides the style default.}
+\item{p.digits}{integer indicating the number of digits used to
+format recognized \strong{numeric} p-value label columns (\code{label} is one
+of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
+\code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
+raw value without rounding (this also disables \code{p.format.style} and the
+related formatting arguments). All other labels are left unchanged: other
+numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
+significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
+already-formatted strings, and \code{\link[glue]{glue}} expressions. A
+p-named column whose values fall outside \code{[0, 1]} is also left as-is.
+Uses the same formatting engine (\code{\link{format_p_value}()}) as
+\code{\link{stat_anova_test}()} for consistency across layers. The style of
+this formatting is further controlled by \code{p.format.style},
+\code{p.leading.zero}, \code{p.min.threshold} and \code{p.decimal.mark}
+(same arguments as \code{\link{stat_compare_means}()}).}
 
-\item{p.leading.zero}{logical indicating whether to include leading zero before
-decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.}
+\item{p.leading.zero}{logical indicating whether to include the leading zero
+before the decimal point (e.g., "0.05" vs ".05"). If provided, overrides the
+style default.}
 
-\item{p.min.threshold}{numeric specifying the minimum p-value to display exactly.
-Values below this threshold are shown as "< threshold". If provided, overrides
-the style default.}
+\item{p.min.threshold}{numeric specifying the minimum p-value to display
+exactly. Values below this threshold are shown as "< threshold" (e.g.
+\code{p.min.threshold = 0.001} renders very small p-values as "< 0.001"). If
+provided, overrides the style default.}
 
-\item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
-uses \code{getOption("OutDec")}.}
+\item{p.decimal.mark}{character string to use as the decimal mark. If
+\code{NULL}, uses \code{getOption("OutDec")}.}
 
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
@@ -176,7 +197,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add automatically Friedman test p-values to a ggplot, such as
-box plots, dot plots and stripcharts.
+ box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_friedman_test.Rd
+++ b/man/stat_friedman_test.Rd
@@ -106,8 +106,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style
 applied to recognized numeric p-value label columns (see \code{p.digits}).

--- a/man/stat_kruskal_test.Rd
+++ b/man/stat_kruskal_test.Rd
@@ -63,7 +63,11 @@ test is performed between the x-groups for each legend level. }}
 "p.adj"), where \code{p} is the p-value. Can be also an expression that can
 be formatted by the \code{\link[glue]{glue}()} package. For example, when
 specifying label = "t-test, p = \{p\}", the expression \{p\} will be
-replaced by its value.}
+replaced by its value. Values inserted through a glue expression are taken
+from the raw data column and are \strong{not} rounded by \code{p.digits}; to
+round within a glue expression, wrap the value, e.g.
+\code{label = "p = \{signif(p, 3)\}"} (or \code{\{format_p_value(p)\}} for the
+p-value house style).}
 
 \item{label.x.npc, label.y.npc}{can be \code{numeric} or \code{character}
 vector of the same length as the number of groups and/or panels. If too
@@ -100,25 +104,42 @@ value (not recommended), use p.adjust.method = "none".}
  Note: \code{significance} is kept for backward compatibility. If provided,
  it takes precedence over \code{signif.cutoffs} and related parameters.}
 
-\item{p.format.style}{character string specifying the p-value formatting style.
+\item{p.format.style}{character string specifying the p-value formatting style
+applied to recognized numeric p-value label columns (see \code{p.digits}).
 One of: \code{"default"} (backward compatible, uses scientific notation),
 \code{"apa"} (APA style, no leading zero), \code{"nejm"} (NEJM style),
 \code{"lancet"} (Lancet style), \code{"ama"} (AMA style), \code{"graphpad"}
-(GraphPad style), or \code{"scientific"} (scientific notation for GWAS).
-See \code{\link{list_p_format_styles}} for details.}
+(GraphPad style), or \code{"scientific"} (scientific notation for GWAS). See
+\code{\link{list_p_format_styles}} for details. Default is \code{"default"},
+which leaves the rendered p-value labels unchanged.}
 
-\item{p.digits}{integer specifying the number of decimal places for p-values.
-If provided, overrides the style default.}
+\item{p.digits}{integer indicating the number of digits used to
+format recognized \strong{numeric} p-value label columns (\code{label} is one
+of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
+\code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
+raw value without rounding (this also disables \code{p.format.style} and the
+related formatting arguments). All other labels are left unchanged: other
+numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
+significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
+already-formatted strings, and \code{\link[glue]{glue}} expressions. A
+p-named column whose values fall outside \code{[0, 1]} is also left as-is.
+Uses the same formatting engine (\code{\link{format_p_value}()}) as
+\code{\link{stat_anova_test}()} for consistency across layers. The style of
+this formatting is further controlled by \code{p.format.style},
+\code{p.leading.zero}, \code{p.min.threshold} and \code{p.decimal.mark}
+(same arguments as \code{\link{stat_compare_means}()}).}
 
-\item{p.leading.zero}{logical indicating whether to include leading zero before
-decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.}
+\item{p.leading.zero}{logical indicating whether to include the leading zero
+before the decimal point (e.g., "0.05" vs ".05"). If provided, overrides the
+style default.}
 
-\item{p.min.threshold}{numeric specifying the minimum p-value to display exactly.
-Values below this threshold are shown as "< threshold". If provided, overrides
-the style default.}
+\item{p.min.threshold}{numeric specifying the minimum p-value to display
+exactly. Values below this threshold are shown as "< threshold" (e.g.
+\code{p.min.threshold = 0.001} renders very small p-values as "< 0.001"). If
+provided, overrides the style default.}
 
-\item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
-uses \code{getOption("OutDec")}.}
+\item{p.decimal.mark}{character string to use as the decimal mark. If
+\code{NULL}, uses \code{getOption("OutDec")}.}
 
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
@@ -171,7 +192,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add Kruskal-Wallis test p-values to a ggplot, such as
-box plots, dot plots and stripcharts.
+ box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_kruskal_test.Rd
+++ b/man/stat_kruskal_test.Rd
@@ -101,8 +101,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style
 applied to recognized numeric p-value label columns (see \code{p.digits}).

--- a/man/stat_welch_anova_test.Rd
+++ b/man/stat_welch_anova_test.Rd
@@ -63,7 +63,11 @@ test is performed between the x-groups for each legend level. }}
 "p.adj"), where \code{p} is the p-value. Can be also an expression that can
 be formatted by the \code{\link[glue]{glue}()} package. For example, when
 specifying label = "t-test, p = \{p\}", the expression \{p\} will be
-replaced by its value.}
+replaced by its value. Values inserted through a glue expression are taken
+from the raw data column and are \strong{not} rounded by \code{p.digits}; to
+round within a glue expression, wrap the value, e.g.
+\code{label = "p = \{signif(p, 3)\}"} (or \code{\{format_p_value(p)\}} for the
+p-value house style).}
 
 \item{label.x.npc, label.y.npc}{can be \code{numeric} or \code{character}
 vector of the same length as the number of groups and/or panels. If too
@@ -100,25 +104,42 @@ value (not recommended), use p.adjust.method = "none".}
  Note: \code{significance} is kept for backward compatibility. If provided,
  it takes precedence over \code{signif.cutoffs} and related parameters.}
 
-\item{p.format.style}{character string specifying the p-value formatting style.
+\item{p.format.style}{character string specifying the p-value formatting style
+applied to recognized numeric p-value label columns (see \code{p.digits}).
 One of: \code{"default"} (backward compatible, uses scientific notation),
 \code{"apa"} (APA style, no leading zero), \code{"nejm"} (NEJM style),
 \code{"lancet"} (Lancet style), \code{"ama"} (AMA style), \code{"graphpad"}
-(GraphPad style), or \code{"scientific"} (scientific notation for GWAS).
-See \code{\link{list_p_format_styles}} for details.}
+(GraphPad style), or \code{"scientific"} (scientific notation for GWAS). See
+\code{\link{list_p_format_styles}} for details. Default is \code{"default"},
+which leaves the rendered p-value labels unchanged.}
 
-\item{p.digits}{integer specifying the number of decimal places for p-values.
-If provided, overrides the style default.}
+\item{p.digits}{integer indicating the number of digits used to
+format recognized \strong{numeric} p-value label columns (\code{label} is one
+of \code{"p"}, \code{"p.adj"}, \code{"p.value"}, \code{"p.val"},
+\code{"pval"}, \code{"padj"}). Default is 3. Set to \code{NULL} to print the
+raw value without rounding (this also disables \code{p.format.style} and the
+related formatting arguments). All other labels are left unchanged: other
+numeric columns (e.g. \code{"statistic"}, \code{"n"}, effect sizes),
+significance symbols (\code{"p.signif"}, \code{"p.adj.signif"}),
+already-formatted strings, and \code{\link[glue]{glue}} expressions. A
+p-named column whose values fall outside \code{[0, 1]} is also left as-is.
+Uses the same formatting engine (\code{\link{format_p_value}()}) as
+\code{\link{stat_anova_test}()} for consistency across layers. The style of
+this formatting is further controlled by \code{p.format.style},
+\code{p.leading.zero}, \code{p.min.threshold} and \code{p.decimal.mark}
+(same arguments as \code{\link{stat_compare_means}()}).}
 
-\item{p.leading.zero}{logical indicating whether to include leading zero before
-decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.}
+\item{p.leading.zero}{logical indicating whether to include the leading zero
+before the decimal point (e.g., "0.05" vs ".05"). If provided, overrides the
+style default.}
 
-\item{p.min.threshold}{numeric specifying the minimum p-value to display exactly.
-Values below this threshold are shown as "< threshold". If provided, overrides
-the style default.}
+\item{p.min.threshold}{numeric specifying the minimum p-value to display
+exactly. Values below this threshold are shown as "< threshold" (e.g.
+\code{p.min.threshold = 0.001} renders very small p-values as "< 0.001"). If
+provided, overrides the style default.}
 
-\item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
-uses \code{getOption("OutDec")}.}
+\item{p.decimal.mark}{character string to use as the decimal mark. If
+\code{NULL}, uses \code{getOption("OutDec")}.}
 
 \item{geom}{The geometric object to use to display the data for this layer.
 When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
@@ -171,7 +192,7 @@ as described in \code{?plotmath}.}
 }
 \description{
 Add Welch one-way ANOVA test p-values to a ggplot, such as
-box plots, dot plots and stripcharts.
+ box plots, dot plots and stripcharts.
 }
 \section{Computed variables}{
  \itemize{

--- a/man/stat_welch_anova_test.Rd
+++ b/man/stat_welch_anova_test.Rd
@@ -101,8 +101,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style
 applied to recognized numeric p-value label columns (see \code{p.digits}).

--- a/tests/testthat/test-add_stat_label.R
+++ b/tests/testthat/test-add_stat_label.R
@@ -165,6 +165,34 @@ test_that("add_stat_label works with Kruskal-Wallis stats label formats", {
 })
 
 
+test_that("add_stat_label works with Welch ANOVA detailed label formats", {
+  res <- data.frame(
+    stringsAsFactors = FALSE,
+    x = c("1"),
+    y = c(36.4),
+    n = c(60L),
+    statistic = c(45.57),
+    DFn = c(2),
+    DFd = c(37.7432475430268),
+    p = c(1.23e-10),
+    method = c("Welch Anova"),
+    p.adj = c(1.23e-10),
+    p.signif = c("****"),
+    p.adj.signif = c("****"),
+    p.format = c("<0.0001"),
+    p.adj.format = c("<0.0001")
+  )
+  res.detailed <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed"))
+  res.detailed.italic <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed_italic"))
+  res.detailed.expression <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed_expression"))
+
+  expect_equal(res.detailed$label, "Welch Anova, F(2, 37.7432475430268) = 45.57, p < 0.0001, n = 60")
+  expect_equal(res.detailed.italic$label, "list(Welch~Anova,~italic(F)('2',~'37.7432475430268')~`=`~'45.57',~italic(p)~`<`~'0.0001',~italic(n)~`=`~'60')")
+  expect_equal(res.detailed.expression$label, "list(Welch~Anova,~italic(F)('2',~'37.7432475430268')~`=`~'45.57',~italic(p)~`<`~'0.0001',~italic(n)~`=`~'60')")
+  expect_false(any(grepl("FALSE", c(res.detailed.italic$label, res.detailed.expression$label), fixed = TRUE)))
+})
+
+
 # Tests for build_symnum_args helper function
 test_that("build_symnum_args uses symnum.args when provided (backward compatibility)", {
   result <- build_symnum_args(


### PR DESCRIPTION
Release preparation for **ggpubr 1.0.0** (major milestone bump from `0.6.3.999`; last CRAN release `v0.6.3`). Refs #747.

This branch contains the release prep only:
- `DESCRIPTION`: Version `1.0.0`, Date set to the submission date. No new hard dependency (only min-version bumps of existing Imports).
- `NEWS.md`: the dev section reorganized into the standard **New features / Main changes / Minor changes / Bug fixes** sections (all `(#NNN)` refs and contributor credits preserved; content unchanged, pure regrouping).
- `man/` + `NAMESPACE`: regenerated with roxygen2 7.3.3 (repo's pinned version) — docs now fully in sync.
- `cran-comments.md`: updated with the reverse-dependency scan result and check results.

Local checks: `devtools::test()` green (1156); `R CMD check --as-cran` → 0 errors / 0 warnings / 1 transient note ("unable to verify current time"); `urlchecker` clean; spelling reviewed (domain vocabulary only).

Reverse dependencies (316): scanned all sources; only 3 call the one behavior-changing path `compare_means(group.by=)` (#200), none pin the affected values in check-evaluated code. No new problems expected.

Per the release process, this branch is **not** to be merged until after CRAN acceptance — the CRAN tarball is built from this branch and master stays on the dev version.

Refs #747.
