### PR TITLE
Add pack argument to geom_pwc()/stat_pwc() for compact brackets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+- `geom_pwc()` and `stat_pwc()` gain a `pack` argument. With `pack = "auto"`,
+  pairwise comparison brackets are packed onto the fewest possible levels so
+  that comparisons whose x-spans do not overlap share a level, keeping the
+  annotation compact while guaranteeing that no two brackets on the same level
+  overlap within a panel. The default `pack = "none"` keeps the previous
+  one-bracket-per-level stacking, so existing plots are unchanged (#757).
+
 - `geom_pwc()` and `stat_pwc()` gain a `{effsize}` label token to display the
   pairwise effect size on each bracket, e.g.
   `label = "{p.adj.signif}, d={effsize}"`. The effect size is the one returned

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -846,12 +846,16 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
   shelf <- integer(n)
   for (i in ord) {
     placed <- FALSE
-    for (s in seq_along(shelf.right)) {
-      if (lo[i] >= shelf.right[s]) {
-        shelf[i] <- s
-        shelf.right[s] <- hi[i]
-        placed <- TRUE
-        break
+    # A bracket with an unknown (NA) span cannot be tested for overlap, so it is
+    # given its own shelf rather than risking a wrong placement.
+    if (!is.na(lo[i]) && !is.na(hi[i])) {
+      for (s in seq_along(shelf.right)) {
+        if (!is.na(shelf.right[s]) && lo[i] >= shelf.right[s]) {
+          shelf[i] <- s
+          shelf.right[s] <- hi[i]
+          placed <- TRUE
+          break
+        }
       }
     }
     if (!placed) {

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -72,6 +72,14 @@ NULL
 #'  include \code{"x.var"} and \code{"legend.var"}.
 #' @param step.increase numeric vector with the increase in fraction of total
 #'  height for every additional comparison to minimize overlap.
+#' @param pack how the pairwise brackets are stacked vertically within a panel.
+#'  \itemize{ \item \code{"none"} (default): one bracket per level, in the order
+#'  the comparisons are computed (the previous behavior). \item \code{"auto"}:
+#'  brackets are packed onto the fewest possible levels so that comparisons whose
+#'  x-spans do not overlap share a level. This keeps the annotation compact and
+#'  guarantees that no two brackets on the same level overlap within a panel;
+#'  the vertical spacing between levels is still controlled by
+#'  \code{step.increase} and \code{bracket.nudge.y}. }
 #' @param tip.length numeric vector with the fraction of total height that the
 #'  bar goes down to indicate the precise column/
 #' @param size change the width of the lines of the bracket
@@ -235,6 +243,14 @@ NULL
 #'   ) +
 #'   scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
 #'
+#' # Compactly pack many brackets so non-overlapping comparisons share a level
+#' ggboxplot(df, x = "dose", y = "len") +
+#'   geom_pwc(
+#'     method = "t_test", label = "p.adj.signif",
+#'     hide.ns = TRUE, pack = "auto"
+#'   ) +
+#'   scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
+#'
 #' # Complex cases
 #' # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #' # 1. Add p-values of OJ vs VC at each dose group
@@ -313,7 +329,8 @@ stat_pwc <- function(mapping = NULL, data = NULL,
                      signif.cutoffs = NULL, signif.symbols = NULL,
                      ns.symbol = "ns", use.four.stars = FALSE,
                      position = "identity", na.rm = FALSE, show.legend = NA,
-                     inherit.aes = TRUE, parse = FALSE, ...) {
+                     inherit.aes = TRUE, parse = FALSE, pack = c("none", "auto"), ...) {
+  pack <- match.arg(pack)
   # Build symnum.args from new parameters
   symnum.args <- build_symnum_args(
     signif.cutoffs = signif.cutoffs,
@@ -360,7 +377,7 @@ stat_pwc <- function(mapping = NULL, data = NULL,
       hide.ns = hide.ns, parse = parse,
       p.format.style = p.format.style, p.digits = p.digits,
       p.leading.zero = p.leading.zero, p.min.threshold = p.min.threshold,
-      p.decimal.mark = p.decimal.mark, ...
+      p.decimal.mark = p.decimal.mark, pack = pack, ...
     )
   )
 }
@@ -405,7 +422,7 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
                            p.adjust.method, p.adjust.by, p.adjust.n = NULL,
                            symnum.args, hide.ns, group.by, dodge, remove.bracket,
                            p.format.style, p.digits, p.leading.zero,
-                           p.min.threshold, p.decimal.mark) {
+                           p.min.threshold, p.decimal.mark, pack = "none") {
     # Compute the statistical tests
     df <- data %>% mutate(x = as.factor(.data$x))
     is.grouped.plots <- contains_multiple_grouping_vars(df)
@@ -727,6 +744,17 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
       }
     }
 
+    # Intra-panel bracket packing (opt-in). Reassign each bracket to the lowest
+    # vertical shelf on which it does not overlap another bracket, so
+    # non-overlapping comparisons share a level and the stack is as short as
+    # possible while staying collision-free within the panel. The default
+    # (pack = "none") keeps the previous one-shelf-per-comparison stacking.
+    if (identical(pack, "auto") && nrow(stat.test) > 1) {
+      bracket.group <- .pack_bracket_shelves(
+        as.numeric(stat.test$xmin), as.numeric(stat.test$xmax)
+      )
+    }
+
     # Parameters for customizing brackets
     group <- 1
     if (nrow(stat.test) > 1) group <- seq_len(nrow(stat.test))
@@ -797,6 +825,44 @@ StatPwc <- ggplot2::ggproto("StatPwc", ggplot2::Stat,
 }
 
 
+# Greedy interval-graph packing of pairwise-comparison brackets. Assigns each
+# bracket (x-span [xmin, xmax]) to the lowest vertical "shelf" (1-based) such
+# that brackets sharing a shelf never have overlapping x-spans, so the stack is
+# as short as possible while remaining collision-free within a panel. Processing
+# brackets left-to-right and placing each on the first shelf whose current right
+# edge is at or before the bracket's left edge is the classic first-fit interval
+# colouring, which uses the minimum number of shelves. Touching spans (one
+# bracket's xmax equal to the next's xmin) may share a shelf. Returns an integer
+# shelf index per input bracket, in the original order.
+.pack_bracket_shelves <- function(xmin, xmax) {
+  n <- length(xmin)
+  if (n <= 1) {
+    return(rep(1L, n))
+  }
+  lo <- pmin(xmin, xmax)
+  hi <- pmax(xmin, xmax)
+  ord <- order(lo, hi)
+  shelf.right <- numeric(0) # current rightmost edge on each open shelf
+  shelf <- integer(n)
+  for (i in ord) {
+    placed <- FALSE
+    for (s in seq_along(shelf.right)) {
+      if (lo[i] >= shelf.right[s]) {
+        shelf[i] <- s
+        shelf.right[s] <- hi[i]
+        placed <- TRUE
+        break
+      }
+    }
+    if (!placed) {
+      shelf.right <- c(shelf.right, hi[i])
+      shelf[i] <- length(shelf.right)
+    }
+  }
+  shelf
+}
+
+
 #' @rdname geom_pwc
 #' @export
 geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
@@ -815,7 +881,9 @@ geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
                      signif.cutoffs = NULL, signif.symbols = NULL,
                      ns.symbol = "ns", use.four.stars = FALSE,
                      position = "identity", na.rm = FALSE,
-                     show.legend = NA, inherit.aes = TRUE, parse = FALSE, ...) {
+                     show.legend = NA, inherit.aes = TRUE, parse = FALSE,
+                     pack = c("none", "auto"), ...) {
+  pack <- match.arg(pack)
   # Build symnum.args from new parameters
   symnum.args <- build_symnum_args(
     signif.cutoffs = signif.cutoffs,
@@ -868,7 +936,7 @@ geom_pwc <- function(mapping = NULL, data = NULL, stat = "pwc",
       p.format.style = p.format.style, p.digits = p.digits,
       p.leading.zero = p.leading.zero, p.min.threshold = p.min.threshold,
       p.decimal.mark = p.decimal.mark,
-      parse = parse,
+      parse = parse, pack = pack,
       ...
     )
   )

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -45,6 +45,7 @@ stat_pwc(
   show.legend = NA,
   inherit.aes = TRUE,
   parse = FALSE,
+  pack = c("none", "auto"),
   ...
 )
 
@@ -90,6 +91,7 @@ geom_pwc(
   show.legend = NA,
   inherit.aes = TRUE,
   parse = FALSE,
+  pack = c("none", "auto"),
   ...
 )
 }
@@ -321,6 +323,15 @@ shouldn't inherit behaviour from the default plot specification. Set to
 
 \item{parse}{logical for parsing plotmath expression.}
 
+\item{pack}{how the pairwise brackets are stacked vertically within a panel.
+\itemize{ \item \code{"none"} (default): one bracket per level, in the order
+the comparisons are computed (the previous behavior). \item \code{"auto"}:
+brackets are packed onto the fewest possible levels so that comparisons whose
+x-spans do not overlap share a level. This keeps the annotation compact and
+guarantees that no two brackets on the same level overlap within a panel;
+the vertical spacing between levels is still controlled by
+\code{step.increase} and \code{bracket.nudge.y}. }}
+
 \item{...}{other arguments passed on to \code{\link[ggplot2]{layer}()}). These are often
 aesthetics, used to set an aesthetic to a fixed value, like \code{color =
 "red"} or \code{size = 3}. They may also be parameters to the paired
@@ -418,6 +429,14 @@ bxp + geom_pwc(
 ggboxplot(df, x = "dose", y = "len") +
   geom_pwc(
     method = "t_test", label = "{p.adj.signif}, d={effsize}"
+  ) +
+  scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
+
+# Compactly pack many brackets so non-overlapping comparisons share a level
+ggboxplot(df, x = "dose", y = "len") +
+  geom_pwc(
+    method = "t_test", label = "p.adj.signif",
+    hide.ns = TRUE, pack = "auto"
   ) +
   scale_y_continuous(expand = expansion(mult = c(0.05, 0.15)))
 

--- a/tests/testthat/test-geom-pwc-pack.R
+++ b/tests/testthat/test-geom-pwc-pack.R
@@ -1,0 +1,96 @@
+context("test-geom-pwc-pack")
+
+# One row per bracket: its x-span and its shelf (y) level.
+bracket_shelves <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  idx <- which(vapply(
+    b$data, function(d) all(c("x", "xend", "y", "yend", "group") %in% names(d)),
+    logical(1)
+  ))
+  d <- b$data[[idx[1]]]
+  do.call(rbind, lapply(split(d, d$group), function(g) {
+    data.frame(xmin = min(g$x, g$xend), xmax = max(g$x, g$xend), y = max(g$y))
+  }))
+}
+
+strict_overlap <- function(a, b) a$xmin < b$xmax & b$xmin < a$xmax
+
+# ---- helper unit tests -----------------------------------------------------
+test_that(".pack_bracket_shelves uses the minimum number of shelves", {
+  # 6 groups -> all-pairwise x-spans; max overlap depth (max clique) at the
+  # centre is 9, so an optimal packing uses exactly 9 shelves.
+  combos <- t(utils::combn(6, 2))
+  xmin <- combos[, 1]
+  xmax <- combos[, 2]
+  shelves <- ggpubr:::.pack_bracket_shelves(xmin, xmax)
+  expect_equal(max(shelves), 9)
+  # No two brackets on the same shelf may strictly overlap.
+  for (s in unique(shelves)) {
+    idx <- which(shelves == s)
+    if (length(idx) > 1) {
+      for (i in seq_along(idx)[-length(idx)]) {
+        for (j in (i + 1):length(idx)) {
+          a <- idx[i]
+          b <- idx[j]
+          expect_false(xmin[a] < xmax[b] && xmin[b] < xmax[a])
+        }
+      }
+    }
+  }
+})
+
+test_that(".pack_bracket_shelves lets touching spans share a shelf", {
+  # [1,2] and [2,3] touch but do not overlap -> same shelf.
+  shelves <- ggpubr:::.pack_bracket_shelves(c(1, 2), c(2, 3))
+  expect_equal(length(unique(shelves)), 1)
+})
+
+# ---- integration tests -----------------------------------------------------
+set.seed(1)
+df6 <- data.frame(
+  g = factor(rep(1:6, each = 12)),
+  y = rnorm(72, rep(1:6, each = 12))
+)
+
+test_that("pack = 'auto' produces no overlapping brackets on the same shelf", {
+  p <- ggboxplot(df6, x = "g", y = "y") +
+    geom_pwc(method = "t_test", pack = "auto")
+  agg <- bracket_shelves(p)
+  bad <- 0
+  for (yy in unique(agg$y)) {
+    s <- agg[agg$y == yy, ]
+    if (nrow(s) > 1) {
+      for (i in seq_len(nrow(s) - 1)) {
+        for (j in (i + 1):nrow(s)) {
+          if (strict_overlap(s[i, ], s[j, ])) bad <- bad + 1
+        }
+      }
+    }
+  }
+  expect_equal(bad, 0)
+})
+
+test_that("pack = 'auto' compacts the stack versus the default", {
+  p_none <- ggboxplot(df6, x = "g", y = "y") +
+    geom_pwc(method = "t_test")
+  p_auto <- ggboxplot(df6, x = "g", y = "y") +
+    geom_pwc(method = "t_test", pack = "auto")
+  n_none <- length(unique(round(bracket_shelves(p_none)$y, 6)))
+  n_auto <- length(unique(round(bracket_shelves(p_auto)$y, 6)))
+  expect_equal(n_none, 15) # one shelf per comparison
+  expect_equal(n_auto, 9) # optimal packing for 6 groups
+  expect_lt(n_auto, n_none)
+})
+
+test_that("pack default is 'none' and leaves bracket y-positions unchanged", {
+  df <- ToothGrowth
+  df$dose <- factor(df$dose)
+  p_default <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "wilcox_test")
+  p_explicit <- ggboxplot(df, x = "dose", y = "len") +
+    geom_pwc(method = "wilcox_test", pack = "none")
+  b_default <- ggplot2::ggplot_build(p_default)$data[[2]]
+  b_explicit <- ggplot2::ggplot_build(p_explicit)$data[[2]]
+  expect_equal(b_default$y, b_explicit$y)
+  expect_equal(b_default$x, b_explicit$x)
+})

--- a/tests/testthat/test-geom-pwc-pack.R
+++ b/tests/testthat/test-geom-pwc-pack.R
@@ -45,6 +45,16 @@ test_that(".pack_bracket_shelves lets touching spans share a shelf", {
   expect_equal(length(unique(shelves)), 1)
 })
 
+test_that(".pack_bracket_shelves handles NA spans without erroring", {
+  # An NA span must not crash; it is given its own shelf and must not disturb
+  # the packing of the well-defined spans ([1,2] and [3,4] still share a shelf).
+  shelves <- ggpubr:::.pack_bracket_shelves(c(1, NA, 3), c(2, 4, 4))
+  expect_length(shelves, 3)
+  expect_false(anyNA(shelves))
+  expect_equal(shelves[1], shelves[3])
+  expect_false(shelves[2] %in% shelves[c(1, 3)])
+})
+
 # ---- integration tests -----------------------------------------------------
 set.seed(1)
 df6 <- data.frame(


### PR DESCRIPTION
## What changed

`geom_pwc()` and `stat_pwc()` gain a `pack` argument controlling how pairwise comparison brackets stack vertically within a panel.

- `pack = "none"` (default) — one bracket per level, in computation order (previous behavior).
- `pack = "auto"` — brackets are packed onto the fewest possible levels so that comparisons whose x-spans do not overlap share a level. Compact, and guaranteed collision-free within a panel (first-fit interval-graph packing). Vertical spacing between levels is still controlled by `step.increase`/`bracket.nudge.y`.

```r
set.seed(1)
df <- data.frame(g = factor(rep(1:6, each = 12)), y = rnorm(72, rep(1:6, each = 12)))
ggboxplot(df, x = "g", y = "y") +
  geom_pwc(method = "t_test", label = "p.adj.signif", hide.ns = TRUE, pack = "auto") +
  scale_y_continuous(expand = expansion(mult = c(0.05, 0.25)))
```

For 6 groups (15 comparisons) this compacts the stack from 15 levels to 9 (the minimum possible).

## User-facing effect

Additive and gated: `pack = "none"` is the default, so existing plots are unchanged. The argument is appended at the end of the signature.

## Tests

Adds `tests/testthat/test-geom-pwc-pack.R`: the packing helper uses the minimum number of levels (equal to the maximum overlap depth) and never places overlapping brackets on the same level; touching spans may share a level; `pack = "auto"` yields no same-level overlaps and compacts 15→9 levels for 6 groups; and the default leaves bracket coordinates unchanged. Existing `geom_pwc()` rendered output is byte-identical (the only difference is the new stored `pack` default).
