### PR TITLE
Add rank-sum and direction-balanced top-gene labeling to ggmaplot() and ggvolcano()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+- `ggmaplot()` and `ggvolcano()` gain two opt-in options for choosing which
+  genes are labeled: `select.top.method = "rank.sum"` ranks by the sum of the
+  `|log2FC|` rank and the adjusted-p rank, so the labeled genes are both
+  high-effect and highly significant; and `top.balanced = TRUE` labels about
+  half up-regulated and half down-regulated genes (with spillover). The default
+  selection is unchanged (#762).
+
 - New `ggvolcano()` draws a publication-ready volcano plot of differential
   expression results: log2 fold change versus `-log10` of the (adjusted)
   p-value, with points colored as up/down/non-significant by fold-change and

--- a/R/ggmaplot.R
+++ b/R/ggmaplot.R
@@ -50,7 +50,9 @@ NULL
 #'  hide to gene labels.
 #' @param select.top.method methods to be used for selecting top genes. Allowed
 #'  values include "padj" and "fc" for selecting by adjusted p values or fold
-#'  changes, respectively.
+#'  changes, respectively; and "rank.sum", which ranks by the sum of the
+#'  \eqn{|log2FC|} rank and the adjusted-p rank so that the labeled genes are
+#'  those that are both high-effect and highly significant.
 #' @param label.select character vector specifying some labels to show.
 #' @param facet.by character vector, of length 1 or 2, specifying grouping
 #'   variables for faceting the plot into multiple panels (one MA plot per group).
@@ -64,6 +66,11 @@ NULL
 #'   \code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
 #'   theme, so the plot keeps ggplot2 default theme or the theme set globally via
 #'   \code{theme_set()}.
+#' @param top.balanced logical. If \code{TRUE}, the labeled top genes are
+#'   direction-balanced: about half up-regulated and half down-regulated (with
+#'   spillover into the other direction when one side has fewer genes), using
+#'   \code{select.top.method} to rank within each direction. Default
+#'   \code{FALSE} (top genes chosen regardless of direction).
 #' @param ... other arguments to be passed to \code{\link{ggpar}}.
 #' @return a ggplot.
 #' @examples
@@ -105,17 +112,23 @@ NULL
 #'   top = 0, label.select = c("BUB1", "CD83")
 #' )
 #'
+#' # Rank the labeled genes by effect AND significance, balanced up/down
+#' ggmaplot(diff_express,
+#'   fdr = 0.05, fc = 2, genenames = as.vector(diff_express$name),
+#'   top = 10, select.top.method = "rank.sum", top.balanced = TRUE
+#' )
+#'
 #' @export
 ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
                      detection_call = NULL, size = NULL, alpha = 1,
                      seed = 42,
                      font.label = c(12, "plain", "black"), label.rectangle = FALSE,
                      palette = c("#B31B21", "#1465AC", "darkgray"),
-                     top = 15, select.top.method = c("padj", "fc"),
+                     top = 15, select.top.method = c("padj", "fc", "rank.sum"),
                      label.select = NULL, facet.by = NULL,
                      main = NULL, xlab = "Log2 mean expression", ylab = "Log2 fold change",
                      line.color = "black",
-                     ggtheme = theme_classic(), ...) {
+                     ggtheme = theme_classic(), top.balanced = FALSE, ...) {
   if (!base::inherits(data, c("matrix", "data.frame", "DataFrame", "DE_Results", "DESeqResults"))) {
     stop("data must be an object of class matrix, data.frame, DataFrame, DE_Results or DESeqResults")
   }
@@ -207,7 +220,14 @@ ggmaplot <- function(data, fdr = 0.05, fc = 1.5, genenames = NULL,
   # select data for top genes
   complete_data <- stats::na.omit(data)
   labs_data <- subset(complete_data, padj <= fdr & name != "" & abs(lfc) >= log2(fc))
-  if (is.null(facet.by)) {
+  if (select.top.method == "rank.sum" || isTRUE(top.balanced)) {
+    # Opt-in ranking: rank-sum of |log2FC| and adjusted-p ranks and/or a
+    # direction-balanced pick. The default path below is left unchanged.
+    labs_data <- .select_top_de_labels(
+      labs_data, top = top, method = select.top.method,
+      balanced = top.balanced, facet.by = facet.by
+    )
+  } else if (is.null(facet.by)) {
     labs_data <- utils::head(labs_data, top)
   } else {
     # #498: select the top genes PER facet. `data` is already ordered by the

--- a/R/ggvolcano.R
+++ b/R/ggvolcano.R
@@ -32,7 +32,9 @@ NULL
 #' @param top the number of top hits to label. Default 15. Use \code{top = 0}
 #'   with \code{label.select} to label only specific genes.
 #' @param select.top.method the ranking used to pick the top hits, one of
-#'   \code{"padj"} (default) or \code{"fc"}.
+#'   \code{"padj"} (default), \code{"fc"}, or \code{"rank.sum"} (ranks by the sum
+#'   of the \eqn{|log2FC|} rank and the adjusted-p rank, so the labeled genes are
+#'   both high-effect and highly significant).
 #' @param label.select a character vector of specific gene names to label.
 #' @param facet.by character vector of grouping variable(s) for faceting; the top
 #'   hits are then selected within each panel.
@@ -41,6 +43,10 @@ NULL
 #'   built from \code{y} (e.g. \code{"-Log10 padj"}).
 #' @param line.color the color of the threshold lines. Default \code{"black"}.
 #' @param ggtheme a ggplot theme. Default \code{\link[ggplot2]{theme_classic}()}.
+#' @param top.balanced logical. If \code{TRUE}, the labeled top genes are
+#'   direction-balanced: about half up-regulated and half down-regulated (with
+#'   spillover when one side has fewer genes), ranked within each direction by
+#'   \code{select.top.method}. Default \code{FALSE}.
 #' @param ... other arguments passed to \code{\link{ggpar}()}.
 #' @return a ggplot.
 #' @seealso \code{\link{ggmaplot}}.
@@ -60,17 +66,24 @@ NULL
 #'   top = 0, label.select = c("BUB1", "CD83")
 #' )
 #'
+#' # Rank the labeled genes by effect AND significance, balanced up/down
+#' ggvolcano(diff_express,
+#'   fdr = 0.05, fc = 2, size = 0.6,
+#'   genenames = as.vector(diff_express$name),
+#'   top = 10, select.top.method = "rank.sum", top.balanced = TRUE
+#' )
+#'
 #' @export
 ggvolcano <- function(data, x = "log2FoldChange", y = "padj",
                       fdr = 0.05, fc = 1.5, genenames = NULL,
                       size = NULL, alpha = 1, seed = 42,
                       font.label = c(12, "plain", "black"), label.rectangle = FALSE,
                       palette = c("#B31B21", "#1465AC", "darkgray"),
-                      top = 15, select.top.method = c("padj", "fc"),
+                      top = 15, select.top.method = c("padj", "fc", "rank.sum"),
                       label.select = NULL, facet.by = NULL,
                       main = NULL, xlab = "Log2 fold change", ylab = NULL,
                       line.color = "black",
-                      ggtheme = theme_classic(), ...) {
+                      ggtheme = theme_classic(), top.balanced = FALSE, ...) {
   if (!base::inherits(data, c("matrix", "data.frame", "DataFrame", "DE_Results", "DESeqResults"))) {
     stop("data must be an object of class matrix, data.frame, DataFrame, DE_Results or DESeqResults")
   }
@@ -158,7 +171,14 @@ ggvolcano <- function(data, x = "log2FoldChange", y = "padj",
   }
   complete_data <- stats::na.omit(data)
   labs_data <- subset(complete_data, padj <= fdr & name != "" & abs(lfc) >= log2(fc))
-  if (is.null(facet.by)) {
+  if (select.top.method == "rank.sum" || isTRUE(top.balanced)) {
+    # Opt-in ranking: rank-sum of |log2FC| and adjusted-p ranks and/or a
+    # direction-balanced pick. The default path below is left unchanged.
+    labs_data <- .select_top_de_labels(
+      labs_data, top = top, method = select.top.method,
+      balanced = top.balanced, facet.by = facet.by
+    )
+  } else if (is.null(facet.by)) {
     labs_data <- utils::head(labs_data, top)
   } else {
     labs_data <- labs_data %>%

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -839,12 +839,13 @@ keep_only_tbl_df_classes <- function(x) {
     }
     up <- rank_pool(pool[pool$lfc > 0, , drop = FALSE])
     down <- rank_pool(pool[pool$lfc < 0, , drop = FALSE])
-    half <- ceiling(top / 2)
-    n_up_slots <- min(half, nrow(up))
-    n_down_slots <- min(half, nrow(down))
-    final_up <- min(nrow(up), top - n_down_slots) # spillover
-    final_down <- min(nrow(down), top - n_up_slots)
-    utils::head(rbind(utils::head(up, final_up), utils::head(down, final_down)), top)
+    # Allocate sequentially so the total is min(top, available) with no wasted
+    # slot: the extra (odd) slot goes to the up direction, then any remaining
+    # slots spill into the other direction when one side is short.
+    n_up <- min(ceiling(top / 2), nrow(up))
+    n_down <- min(nrow(down), top - n_up)
+    n_up <- min(nrow(up), top - n_down)
+    utils::head(rbind(utils::head(up, n_up), utils::head(down, n_down)), top)
   }
 
   if (is.null(facet.by)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -796,6 +796,66 @@ keep_only_tbl_df_classes <- function(x) {
 }
 
 
+# Rank a significance-gated differential-expression label pool (columns: name,
+# lfc, padj) and pick up to `top` rows, optionally direction-balanced and/or per
+# facet group. Used by ggmaplot()/ggvolcano() for the opt-in "rank.sum" method
+# and the top.balanced option; the default (method = "padj"/"fc",
+# top.balanced = FALSE) does NOT call this - it keeps the historical path.
+#
+# - method: ranking key. "padj" (ascending adjusted p), "fc" (descending
+#   |log2FC|), or "rank.sum" (rank of descending |log2FC| + rank of ascending
+#   padj, lowest wins - genes that are both high-effect AND highly significant).
+#   Ties are broken by larger |log2FC|.
+# - balanced: if TRUE, take ceil(top/2) up- and down-regulated genes with
+#   spillover when one direction is short (direction from sign(lfc)).
+# - facet.by: if not NULL, select within each facet group.
+# Returns the selected rows, best-first.
+.select_top_de_labels <- function(df, top, method = c("padj", "fc", "rank.sum"),
+                                   balanced = FALSE, facet.by = NULL) {
+  method <- match.arg(method)
+  if (nrow(df) == 0L || top <= 0L) {
+    return(df[0, , drop = FALSE])
+  }
+
+  rank_pool <- function(pool) {
+    if (nrow(pool) == 0L) {
+      return(pool)
+    }
+    ord <- switch(method,
+      padj = order(pool$padj, -abs(pool$lfc)),
+      fc = order(-abs(pool$lfc), pool$padj),
+      rank.sum = order(
+        rank(-abs(pool$lfc), ties.method = "first") +
+          rank(pool$padj, ties.method = "first"),
+        -abs(pool$lfc)
+      )
+    )
+    pool[ord, , drop = FALSE]
+  }
+
+  pick <- function(pool) {
+    if (!isTRUE(balanced)) {
+      return(utils::head(rank_pool(pool), top))
+    }
+    up <- rank_pool(pool[pool$lfc > 0, , drop = FALSE])
+    down <- rank_pool(pool[pool$lfc < 0, , drop = FALSE])
+    half <- ceiling(top / 2)
+    n_up_slots <- min(half, nrow(up))
+    n_down_slots <- min(half, nrow(down))
+    final_up <- min(nrow(up), top - n_down_slots) # spillover
+    final_down <- min(nrow(down), top - n_up_slots)
+    utils::head(rbind(utils::head(up, final_up), utils::head(down, final_down)), top)
+  }
+
+  if (is.null(facet.by)) {
+    return(pick(df))
+  }
+  groups <- do.call(paste, c(df[, facet.by, drop = FALSE], sep = "\r"))
+  parts <- lapply(split(df, groups), pick)
+  do.call(rbind, parts)
+}
+
+
 # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # Apply ggpubr functions on a data
 # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/man/ggmaplot.Rd
+++ b/man/ggmaplot.Rd
@@ -17,7 +17,7 @@ ggmaplot(
   label.rectangle = FALSE,
   palette = c("#B31B21", "#1465AC", "darkgray"),
   top = 15,
-  select.top.method = c("padj", "fc"),
+  select.top.method = c("padj", "fc", "rank.sum"),
   label.select = NULL,
   facet.by = NULL,
   main = NULL,
@@ -25,6 +25,7 @@ ggmaplot(
   ylab = "Log2 fold change",
   line.color = "black",
   ggtheme = theme_classic(),
+  top.balanced = FALSE,
   ...
 )
 }
@@ -89,7 +90,9 @@ hide to gene labels.}
 
 \item{select.top.method}{methods to be used for selecting top genes. Allowed
 values include "padj" and "fc" for selecting by adjusted p values or fold
-changes, respectively.}
+changes, respectively; and "rank.sum", which ranks by the sum of the
+\eqn{|log2FC|} rank and the adjusted-p rank so that the labeled genes are
+those that are both high-effect and highly significant.}
 
 \item{label.select}{character vector specifying some labels to show.}
 
@@ -115,6 +118,12 @@ at 0 and the two fold-change cutoff lines). Default is "black".}
 \code{theme_classic()}. Set \code{ggtheme = NULL} to skip applying a ggpubr
 theme, so the plot keeps ggplot2 default theme or the theme set globally via
 \code{theme_set()}.}
+
+\item{top.balanced}{logical. If \code{TRUE}, the labeled top genes are
+direction-balanced: about half up-regulated and half down-regulated (with
+spillover into the other direction when one side has fewer genes), using
+\code{select.top.method} to rank within each direction. Default
+\code{FALSE} (top genes chosen regardless of direction).}
 
 \item{...}{other arguments to be passed to \code{\link{ggpar}}.}
 }
@@ -164,6 +173,12 @@ ggmaplot(diff_express,
   genenames = as.vector(diff_express$name),
   ggtheme = ggplot2::theme_minimal(),
   top = 0, label.select = c("BUB1", "CD83")
+)
+
+# Rank the labeled genes by effect AND significance, balanced up/down
+ggmaplot(diff_express,
+  fdr = 0.05, fc = 2, genenames = as.vector(diff_express$name),
+  top = 10, select.top.method = "rank.sum", top.balanced = TRUE
 )
 
 }

--- a/man/ggvolcano.Rd
+++ b/man/ggvolcano.Rd
@@ -18,7 +18,7 @@ ggvolcano(
   label.rectangle = FALSE,
   palette = c("#B31B21", "#1465AC", "darkgray"),
   top = 15,
-  select.top.method = c("padj", "fc"),
+  select.top.method = c("padj", "fc", "rank.sum"),
   label.select = NULL,
   facet.by = NULL,
   main = NULL,
@@ -26,6 +26,7 @@ ggvolcano(
   ylab = NULL,
   line.color = "black",
   ggtheme = theme_classic(),
+  top.balanced = FALSE,
   ...
 )
 }
@@ -68,7 +69,9 @@ points, in that order. Default \code{c("#B31B21", "#1465AC", "darkgray")}.}
 with \code{label.select} to label only specific genes.}
 
 \item{select.top.method}{the ranking used to pick the top hits, one of
-\code{"padj"} (default) or \code{"fc"}.}
+\code{"padj"} (default), \code{"fc"}, or \code{"rank.sum"} (ranks by the sum
+of the \eqn{|log2FC|} rank and the adjusted-p rank, so the labeled genes are
+both high-effect and highly significant).}
 
 \item{label.select}{a character vector of specific gene names to label.}
 
@@ -83,6 +86,11 @@ built from \code{y} (e.g. \code{"-Log10 padj"}).}
 \item{line.color}{the color of the threshold lines. Default \code{"black"}.}
 
 \item{ggtheme}{a ggplot theme. Default \code{\link[ggplot2]{theme_classic}()}.}
+
+\item{top.balanced}{logical. If \code{TRUE}, the labeled top genes are
+direction-balanced: about half up-regulated and half down-regulated (with
+spillover when one side has fewer genes), ranked within each direction by
+\code{select.top.method}. Default \code{FALSE}.}
 
 \item{...}{other arguments passed to \code{\link{ggpar}()}.}
 }
@@ -111,6 +119,13 @@ ggvolcano(diff_express,
   fdr = 0.05, fc = 2, size = 0.6,
   genenames = as.vector(diff_express$name),
   top = 0, label.select = c("BUB1", "CD83")
+)
+
+# Rank the labeled genes by effect AND significance, balanced up/down
+ggvolcano(diff_express,
+  fdr = 0.05, fc = 2, size = 0.6,
+  genenames = as.vector(diff_express$name),
+  top = 10, select.top.method = "rank.sum", top.balanced = TRUE
 )
 
 }

--- a/tests/testthat/test-de-top-gene-ranking.R
+++ b/tests/testthat/test-de-top-gene-ranking.R
@@ -1,0 +1,83 @@
+context("test-de-top-gene-ranking")
+
+# Extract the labeled gene names (the ggrepel layer's data).
+labelled <- function(p) {
+  i <- which(vapply(p$layers, function(l) grepl("Repel", class(l$geom)[1]), logical(1)))
+  as.character(p$layers[[i[1]]]$data$name)
+}
+
+# ---- .select_top_de_labels() port fidelity ---------------------------------
+test_that(".select_top_de_labels ranks by rank-sum of |lfc| and padj", {
+  # g1: biggest effect but weakest p; g4: strongest p but smallest effect; g2/g3
+  # are moderate on both. Rank-sum should favor the both-strong genes.
+  df <- data.frame(
+    name = c("g1", "g2", "g3", "g4"),
+    lfc = c(5.0, 3.0, 2.5, 1.1),
+    padj = c(1e-3, 1e-8, 1e-7, 1e-30)
+  )
+  out <- ggpubr:::.select_top_de_labels(df, top = 2, method = "rank.sum")
+  # rank-sum scores: g1 fc1+padj4=5; g2 fc2+padj2=4; g3 fc3+padj3=6; g4 fc4+padj1=5
+  # -> g2 (4) best, then g1/g4 tie at 5 broken by larger |lfc| -> g1
+  expect_equal(out$name, c("g2", "g1"))
+})
+
+test_that(".select_top_de_labels balances direction with spillover", {
+  df <- data.frame(
+    name = c("u1", "u2", "u3", "d1"),
+    lfc = c(2, 3, 4, -2),
+    padj = c(1e-4, 1e-5, 1e-6, 1e-4)
+  )
+  # top = 4, only 1 down gene -> 3 up + 1 down (spillover into up)
+  out <- ggpubr:::.select_top_de_labels(df, top = 4, method = "padj", balanced = TRUE)
+  expect_equal(sum(out$lfc > 0), 3)
+  expect_equal(sum(out$lfc < 0), 1)
+})
+
+test_that(".select_top_de_labels selects within each facet group", {
+  df <- data.frame(
+    name = c("a1", "a2", "b1", "b2"),
+    lfc = c(3, 2, 3, 2),
+    padj = c(1e-5, 1e-4, 1e-5, 1e-4),
+    grp = c("A", "A", "B", "B")
+  )
+  out <- ggpubr:::.select_top_de_labels(df, top = 1, method = "padj", facet.by = "grp")
+  expect_equal(nrow(out), 2) # one per group
+  expect_setequal(out$grp, c("A", "B"))
+})
+
+# ---- integration in ggmaplot / ggvolcano -----------------------------------
+de <- data.frame(
+  name = paste0("g", 1:6),
+  baseMean = 100,
+  log2FoldChange = c(6, 4, 3, -5, -4, 1.2),
+  padj = c(1e-2, 1e-20, 1e-10, 1e-3, 1e-15, 1e-40)
+)
+
+test_that("select.top.method = 'rank.sum' changes the labeled set", {
+  p_padj <- ggmaplot(de, fdr = 0.05, fc = 2, genenames = de$name, top = 3)
+  p_rs <- ggmaplot(de, fdr = 0.05, fc = 2, genenames = de$name, top = 3,
+    select.top.method = "rank.sum"
+  )
+  expect_false(identical(sort(labelled(p_padj)), sort(labelled(p_rs))))
+  expect_silent(ggplot2::ggplotGrob(p_rs))
+})
+
+test_that("top.balanced labels both directions in ggmaplot and ggvolcano", {
+  pm <- ggmaplot(de, fdr = 0.05, fc = 2, genenames = de$name, top = 4,
+    select.top.method = "rank.sum", top.balanced = TRUE
+  )
+  lm <- pm$layers[[which(vapply(pm$layers, function(l) grepl("Repel", class(l$geom)[1]), logical(1)))[1]]]$data
+  expect_true(any(lm$lfc > 0) && any(lm$lfc < 0))
+
+  pv <- ggvolcano(de, fdr = 0.05, fc = 2, genenames = de$name, top = 4,
+    select.top.method = "rank.sum", top.balanced = TRUE
+  )
+  expect_silent(ggplot2::ggplotGrob(pv))
+})
+
+test_that("the default selection is unchanged when the new options are not used", {
+  # padj-ranked head(top) still labels the smallest-padj significant genes.
+  p <- ggvolcano(de, fdr = 0.05, fc = 2, genenames = de$name, top = 2)
+  # g6 (padj 1e-40) and g2 (1e-20) are the two smallest-padj significant hits
+  expect_setequal(labelled(p), c("g6", "g2"))
+})

--- a/tests/testthat/test-de-top-gene-ranking.R
+++ b/tests/testthat/test-de-top-gene-ranking.R
@@ -33,6 +33,27 @@ test_that(".select_top_de_labels balances direction with spillover", {
   expect_equal(sum(out$lfc < 0), 1)
 })
 
+test_that(".select_top_de_labels returns exactly `top` labels (incl. odd top)", {
+  rich <- data.frame(
+    name = paste0("g", 1:200),
+    lfc = c(rep(2, 100), rep(-2, 100)),
+    padj = 1e-5
+  )
+  # odd tops (incl. the package default 15) must not lose a label
+  for (n in c(1, 5, 7, 11, 15)) {
+    expect_equal(nrow(ggpubr:::.select_top_de_labels(rich, n, "padj", TRUE)), n, info = n)
+  }
+  # no wasted slot when one side is short: 8 up + rich down, top = 15 -> 8 up + 7 down
+  short.up <- data.frame(
+    name = paste0("g", 1:108),
+    lfc = c(rep(2, 8), rep(-2, 100)),
+    padj = 1e-5
+  )
+  out <- ggpubr:::.select_top_de_labels(short.up, 15, "padj", TRUE)
+  expect_equal(nrow(out), 15)
+  expect_equal(sum(out$lfc > 0), 8)
+})
+
 test_that(".select_top_de_labels selects within each facet group", {
   df <- data.frame(
     name = c("a1", "a2", "b1", "b2"),


### PR DESCRIPTION
## What changed

`ggmaplot()` and `ggvolcano()` gain two **opt-in** options for choosing which genes get labeled:

- `select.top.method = "rank.sum"` — ranks by the sum of the `|log2FC|` rank and the adjusted-p rank, so the labeled genes are **both high-effect and highly significant** (not just the most significant tiny-effect genes, or the biggest-effect non-significant ones).
- `top.balanced = TRUE` — labels about **half up-regulated and half down-regulated** genes, with spillover into the other direction when one side is short.

```r
data(diff_express)
ggvolcano(diff_express, fdr = 0.05, fc = 2,
  genenames = as.vector(diff_express$name),
  top = 10, select.top.method = "rank.sum", top.balanced = TRUE)
```

Both are driven by a shared internal helper, `.select_top_de_labels()`.

## User-facing effect

Additive and gated. The **default selection is unchanged** — a call without `rank.sum`/`top.balanced` stays on its existing code path and produces byte-identical output. Verified: the default labeled-gene set for `ggmaplot()` and `ggvolcano()` (padj/fc, `label.select`, and faceted) is identical to `origin/master`, and the byte-identity harness passes 39/39.

## Tests

Adds `tests/testthat/test-de-top-gene-ranking.R`: rank-sum ordering (with the tie-break), direction-balancing with spillover, per-facet selection, that `rank.sum` changes the labeled set vs the default, that `top.balanced` labels both directions in both functions, and that the default selection is unchanged.
