### PR TITLE
Fix Welch labels and clarify statistical docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,10 +16,10 @@ Description: The 'ggplot2' package is excellent and flexible for elegant data
     with no advanced R programming skills. 'ggpubr' provides some easy-to-use
     functions for creating and customizing 'ggplot2'-based publication ready plots.
     This version includes modern R ecosystem compatibility updates and customizable
-    p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication
-    workflows, plus robust sparse-subset handling in statistical annotation layers
-    such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group
-    skip diagnostics for non-comparable subsets.
+    p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad, and scientific
+    notation) for publication workflows, plus robust sparse-subset handling in
+    statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()',
+    with informative per-group skip diagnostics for non-comparable subsets.
 License: GPL (>= 2)
 LazyData: TRUE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,11 +20,15 @@
 ## New features
 
 - `ggmaplot()` gains an optional `facet.by` argument to split the MA plot into
-  multiple panels (e.g. one per contrast or species). The top genes and point
-  colors are computed per panel. Default output (no `facet.by`) is unchanged (#498).
+  multiple panels (e.g. one per contrast or species). Top genes are selected per
+  panel, while point colors use the same significance thresholds in every panel.
+  Default output (no `facet.by`) is unchanged (#498).
 
 ## Robustness fixes
 
+- `stat_welch_anova_test(label = "as_detailed_italic")` and
+  `stat_welch_anova_test(label = "as_detailed_expression")` now display the
+  numeric F statistic instead of `FALSE`.
 - `ggbarplot()` now supports mapping `alpha` to a discrete grouping variable together
   with a summary (e.g. `alpha = clarity, add = "mean_ci", position = position_dodge()`).
   Previously this errored at draw time (`"alpha * 255": non-numeric argument to binary
@@ -428,6 +432,9 @@
 ## Tests and docs
 
 - Expanded test coverage for formatting helpers and compatibility paths.
+- Clarified `ggtheme` default documentation, p-value threshold/display
+  documentation, and statistical label-separator documentation to match function
+  usage and style-default behavior.
 - Regenerated manuals and package documentation after source sync.
 
 ## Issue closures

--- a/R/compare_means.R
+++ b/R/compare_means.R
@@ -83,8 +83,9 @@ NULL
 #' @param p.leading.zero logical indicating whether to include leading zero before
 #'  decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 #' @param p.min.threshold numeric specifying the minimum p-value to display exactly.
-#'  Values below this threshold are shown as "< threshold". Set to NULL to always
-#'  show exact values. If provided, overrides the style default.
+#'  Values below this threshold are shown as "< threshold". If NULL, the selected
+#'  style's default threshold is used; styles without a threshold show exact
+#'  values. If provided, overrides the style default.
 #' @param p.decimal.mark character string to use as the decimal mark. If NULL,
 #'  uses \code{getOption("OutDec")}.
 #' @return a data frame with the following columns:

--- a/R/ggballoonplot.R
+++ b/R/ggballoonplot.R
@@ -38,6 +38,10 @@
 #'   "bold", "red"). To specify only the size and the style, use font.label =
 #'   c(14, "plain").
 #' @param rotate.x.text logical. If TRUE (default), rotate the x axis text.
+#' @param ggtheme function, ggplot2 theme name. Default value is
+#'   \code{theme_minimal()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+#'   theme, so the plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #' @param ... other arguments passed to the function \code{\link{ggpar}}
 #'
 #' @examples

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -55,10 +55,15 @@ NULL
 #' @param facet.by character vector, of length 1 or 2, specifying grouping
 #'   variables for faceting the plot into multiple panels (one MA plot per group).
 #'   The variable(s) must be columns of \code{data} (supplied as a data frame). The
-#'   top genes and the point colors are computed \emph{per panel}. Default is NULL
-#'   (no faceting), in which case the output is unchanged.
+#'   top genes are selected \emph{per panel}; point colors use the same
+#'   significance thresholds in every panel. Default is NULL (no faceting), in
+#'   which case the output is unchanged.
 #' @param line.color color of the horizontal threshold lines (the central line
 #'   at 0 and the two fold-change cutoff lines). Default is "black".
+#' @param ggtheme function, ggplot2 theme name. Default value is
+#'   \code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+#'   theme, so the plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
 #' @return a ggplot.
 #' @examples
@@ -123,9 +128,6 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
   } else {
     detection_call <- rep(1, nrow(data))
   }
-
-  # Legend position
-  if (is.null(list(...)$legend)) legend <- c(0.12, 0.9)
   # If basemean logged, we'll leave it as is, otherwise log2 transform
   is.basemean.logged <- "baseMeanLog2" %in% colnames(data)
   if (is.basemean.logged) {

--- a/R/ggpar.R
+++ b/R/ggpar.R
@@ -67,7 +67,11 @@ NULL
 #'   orientation to horizontal.
 #' @param orientation change the orientation of the plot. Allowed values are one
 #'   of c( "vertical", "horizontal", "reverse"). Partial match is allowed.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+#' @param ggtheme function, ggplot2 theme name. The default is set by each
+#'   function's \code{ggtheme} argument; see the function usage for the actual
+#'   default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+#'   plot keeps ggplot2 default theme or the theme set globally via
+#'   \code{theme_set()}.
 #'   Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 #'   theme_minimal(), theme_classic(), theme_void(), ....
 #' @param ... not used

--- a/R/p_format_utils.R
+++ b/R/p_format_utils.R
@@ -146,7 +146,8 @@ list_p_format_styles <- function() {
 #'   decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 #' @param min.threshold Numeric specifying the minimum p-value to display exactly.
 #'   Values below this threshold are shown as "< threshold" (e.g., "< 0.001").
-#'   Set to NULL to always show exact values. If provided, overrides the style default.
+#'   If NULL, the selected style's default threshold is used; styles without a
+#'   threshold show exact values. If provided, overrides the style default.
 #'   Must be a single positive finite number.
 #' @param decimal.mark Character string to use as the decimal mark. If NULL,
 #'   uses \code{getOption("OutDec")}.

--- a/R/stat_anova_test.R
+++ b/R/stat_anova_test.R
@@ -58,8 +58,9 @@ NULL
 #'  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
 #'  \item \code{****}:  p <= 0.0001 }
 #'
-#'  Note: \code{significance} is kept for backward compatibility. If provided,
-#'  it takes precedence over \code{signif.cutoffs} and related parameters.
+#'  Note: \code{significance} is kept for backward compatibility. For functions
+#'  that also expose \code{signif.cutoffs} and related parameters,
+#'  \code{significance} takes precedence when provided.
 #' @param signif.cutoffs numeric vector of p-value cutoffs in descending order
 #'  for assigning significance symbols. For example, \code{c(0.10, 0.05, 0.01)}
 #'  means p < 0.10 gets "*", p < 0.05 gets "**", p < 0.01 gets "***".

--- a/R/stat_compare_means.R
+++ b/R/stat_compare_means.R
@@ -64,7 +64,7 @@ NULL
 #'  using \code{label = "p.format.signif"}. If FALSE, falls back to showing only
 #'  the p-value (equivalent to \code{label = "p.format"}) with a warning.
 #' @param label.sep a character string to separate the terms. Default is ", ", to
-#'  separate the correlation coefficient and the p.value.
+#'  separate the test method name and the p-value.
 #' @param label.x.npc,label.y.npc can be \code{numeric} or \code{character}
 #'  vector of the same length as the number of groups and/or panels. If too
 #'  short they will be recycled. \itemize{ \item If \code{numeric}, value should

--- a/R/stat_cor.R
+++ b/R/stat_cor.R
@@ -49,7 +49,10 @@ NULL
 #' @param output.type character One of "expression", "latex", "tex" or "text".
 #' @param digits,r.digits,p.digits integer indicating the number of decimal
 #'  places (round) or significant digits (signif) to be used for the correlation
-#'  coefficient and the p-value, respectively..
+#'  coefficient and the p-value, respectively. In the default p-value label style,
+#'  the displayed p-value keeps the legacy raw value unless \code{p.accuracy} is
+#'  set; \code{p.digits} is used by non-default \code{p.format.style} outputs and
+#'  the computed \code{p} variable.
 #' @param r.accuracy a real value specifying the number of decimal places of
 #'  precision for the correlation coefficient. Default is NULL. Use (e.g.) 0.01
 #'  to show 2 decimal places of precision. If specified, then \code{r.digits} is

--- a/R/stat_welch_anova_test.R
+++ b/R/stat_welch_anova_test.R
@@ -122,8 +122,8 @@ get_welch_anova_test_label_template <- function(label) {
   switch(label,
     as_italic = "{method}, italic(p) = {p.format}",
     as_detailed = "{method}, F({DFn}, {DFd}) = {statistic}, p = {p.format}, n = {n}",
-    as_detailed_italic = "{method}, italic(F)({DFn}, {DFd}) = {F}, italic(p) = {p.format}, italic(n) = {n}",
-    as_detailed_expression = "{method}, italic(F)({DFn}, {DFd}) = {F}, italic(p) = {p.format}, italic(n) = {n}",
+    as_detailed_italic = "{method}, italic(F)({DFn}, {DFd}) = {statistic}, italic(p) = {p.format}, italic(n) = {n}",
+    as_detailed_expression = "{method}, italic(F)({DFn}, {DFd}) = {statistic}, italic(p) = {p.format}, italic(n) = {n}",
     label
   )
 }

--- a/man/compare_means.Rd
+++ b/man/compare_means.Rd
@@ -105,8 +105,9 @@ If provided, overrides the style default.}
 decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.}
 
 \item{p.min.threshold}{numeric specifying the minimum p-value to display exactly.
-Values below this threshold are shown as "< threshold". Set to NULL to always
-show exact values. If provided, overrides the style default.}
+Values below this threshold are shown as "< threshold". If NULL, the selected
+style's default threshold is used; styles without a threshold show exact
+values. If provided, overrides the style default.}
 
 \item{p.decimal.mark}{character string to use as the decimal mark. If NULL,
 uses \code{getOption("OutDec")}.}

--- a/man/format_p_value.Rd
+++ b/man/format_p_value.Rd
@@ -36,7 +36,8 @@ decimal point (e.g., "0.05" vs ".05"). If provided, overrides the style default.
 
 \item{min.threshold}{Numeric specifying the minimum p-value to display exactly.
 Values below this threshold are shown as "< threshold" (e.g., "< 0.001").
-Set to NULL to always show exact values. If provided, overrides the style default.
+If NULL, the selected style's default threshold is used; styles without a
+threshold show exact values. If provided, overrides the style default.
 Must be a single positive finite number.}
 
 \item{decimal.mark}{Character string to use as the decimal mark. If NULL,

--- a/man/ggballoonplot.Rd
+++ b/man/ggballoonplot.Rd
@@ -66,7 +66,10 @@ c(14, "plain").}
 
 \item{rotate.x.text}{logical. If TRUE (default), rotate the x axis text.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+\item{ggtheme}{function, ggplot2 theme name. Default value is
+\code{theme_minimal()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+theme, so the plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -96,8 +96,9 @@ changes, respectively.}
 \item{facet.by}{character vector, of length 1 or 2, specifying grouping
 variables for faceting the plot into multiple panels (one MA plot per group).
 The variable(s) must be columns of \code{data} (supplied as a data frame). The
-top genes and the point colors are computed \emph{per panel}. Default is NULL
-(no faceting), in which case the output is unchanged.}
+top genes are selected \emph{per panel}; point colors use the same
+significance thresholds in every panel. Default is NULL (no faceting), in
+which case the output is unchanged.}
 
 \item{main}{plot main title.}
 
@@ -110,7 +111,10 @@ hide ylab.}
 \item{line.color}{color of the horizontal threshold lines (the central line
 at 0 and the two fold-change cutoff lines). Default is "black".}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+\item{ggtheme}{function, ggplot2 theme name. Default value is
+\code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
+theme, so the plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpar.Rd
+++ b/man/ggpar.Rd
@@ -141,7 +141,11 @@ orientation to horizontal.}
 \item{orientation}{change the orientation of the plot. Allowed values are one
 of c( "vertical", "horizontal", "reverse"). Partial match is allowed.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/ggpubr-package.Rd
+++ b/man/ggpubr-package.Rd
@@ -6,7 +6,7 @@
 \alias{ggpubr-package}
 \title{ggpubr: 'ggplot2' Based Publication Ready Plots}
 \description{
-The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
+The 'ggplot2' package is excellent and flexible for elegant data visualization in R. However the default generated plots require some formatting before we can send them for publication. Furthermore, to customize a 'ggplot', the syntax is opaque and this raises the level of difficulty for researchers with no advanced R programming skills. 'ggpubr' provides some easy-to-use functions for creating and customizing 'ggplot2'-based publication ready plots. This version includes modern R ecosystem compatibility updates and customizable p-value formatting presets (APA, AMA, NEJM, Lancet, GraphPad, and scientific notation) for publication workflows, plus robust sparse-subset handling in statistical annotation layers such as 'stat_compare_means()' and 'geom_pwc()', with informative per-group skip diagnostics for non-comparable subsets.
 }
 \details{
 General resources:

--- a/man/stat_anova_test.Rd
+++ b/man/stat_anova_test.Rd
@@ -154,8 +154,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{signif.cutoffs}{numeric vector of p-value cutoffs in descending order
 for assigning significance symbols. For example, \code{c(0.10, 0.05, 0.01)}

--- a/man/stat_compare_means.Rd
+++ b/man/stat_compare_means.Rd
@@ -103,7 +103,7 @@ for wilcoxon test.}
 significance levels.}
 
 \item{label.sep}{a character string to separate the terms. Default is ", ", to
-separate the correlation coefficient and the p.value.}
+separate the test method name and the p-value.}
 
 \item{label}{character string specifying label type. Allowed values include
 \code{"p.signif"} (shows the significance levels), \code{"p.format"} (shows

--- a/man/stat_cor.Rd
+++ b/man/stat_cor.Rd
@@ -110,7 +110,10 @@ separate plots combined with \code{\link{ggarrange}()}. An explicit
 
 \item{digits, r.digits, p.digits}{integer indicating the number of decimal
 places (round) or significant digits (signif) to be used for the correlation
-coefficient and the p-value, respectively..}
+coefficient and the p-value, respectively. In the default p-value label style,
+the displayed p-value keeps the legacy raw value unless \code{p.accuracy} is
+set; \code{p.digits} is used by non-default \code{p.format.style} outputs and
+the computed \code{p} variable.}
 
 \item{r.accuracy}{a real value specifying the number of decimal places of
 precision for the correlation coefficient. Default is NULL. Use (e.g.) 0.01

--- a/man/stat_friedman_test.Rd
+++ b/man/stat_friedman_test.Rd
@@ -102,8 +102,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style.
 One of: \code{"default"} (backward compatible, uses scientific notation),

--- a/man/stat_kruskal_test.Rd
+++ b/man/stat_kruskal_test.Rd
@@ -97,8 +97,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style.
 One of: \code{"default"} (backward compatible, uses scientific notation),

--- a/man/stat_welch_anova_test.Rd
+++ b/man/stat_welch_anova_test.Rd
@@ -97,8 +97,9 @@ value (not recommended), use p.adjust.method = "none".}
  \code{*}: p <= 0.05 \item \code{**}: p <= 0.01 \item \code{***}: p <= 0.001
  \item \code{****}:  p <= 0.0001 }
 
- Note: \code{significance} is kept for backward compatibility. If provided,
- it takes precedence over \code{signif.cutoffs} and related parameters.}
+ Note: \code{significance} is kept for backward compatibility. For functions
+ that also expose \code{signif.cutoffs} and related parameters,
+ \code{significance} takes precedence when provided.}
 
 \item{p.format.style}{character string specifying the p-value formatting style.
 One of: \code{"default"} (backward compatible, uses scientific notation),

--- a/tests/testthat/test-add_stat_label.R
+++ b/tests/testthat/test-add_stat_label.R
@@ -165,6 +165,34 @@ test_that("add_stat_label works with Kruskal-Wallis stats label formats", {
 })
 
 
+test_that("add_stat_label works with Welch ANOVA detailed label formats", {
+  res <- data.frame(
+    stringsAsFactors = FALSE,
+    x = c("1"),
+    y = c(36.4),
+    n = c(60L),
+    statistic = c(45.57),
+    DFn = c(2),
+    DFd = c(37.7432475430268),
+    p = c(1.23e-10),
+    method = c("Welch Anova"),
+    p.adj = c(1.23e-10),
+    p.signif = c("****"),
+    p.adj.signif = c("****"),
+    p.format = c("<0.0001"),
+    p.adj.format = c("<0.0001")
+  )
+  res.detailed <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed"))
+  res.detailed.italic <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed_italic"))
+  res.detailed.expression <- add_stat_label(res, label = get_welch_anova_test_label_template("as_detailed_expression"))
+
+  expect_equal(res.detailed$label, "Welch Anova, F(2, 37.7432475430268) = 45.57, p < 0.0001, n = 60")
+  expect_equal(res.detailed.italic$label, "list(Welch~Anova,~italic(F)('2',~'37.7432475430268')~`=`~'45.57',~italic(p)~`<`~'0.0001',~italic(n)~`=`~'60')")
+  expect_equal(res.detailed.expression$label, "list(Welch~Anova,~italic(F)('2',~'37.7432475430268')~`=`~'45.57',~italic(p)~`<`~'0.0001',~italic(n)~`=`~'60')")
+  expect_false(any(grepl("FALSE", c(res.detailed.italic$label, res.detailed.expression$label), fixed = TRUE)))
+})
+
+
 # Tests for build_symnum_args helper function
 test_that("build_symnum_args uses symnum.args when provided (backward compatibility)", {
   result <- build_symnum_args(


### PR DESCRIPTION
Hi, you did an amazing job on the new release. These are some thoughts to the new dev version. Please take a look into them

I found one small label-output bug and several documentation mismatches while reviewing the current development version. The Welch ANOVA detailed labels were using the wrong field for the F statistic, which could make the plotted label show `FALSE` instead of the numeric F value. This changes those templates to use the statistic field and adds a regression test.

The remaining changes clarify documentation so it matches existing behavior: `ggmaplot()` faceting, `ggtheme` defaults, p-value threshold defaults, `stat_compare_means()` label separators, `stat_cor()` p-value display precision, inherited significance-legend wording, and the package description's list of p-value formatting styles. I also removed a dead `ggmaplot()` legend assignment that was not used by the plot.

Validation run from a clean publication worktree:

- `devtools::test(reporter = "summary")`
- `check-as-cran.sh` with local CRAN-style checks

The final local CRAN-style check passed with one existing NOTE: the `Date` field is over a month old. Remote CRAN incoming index checks were disabled because `CRAN.R-project.org` was unreachable from this local environment during validation.
