### PR TITLE
Require rstatix (>= 1.1.0) and add dev Remotes for it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     glue,
     polynom,
     rlang (>= 1.1.7),
-    rstatix (>= 1.0.0),
+    rstatix (>= 1.1.0),
     tibble,
     magrittr
 Suggests:
@@ -51,6 +51,8 @@ Suggests:
     RColorBrewer,
     gtable,
     testthat
+Remotes:
+    kassambara/rstatix@release/1.1.0
 URL: https://rpkgs.datanovia.com/ggpubr/,
     https://github.com/kassambara/ggpubr
 BugReports: https://github.com/kassambara/ggpubr/issues


### PR DESCRIPTION
## What changed

- Bump the rstatix dependency floor: `Imports: rstatix (>= 1.1.0)`.
- Add a development-only `Remotes: kassambara/rstatix@release/1.1.0` so dev installs can resolve rstatix 1.1.0 (not yet on CRAN) from GitHub.

## Why

rstatix 1.1.0 adds the pairwise effect-size column (`cohens.d`/`cliff.delta`/`r`) and `cliff_delta()`, which upcoming ggpubr annotation features build on.

## User-facing effect

None on existing output — this is a dependency/metadata change only. No R code paths change.

## CRAN note

`Remotes:` is a development convenience ignored by CRAN and not permitted in a CRAN submission. Before any ggpubr CRAN submission, rstatix 1.1.0 must be on CRAN and this `Remotes:` line removed (keeping the `>= 1.1.0` floor). Until then ggpubr's floor is only satisfiable via the Remote, which is expected during development.
