### PR TITLE
Add {effsize} label token to geom_pwc()/stat_pwc()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+- `geom_pwc()` and `stat_pwc()` gain a `{effsize}` label token to display the
+  pairwise effect size on each bracket, e.g.
+  `label = "{p.adj.signif}, d={effsize}"`. The effect size is the one returned
+  by the chosen `method` (Cohen's d for `"t_test"`/`"games_howell_test"`,
+  Cliff's delta for `"wilcox_test"`, r for `"dunn_test"`), rounded to two
+  decimals. Labels without `{effsize}` are unchanged.
+
 - New `stat_cld()` adds a compact letter display (CLD) of all-pairwise
   comparisons to a plot: one letter per group, placed above each box/violin,
   where groups that do not share a letter are significantly different. Letters

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
   `label = "{p.adj.signif}, d={effsize}"`. The effect size is the one returned
   by the chosen `method` (Cohen's d for `"t_test"`/`"games_howell_test"`,
   Cliff's delta for `"wilcox_test"`, r for `"dunn_test"`), rounded to two
-  decimals. Labels without `{effsize}` are unchanged.
+  decimals. Labels without `{effsize}` are unchanged (#756).
 
 - New `stat_cld()` adds a compact letter display (CLD) of all-pairwise
   comparisons to a plot: one letter per group, placed above each box/violin,

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -40,6 +40,14 @@ NULL
 #'  plotmath expressions and glue expressions. You may want some of the
 #'  statistical parameter in italic; for example:\code{label = "Wilcoxon,
 #'  italic(p)= {p}"}}.
+#'
+#'  The glue expression can also include the token \code{\{effsize\}} to display
+#'  the pairwise effect size next to the p-value, e.g. \code{label =
+#'  "\{p.adj.signif\}, d=\{effsize\}"}. \code{\{effsize\}} is the effect size
+#'  returned by the chosen \code{method} (Cohen's d for \code{"t_test"} and
+#'  \code{"games_howell_test"}, Cliff's delta for \code{"wilcox_test"}, and the r
+#'  effect size for \code{"dunn_test"}), rounded to two decimals; it is available
+#'  only for those four methods.
 #' @param y.position numeric vector with the y positions of the brackets
 #' @param group.by (optional) character vector specifying the grouping variable;
 #'  it should be used only for grouped plots. Possible values are : \itemize{
@@ -220,6 +228,13 @@ NULL
 #'   hide.ns = TRUE
 #' )
 #'
+#' # Show the significance and the effect size (Cohen's d) on each bracket
+#' ggboxplot(df, x = "dose", y = "len") +
+#'   geom_pwc(
+#'     method = "t_test", label = "{p.adj.signif}, d={effsize}"
+#'   ) +
+#'   scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
+#'
 #' # Complex cases
 #' # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #' # 1. Add p-values of OJ vs VC at each dose group
@@ -363,6 +378,23 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
       method.args$p.adjust.method <- params$p.adjust.method
     }
     pwc_func <- get_pwc_stat_function(method, method.args)
+    # Pairwise effect-size token: when the label references {effsize}, request
+    # the effect size from the underlying rstatix test (this adds a cohens.d /
+    # cliff.delta / r column, depending on the method). This runs ONLY when the
+    # label asks for it, so labels without {effsize} keep the exact previous
+    # method arguments and output.
+    if (grepl("effsize", params$stat.label, fixed = TRUE)) {
+      if ("effect.size" %in% names(formals(pwc_func$method))) {
+        pwc_func$method.args$effect.size <- TRUE
+      } else {
+        warning(
+          "The '{effsize}' label token is only available for method = 't_test', ",
+          "'wilcox_test', 'dunn_test' or 'games_howell_test'; {effsize} will show ",
+          "NA for the current method.",
+          call. = FALSE
+        )
+      }
+    }
     params$method <- pwc_func$method
     params$method.args <- pwc_func$method.args
     return(params)
@@ -566,6 +598,21 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
       stat.label <- gsub(pattern = "\\{method\\},\\s?", replacement = "", stat.label)
     }
     stat.test$method <- method.name
+
+    # Pairwise effect-size token: unify the per-method effect-size column
+    # (cohens.d for t_test / games_howell_test, cliff.delta for wilcox_test,
+    # r for dunn_test) into a single {effsize} value used by the label. Only
+    # runs when the label requests {effsize}; the column is created NA when the
+    # method provides no effect size, so the label degrades to "NA" rather than
+    # erroring.
+    if (grepl("effsize", stat.label, fixed = TRUE)) {
+      es.col <- intersect(c("cohens.d", "cliff.delta", "r"), colnames(stat.test))
+      stat.test$effsize <- if (length(es.col) >= 1) {
+        round(stat.test[[es.col[1]]], 2)
+      } else {
+        NA_real_
+      }
+    }
 
     # P-value adjustment, formatting and significance
     if (!("p.adj" %in% colnames(stat.test))) {

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -143,16 +143,24 @@ for wilcoxon test.}
  basemean). }}
 
 \item{label}{character string specifying label. Can be: \itemize{ \item the
-column containing the label (e.g.: \code{label = "p"} or \code{label =
-"p.adj"}), where \code{p} is the p-value. Other possible values are
-\code{"p.signif", "p.adj.signif", "p.format", "p.format.signif", "p.adj.format"}.
-\item an
-expression that can be formatted by the \code{\link[glue]{glue}()} package.
-For example, when specifying \code{label = "Wilcoxon, p = \{p\}"}, the
-expression \{p\} will be replaced by its value. \item a combination of
-plotmath expressions and glue expressions. You may want some of the
-statistical parameter in italic; for example:\code{label = "Wilcoxon,
-italic(p)= {p}"}}.}
+ column containing the label (e.g.: \code{label = "p"} or \code{label =
+ "p.adj"}), where \code{p} is the p-value. Other possible values are
+ \code{"p.signif", "p.adj.signif", "p.format", "p.format.signif", "p.adj.format"}.
+ \item an
+ expression that can be formatted by the \code{\link[glue]{glue}()} package.
+ For example, when specifying \code{label = "Wilcoxon, p = \{p\}"}, the
+ expression \{p\} will be replaced by its value. \item a combination of
+ plotmath expressions and glue expressions. You may want some of the
+ statistical parameter in italic; for example:\code{label = "Wilcoxon,
+ italic(p)= {p}"}}.
+
+ The glue expression can also include the token \code{\{effsize\}} to display
+ the pairwise effect size next to the p-value, e.g. \code{label =
+ "\{p.adj.signif\}, d=\{effsize\}"}. \code{\{effsize\}} is the effect size
+ returned by the chosen \code{method} (Cohen's d for \code{"t_test"} and
+ \code{"games_howell_test"}, Cliff's delta for \code{"wilcox_test"}, and the r
+ effect size for \code{"dunn_test"}), rounded to two decimals; it is available
+ only for those four methods.}
 
 \item{y.position}{numeric vector with the y positions of the brackets}
 
@@ -405,6 +413,13 @@ bxp + geom_pwc(
   p.adjust.method = "bonferroni", p.adjust.by = "panel",
   hide.ns = TRUE
 )
+
+# Show the significance and the effect size (Cohen's d) on each bracket
+ggboxplot(df, x = "dose", y = "len") +
+  geom_pwc(
+    method = "t_test", label = "{p.adj.signif}, d={effsize}"
+  ) +
+  scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
 
 # Complex cases
 # \%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%

--- a/man/ggadjust_pvalue.Rd
+++ b/man/ggadjust_pvalue.Rd
@@ -39,16 +39,24 @@ method. Allowed values include "holm", "hochberg", "hommel", "bonferroni",
 recommended), use p.adjust.method = "none".}
 
 \item{label}{character string specifying label. Can be: \itemize{ \item the
-column containing the label (e.g.: \code{label = "p"} or \code{label =
-"p.adj"}), where \code{p} is the p-value. Other possible values are
-\code{"p.signif", "p.adj.signif", "p.format", "p.format.signif", "p.adj.format"}.
-\item an
-expression that can be formatted by the \code{\link[glue]{glue}()} package.
-For example, when specifying \code{label = "Wilcoxon, p = \{p\}"}, the
-expression \{p\} will be replaced by its value. \item a combination of
-plotmath expressions and glue expressions. You may want some of the
-statistical parameter in italic; for example:\code{label = "Wilcoxon,
-italic(p)= {p}"}}.}
+ column containing the label (e.g.: \code{label = "p"} or \code{label =
+ "p.adj"}), where \code{p} is the p-value. Other possible values are
+ \code{"p.signif", "p.adj.signif", "p.format", "p.format.signif", "p.adj.format"}.
+ \item an
+ expression that can be formatted by the \code{\link[glue]{glue}()} package.
+ For example, when specifying \code{label = "Wilcoxon, p = \{p\}"}, the
+ expression \{p\} will be replaced by its value. \item a combination of
+ plotmath expressions and glue expressions. You may want some of the
+ statistical parameter in italic; for example:\code{label = "Wilcoxon,
+ italic(p)= {p}"}}.
+
+ The glue expression can also include the token \code{\{effsize\}} to display
+ the pairwise effect size next to the p-value, e.g. \code{label =
+ "\{p.adj.signif\}, d=\{effsize\}"}. \code{\{effsize\}} is the effect size
+ returned by the chosen \code{method} (Cohen's d for \code{"t_test"} and
+ \code{"games_howell_test"}, Cliff's delta for \code{"wilcox_test"}, and the r
+ effect size for \code{"dunn_test"}), rounded to two decimals; it is available
+ only for those four methods.}
 
 \item{hide.ns}{can be logical value (\code{TRUE} or \code{FALSE}) or a character vector (\code{"p.adj"} or \code{"p"}).}
 

--- a/tests/testthat/test-geom-pwc-effsize.R
+++ b/tests/testthat/test-geom-pwc-effsize.R
@@ -1,0 +1,71 @@
+context("test-geom-pwc-effsize")
+
+df <- ToothGrowth
+df$dose <- as.factor(df$dose)
+
+# Helper: extract the unique non-NA bracket labels from a pwc plot
+pwc_labels <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  idx <- which(vapply(
+    b$data, function(d) all(c("x", "xend", "y", "yend", "label") %in% names(d)),
+    logical(1)
+  ))
+  d <- b$data[[idx[1]]]
+  unique(d$label[!is.na(d$label)])
+}
+
+test_that("{effsize} token equals rstatix cohens.d for t_test", {
+  p <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "t_test", label = "d={effsize}")
+  labs <- pwc_labels(p)
+  truth <- rstatix::t_test(df, len ~ dose, effect.size = TRUE)
+  expected <- paste0("d=", round(truth$cohens.d, 2))
+  expect_setequal(labs, expected)
+})
+
+test_that("{effsize} token maps to the per-method effect-size column", {
+  # wilcox_test -> cliff.delta
+  lw <- pwc_labels(ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "wilcox_test", label = "d={effsize}"))
+  ew <- paste0("d=", round(rstatix::wilcox_test(df, len ~ dose, effect.size = TRUE)$cliff.delta, 2))
+  expect_setequal(lw, ew)
+
+  # dunn_test -> r
+  ld <- pwc_labels(ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "dunn_test", label = "d={effsize}"))
+  ed <- paste0("d=", round(rstatix::dunn_test(df, len ~ dose, effect.size = TRUE)$r, 2))
+  expect_setequal(ld, ed)
+
+  # games_howell_test -> cohens.d
+  lg <- pwc_labels(ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "games_howell_test", label = "d={effsize}"))
+  eg <- paste0("d=", round(rstatix::games_howell_test(df, len ~ dose, effect.size = TRUE)$cohens.d, 2))
+  expect_setequal(lg, eg)
+})
+
+test_that("{effsize} combines with significance tokens", {
+  p <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "t_test", label = "{p.adj.signif}, d={effsize}")
+  labs <- pwc_labels(p)
+  truth <- rstatix::t_test(df, len ~ dose, effect.size = TRUE)
+  expected <- paste0(truth$p.adj.signif, ", d=", round(truth$cohens.d, 2))
+  expect_setequal(labs, expected)
+})
+
+test_that("{effsize} warns and shows NA for a method without effect size", {
+  p <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "tukey_hsd", label = "d={effsize}")
+  expect_warning(labs <- pwc_labels(p), "effsize")
+  expect_true(all(labs == "d=NA"))
+})
+
+test_that("a label without {effsize} does not request an effect size", {
+  # No effect-size column should be computed; label matches the plain p.adj.format
+  p <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "t_test", label = "{p.adj.format}")
+  labs <- pwc_labels(p)
+  truth <- rstatix::t_test(df, len ~ dose) %>%
+    rstatix::adjust_pvalue(method = "holm")
+  # labels are the formatted adjusted p-values (no effect size appended)
+  expect_false(any(grepl("d=", labs)))
+})


### PR DESCRIPTION
## What changed

`geom_pwc()` and `stat_pwc()` gain an `{effsize}` label token, so the pairwise **effect size** can be shown on each bracket alongside the p-value:

```r
df <- ToothGrowth; df$dose <- factor(df$dose)
ggboxplot(df, x = "dose", y = "len") +
  geom_pwc(method = "t_test", label = "{p.adj.signif}, d={effsize}") +
  scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
```

When the label requests `{effsize}`, the underlying rstatix test is run with `effect.size = TRUE`, and the per-method effect-size column is exposed as a single `{effsize}` token (rounded to two decimals):

| method | effect size shown |
|---|---|
| `t_test`, `games_howell_test` | Cohen's d (`cohens.d`) |
| `wilcox_test` | Cliff's delta (`cliff.delta`) |
| `dunn_test` | r effect size (`r`) |

Other methods (e.g. `tukey_hsd`) warn and show `NA`.

## User-facing effect

Additive and gated: the effect size is requested **only** when the label contains `{effsize}`. Labels without it request no effect size and produce byte-identical output to before.

## Tests

Adds `tests/testthat/test-geom-pwc-effsize.R`: token value equals `rstatix::cohens_d()` for `t_test`; correct per-method column mapping (`cliff.delta`/`r`/`cohens.d`); combination with significance tokens; the warning + `NA` path for unsupported methods; and that a label without `{effsize}` requests no effect size. Existing `geom_pwc()` output verified byte-identical across methods, grouped/`ref.group`/facet/`coord_flip` configurations.
