### PR TITLE
Two-way / interaction comparison figures with ggcompare()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,10 +49,14 @@ Imports:
 Suggests:
     grDevices,
     knitr,
+    rmarkdown,
     RColorBrewer,
     gtable,
     testthat,
-    spelling
+    spelling,
+    datarium,
+    emmeans
+VignetteBuilder: knitr
 Remotes:
     kassambara/rstatix@release/1.1.0
 URL: https://rpkgs.datanovia.com/ggpubr/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## New features
 
+- `ggcompare()` gains a two-way (grouped) mode. When a second factor is mapped
+  through `color` or `fill`, it composes a two-way comparison figure in one
+  call: dodged boxes for the two factors, simple pairwise comparison brackets of
+  one factor within each level of the other (`pwc.group.by`), and a subtitle
+  from the two-way ANOVA that names the interaction (e.g.
+  "Interaction (gender × education_level), F(2,52) = 7.34, p = 0.002"). In this
+  mode the pairwise `method` defaults to `"emmeans_test"`, `p.adjust.method` to
+  `"bonferroni"` and `hide.ns` to `TRUE`; each remains overridable. The one-way
+  behavior is unchanged (#763).
+
+- `add_test_label()` gains `group.by` and `effect` arguments to label a two-way
+  ANOVA effect. With `group.by` set, the subtitle reports the two-way
+  `y ~ x * group.by` model; `effect` selects the interaction (default), a named
+  term, or `"all"` for a multi-line label of both main effects and the
+  interaction (#763).
+
 - `ggmaplot()` and `ggvolcano()` gain two opt-in options for choosing which
   genes are labeled: `select.top.method = "rank.sum"` ranks by the sum of the
   `|log2FC|` rank and the adjusted-p rank, so the labeled genes are both

--- a/R/add_test_label.R
+++ b/R/add_test_label.R
@@ -35,8 +35,20 @@ NULL
 #' @param p.adjust.method method for adjusting the pairwise p-values used by the
 #'   caption (see \code{\link[stats]{p.adjust}}); ignored by \code{"tukey_hsd"}
 #'   and \code{"games_howell_test"}, which adjust internally.
+#' @param group.by optional name of a second grouping factor (typically the one
+#'   mapped to \code{color}/\code{fill}). When supplied, a two-way ANOVA
+#'   \code{y ~ x * group.by} is computed and the subtitle names the selected
+#'   effect (see \code{effect}). Only used when \code{method = "anova"}. Default
+#'   \code{NULL} (one-way \code{y ~ x}, the historical behavior).
+#' @param effect which effect of the two-way ANOVA to label (only used when
+#'   \code{group.by} is set). One of \code{"interaction"} (default, the
+#'   \code{x:group.by} row, described as \dQuote{Interaction (x \eqn{\times}
+#'   group.by)}), \code{"all"} (a multi-line label with both main effects and the
+#'   interaction), or a term name (e.g. \code{"gender"} or
+#'   \code{"gender:education_level"}) or a numeric row index of the ANOVA table.
 #' @param ... additional arguments passed to
-#'   \code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}).
+#'   \code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}, or
+#'   \code{description} to override the auto-derived effect name).
 #' @return the input ggplot with the subtitle (and optionally caption) added.
 #' @seealso \code{\link{stat_anova_test}}, \code{\link{stat_kruskal_test}},
 #'   \code{\link[rstatix]{get_test_label}}, \code{\link[rstatix]{get_pwc_label}}.
@@ -53,11 +65,16 @@ NULL
 #'   geom_pwc(method = "dunn_test", label = "p.adj.signif", hide.ns = TRUE)
 #' add_test_label(p2, method = "kruskal", caption = TRUE)
 #'
+#' # Two-way design: name the interaction in the subtitle
+#' p3 <- ggboxplot(df, x = "dose", y = "len", color = "supp")
+#' add_test_label(p3, group.by = "supp", type = "text")
+#'
 #' @export
 add_test_label <- function(p, method = c("anova", "kruskal"),
                            caption = FALSE, pwc.method = NULL,
                            detailed = TRUE, type = c("expression", "text"),
-                           p.adjust.method = "holm", ...) {
+                           p.adjust.method = "holm",
+                           group.by = NULL, effect = NULL, ...) {
   if (!inherits(p, "ggplot")) {
     stop("`p` must be a ggplot.", call. = FALSE)
   }
@@ -78,6 +95,24 @@ add_test_label <- function(p, method = c("anova", "kruskal"),
     )
   }
 
+  # A second grouping factor turns the omnibus into a two-way ANOVA whose named
+  # effect (by default the interaction) becomes the subtitle. This is gated
+  # entirely behind a non-NULL `group.by`, so the one-way call below is
+  # byte-identical to the historical behavior.
+  two.way <- !is.null(group.by)
+  if (two.way && method != "anova") {
+    warning(
+      "Naming a two-way effect requires method = 'anova'; ignoring `group.by`.",
+      call. = FALSE
+    )
+    two.way <- FALSE
+  }
+  if (two.way && !(group.by %in% colnames(p$data))) {
+    stop("`group.by` column ('", group.by, "') not found in the plot data.",
+      call. = FALSE
+    )
+  }
+
   if (!inherits(p$facet, "FacetNull")) {
     warning(
       "add_test_label() computes a single test pooling all facet panels. ",
@@ -90,13 +125,20 @@ add_test_label <- function(p, method = c("anova", "kruskal"),
   .formula <- stats::as.formula(paste(y, "~", x))
 
   # Omnibus test -> subtitle
-  omnibus <- switch(method,
-    anova = rstatix::anova_test(.data, .formula),
-    kruskal = rstatix::kruskal_test(.data, .formula)
-  )
-  subtitle.label <- rstatix::get_test_label(
-    omnibus, detailed = detailed, type = type, ...
-  )
+  if (two.way) {
+    subtitle.label <- .two_way_test_label(
+      .data, x = x, y = y, group.by = group.by, effect = effect,
+      detailed = detailed, type = type, ...
+    )
+  } else {
+    omnibus <- switch(method,
+      anova = rstatix::anova_test(.data, .formula),
+      kruskal = rstatix::kruskal_test(.data, .formula)
+    )
+    subtitle.label <- rstatix::get_test_label(
+      omnibus, detailed = detailed, type = type, ...
+    )
+  }
 
   # Only set the labels we actually produce, using separate labs() calls. In
   # particular, when caption = FALSE we must NOT touch the caption at all,
@@ -117,4 +159,65 @@ add_test_label <- function(p, method = c("anova", "kruskal"),
     p <- p + ggplot2::labs(caption = rstatix::get_pwc_label(pwc, type = type))
   }
   p
+}
+
+# Build the subtitle label for a two-way ANOVA y ~ x * group.by, naming the
+# selected effect. `effect` is "interaction" (default), "all", a term name, or a
+# numeric row index. Returns a text/expression label from get_test_label().
+.two_way_test_label <- function(.data, x, y, group.by, effect = NULL,
+                                detailed = TRUE, type = "expression", ...) {
+  .formula <- stats::as.formula(paste(y, "~", x, "*", group.by))
+  res.aov <- rstatix::anova_test(.data, .formula)
+  atab <- rstatix::get_anova_table(res.aov)
+  terms <- as.character(atab$Effect)
+  # A term's readable description: the interaction term "A:B" reads
+  # "Interaction (A x B)"; a main effect keeps its term name.
+  describe_term <- function(term) {
+    if (grepl(":", term)) {
+      paste0("Interaction (", gsub(":", " \u00d7 ", term), ")")
+    } else {
+      term
+    }
+  }
+  dots <- list(...)
+  user.description <- "description" %in% names(dots)
+
+  # Resolve `effect` to the ANOVA-table row(s) to label.
+  if (is.null(effect)) effect <- "interaction"
+  if (identical(effect, "all")) {
+    rows <- seq_along(terms)
+  } else if (identical(effect, "interaction")) {
+    rows <- which(grepl(":", terms))
+    if (length(rows) == 0L) rows <- length(terms) # fall back to the last row
+  } else if (is.numeric(effect)) {
+    rows <- as.integer(effect)
+  } else {
+    # Match a term name, tolerating "A:B" / "A*B" and reversed factor order.
+    key <- function(z) paste(sort(strsplit(gsub("[*]", ":", z), ":")[[1]]), collapse = ":")
+    rows <- which(vapply(terms, function(t) key(t) == key(effect), logical(1)))
+    if (length(rows) == 0L) {
+      stop("`effect` = '", effect, "' does not match an ANOVA term. Available: ",
+        paste(terms, collapse = ", "), ".", call. = FALSE)
+    }
+  }
+
+  make_label <- function(row) {
+    args <- c(
+      list(res.aov, row = row, detailed = detailed, type = type),
+      if (!user.description) list(description = describe_term(terms[row])),
+      dots
+    )
+    do.call(rstatix::get_test_label, args)
+  }
+
+  if (length(rows) == 1L) {
+    return(make_label(rows))
+  }
+  # Multi-line: stack one line per effect. Plain text joins with newlines;
+  # plotmath stacks the per-line expressions with atop().
+  labels <- lapply(rows, make_label)
+  if (type == "text") {
+    return(paste(unlist(labels), collapse = "\n"))
+  }
+  Reduce(function(a, b) substitute(atop(a, b), list(a = a, b = b)), labels)
 }

--- a/R/ggcompare.R
+++ b/R/ggcompare.R
@@ -42,6 +42,17 @@ NULL
 #'   \code{"emmeans_test"}); the all-pairwise-only tests (\code{"dunn_test"},
 #'   \code{"games_howell_test"}, \code{"tukey_hsd"}) draw all pairs, so
 #'   \code{comparisons} is not allowed with them (use \code{ref.group} instead).
+#'
+#'   \strong{Two-way / grouped mode.} When a second factor is mapped through
+#'   \code{color} or \code{fill} (a data column other than \code{x}),
+#'   \code{ggcompare()} composes a two-way figure in one call: dodged boxes for
+#'   the two factors, simple pairwise comparison brackets of one factor within
+#'   each level of the other (see \code{pwc.group.by}), and a subtitle from the
+#'   two-way ANOVA that names the interaction. In this mode the pairwise
+#'   \code{method} defaults to \code{"emmeans_test"} (pooled-model simple
+#'   comparisons), \code{p.adjust.method} to \code{"bonferroni"} and
+#'   \code{hide.ns} to \code{TRUE}; each remains overridable. The one-way path is
+#'   unchanged.
 #' @param ref.group a group level used as the reference; each other group is
 #'   compared to it. See \code{\link{geom_pwc}()}.
 #' @param method the pairwise comparison test. Default \code{"t_test"}. See
@@ -67,6 +78,10 @@ NULL
 #' @param omnibus.args additional arguments passed to
 #'   \code{\link{add_test_label}()} (non-faceted plots) or the corresponding stat
 #'   layer (faceted plots).
+#' @param pwc.group.by used only in the two-way (grouped) mode described below.
+#'   Direction of the grouped pairwise comparisons: \code{"x.var"} (default)
+#'   compares the second factor within each \code{x} group; \code{"legend.var"}
+#'   compares the \code{x} groups within each level of the second factor.
 #' @param ... additional arguments passed to the base builder (e.g.
 #'   \code{ggboxplot}), such as \code{title}, \code{xlab}, \code{ylab}.
 #' @return a single customizable \code{ggplot}.
@@ -89,6 +104,16 @@ NULL
 #' # Composed with a summary-statistics table
 #' ggsummarystats(df, x = "dose", y = "len", ggfunc = ggcompare)
 #'
+#' # Two-way / grouped design: a second factor mapped through `color` triggers
+#' # dodged boxes, simple pairwise brackets within each x group, and a subtitle
+#' # naming the interaction. (Uses emmeans_test by default, so guard on emmeans.)
+#' if (requireNamespace("emmeans", quietly = TRUE)) {
+#'   data("ToothGrowth")
+#'   tg <- ToothGrowth
+#'   tg$dose <- as.factor(tg$dose)
+#'   ggcompare(tg, x = "supp", y = "len", color = "dose")
+#' }
+#'
 #' @export
 ggcompare <- function(data, x, y,
                       color = "black", fill = "white", palette = "jco",
@@ -102,16 +127,52 @@ ggcompare <- function(data, x, y,
                       effsize = FALSE, hide.ns = FALSE,
                       pack = c("auto", "none"), pwc.args = list(),
                       omnibus = c("anova", "kruskal", "none"),
-                      omnibus.args = list(), ...) {
+                      omnibus.args = list(),
+                      pwc.group.by = c("x.var", "legend.var"), ...) {
   base <- match.arg(base)
   pack <- match.arg(pack)
   omnibus <- match.arg(omnibus)
+  pwc.group.by <- match.arg(pwc.group.by)
+
+  # Record which comparison controls the caller left at their defaults, so a
+  # two-way call can adopt two-way-appropriate defaults (emmeans / Bonferroni /
+  # hide ns) without overriding an explicit choice. Captured before any coercion.
+  method.missing <- missing(method)
+  padj.missing <- missing(p.adjust.method)
+  hide.ns.missing <- missing(hide.ns)
+  color.missing <- missing(color)
+  fill.missing <- missing(fill)
 
   # Coerce x to a factor so the discrete positions (and the comparison
   # translation below) are well defined; keep an existing factor's level order.
   if (!is.factor(data[[x]])) {
     data[[x]] <- factor(data[[x]])
   }
+
+  # Two-way mode is entered only when a SECOND factor is mapped through
+  # color/fill (a data column distinct from x). Everything below is gated on
+  # this, so a one-way call (color/fill a fixed colour) is byte-identical.
+  # Only an EXPLICITLY supplied color/fill that names a data column (other than
+  # x) is treated as the second factor; the "black"/"white" defaults never
+  # trigger two-way mode, even if the data happens to carry such a column.
+  group.var <- NULL
+  is_col <- function(v) is.character(v) && length(v) == 1L && v %in% colnames(data)
+  if (!color.missing && is_col(color) && color != x) {
+    group.var <- color
+  } else if (!fill.missing && is_col(fill) && fill != x) {
+    group.var <- fill
+  }
+  two.way <- !is.null(group.var)
+  if (two.way) {
+    if (!is.factor(data[[group.var]])) data[[group.var]] <- factor(data[[group.var]])
+    # Simple pairwise comparisons in a two-way design are best drawn from the
+    # pooled-model emmeans test with Bonferroni adjustment; declutter by hiding
+    # ns. These are defaults only - an explicit argument always wins.
+    if (method.missing) method <- "emmeans_test"
+    if (padj.missing) p.adjust.method <- "bonferroni"
+    if (hide.ns.missing) hide.ns <- TRUE
+  }
+
   if (missing(ggtheme) && !is.null(facet.by)) {
     ggtheme <- theme_pubr(border = TRUE)
   }
@@ -167,7 +228,7 @@ ggcompare <- function(data, x, y,
   # t_test/games_howell_test, Cliff's delta for wilcox_test, r for dunn_test),
   # so a rank-based effect size is not mislabelled as "d". A bare column token
   # is braced first so it stays a valid glue template.
-  if (isTRUE(effsize)) {
+  if (isTRUE(effsize) && !two.way) {
     es.symbol <- switch(if (is.na(method.name)) "" else method.name,
       t_test = "d", games_howell_test = "d",
       wilcox_test = "delta", dunn_test = "r",
@@ -175,6 +236,90 @@ ggcompare <- function(data, x, y,
     )
     if (!grepl("\\{", label)) label <- paste0("{", label, "}")
     label <- paste0(label, ", ", es.symbol, "={effsize}")
+  }
+
+  # ---- Two-way / grouped mode ------------------------------------------------
+  # When a second factor is mapped through color/fill, draw simple pairwise
+  # comparisons of one factor within each level of the other, from a PRECOMPUTED
+  # rstatix test (positioned with add_xy_position(), drawn with
+  # stat_pvalue_manual()), plus a two-way omnibus subtitle that names the
+  # interaction. The pooled-model emmeans / per-group pairwise values are
+  # computed directly here because geom_pwc()'s internal grouped test does not
+  # reproduce them for a multi-level legend.
+  if (two.way) {
+    if (!is.null(facet.by)) {
+      stop("`facet.by` is not yet supported in two-way (grouped) mode. Draw the ",
+        "grouped figure without faceting, or facet a one-way plot.",
+        call. = FALSE)
+    }
+    if (isTRUE(effsize)) {
+      warning("`effsize` is not supported in two-way (grouped) mode; ignoring it.",
+        call. = FALSE)
+    }
+    if (!is.null(comparisons)) {
+      stop("`comparisons` subsetting is not supported in two-way (grouped) mode; ",
+        "all pairwise comparisons are drawn within each group. Use `ref.group` ",
+        "to compare against a reference level.", call. = FALSE)
+    }
+    if (is.function(method)) {
+      stop("A function `method` is not supported in two-way (grouped) mode; ",
+        "pass a method name such as 'emmeans_test', 't_test' or 'wilcox_test'.",
+        call. = FALSE)
+    }
+    if (is.na(method.name) ||
+      !exists(method.name, envir = asNamespace("rstatix"), inherits = FALSE)) {
+      stop("Unknown two-way pairwise `method`: '", method, "'.", call. = FALSE)
+    }
+    # group.by = "x.var" (default): group by x, compare the second factor within
+    # each x. "legend.var": the reverse.
+    if (pwc.group.by == "x.var") {
+      grp.var <- x
+      comp.var <- group.var
+    } else {
+      grp.var <- group.var
+      comp.var <- x
+    }
+    test.fun2 <- get(method.name, envir = asNamespace("rstatix"))
+    test.formula <- stats::as.formula(paste(y, "~", comp.var))
+    call.args <- c(
+      list(dplyr::group_by(data, .data[[grp.var]]), test.formula),
+      method.args
+    )
+    if ("p.adjust.method" %in% names(formals(test.fun2))) {
+      call.args$p.adjust.method <- p.adjust.method
+    }
+    if (!is.null(ref.group)) {
+      if (!("ref.group" %in% names(formals(test.fun2)))) {
+        stop("`ref.group` is not supported for method = '", method,
+          "' in two-way mode.", call. = FALSE)
+      }
+      call.args$ref.group <- as.character(ref.group)
+    }
+    pwc <- do.call(test.fun2, call.args)
+    # Position the brackets against the plotted layout: x is always the plot's
+    # x axis and the second factor is the dodge group -- regardless of the
+    # comparison direction. (Positioning on `grp.var` would place legend.var
+    # brackets on the wrong x scale, off the panel.)
+    pwc <- rstatix::add_xy_position(pwc, x = x, group = group.var, dodge = 0.8)
+    spm.call <- c(list(data = pwc, label = label, hide.ns = hide.ns), pwc.args)
+    p <- p + do.call(stat_pvalue_manual, spm.call)
+
+    # Caption describing the pairwise test (kept unless the caller already set
+    # one). Matches the subtitle's output type.
+    cap.type <- if (!is.null(omnibus.args$type)) omnibus.args$type else "expression"
+    if (is.null(p$labels$caption)) {
+      p <- p + ggplot2::labs(caption = rstatix::get_pwc_label(pwc, type = cap.type))
+    }
+
+    if (omnibus == "anova") {
+      p <- do.call(
+        add_test_label,
+        c(list(p, method = "anova", group.by = group.var), omnibus.args)
+      )
+    } else if (omnibus == "kruskal") {
+      p <- do.call(add_test_label, c(list(p, method = "kruskal"), omnibus.args))
+    }
+    return(p)
   }
 
   # (3) Translate a subset of comparisons from group levels to the 1-based

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -130,6 +130,7 @@ geoms
 ges
 ggbarplot
 ggboxplot
+ggcompare
 ggdensity
 ggdotchart
 ggdotplot
@@ -204,6 +205,7 @@ npg
 nrow
 ns
 oldrel
+overridable
 padj
 params
 pearson

--- a/man/add_test_label.Rd
+++ b/man/add_test_label.Rd
@@ -12,6 +12,8 @@ add_test_label(
   detailed = TRUE,
   type = c("expression", "text"),
   p.adjust.method = "holm",
+  group.by = NULL,
+  effect = NULL,
   ...
 )
 }
@@ -45,8 +47,22 @@ freedom, effect size, n) is shown.}
 caption (see \code{\link[stats]{p.adjust}}); ignored by \code{"tukey_hsd"}
 and \code{"games_howell_test"}, which adjust internally.}
 
+\item{group.by}{optional name of a second grouping factor (typically the one
+mapped to \code{color}/\code{fill}). When supplied, a two-way ANOVA
+\code{y ~ x * group.by} is computed and the subtitle names the selected
+effect (see \code{effect}). Only used when \code{method = "anova"}. Default
+\code{NULL} (one-way \code{y ~ x}, the historical behavior).}
+
+\item{effect}{which effect of the two-way ANOVA to label (only used when
+\code{group.by} is set). One of \code{"interaction"} (default, the
+\code{x:group.by} row, described as \dQuote{Interaction (x \eqn{\times}
+group.by)}), \code{"all"} (a multi-line label with both main effects and the
+interaction), or a term name (e.g. \code{"gender"} or
+\code{"gender:education_level"}) or a numeric row index of the ANOVA table.}
+
 \item{...}{additional arguments passed to
-\code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}).}
+\code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}, or
+\code{description} to override the auto-derived effect name).}
 }
 \value{
 the input ggplot with the subtitle (and optionally caption) added.
@@ -79,6 +95,10 @@ add_test_label(p)
 p2 <- ggboxplot(df, x = "dose", y = "len") +
   geom_pwc(method = "dunn_test", label = "p.adj.signif", hide.ns = TRUE)
 add_test_label(p2, method = "kruskal", caption = TRUE)
+
+# Two-way design: name the interaction in the subtitle
+p3 <- ggboxplot(df, x = "dose", y = "len", color = "supp")
+add_test_label(p3, group.by = "supp", type = "text")
 
 }
 \seealso{

--- a/man/ggcompare.Rd
+++ b/man/ggcompare.Rd
@@ -29,6 +29,7 @@ ggcompare(
   pwc.args = list(),
   omnibus = c("anova", "kruskal", "none"),
   omnibus.args = list(),
+  pwc.group.by = c("x.var", "legend.var"),
   ...
 )
 }
@@ -60,12 +61,23 @@ builder (e.g. \code{"jitter"}, \code{"mean"}, \code{"mean_sd"}). Default
 \item{add.params}{a list of parameters passed to the \code{add} layers.}
 
 \item{comparisons}{a list of length-2 vectors giving the group levels to
-compare. If \code{NULL} (default), all pairwise comparisons are drawn.
-Subsetting is supported for the tests that accept a \code{comparisons}
-argument (\code{"t_test"}, \code{"wilcox_test"}, \code{"sign_test"},
-\code{"emmeans_test"}); the all-pairwise-only tests (\code{"dunn_test"},
-\code{"games_howell_test"}, \code{"tukey_hsd"}) draw all pairs, so
-\code{comparisons} is not allowed with them (use \code{ref.group} instead).}
+  compare. If \code{NULL} (default), all pairwise comparisons are drawn.
+  Subsetting is supported for the tests that accept a \code{comparisons}
+  argument (\code{"t_test"}, \code{"wilcox_test"}, \code{"sign_test"},
+  \code{"emmeans_test"}); the all-pairwise-only tests (\code{"dunn_test"},
+  \code{"games_howell_test"}, \code{"tukey_hsd"}) draw all pairs, so
+  \code{comparisons} is not allowed with them (use \code{ref.group} instead).
+
+  \strong{Two-way / grouped mode.} When a second factor is mapped through
+  \code{color} or \code{fill} (a data column other than \code{x}),
+  \code{ggcompare()} composes a two-way figure in one call: dodged boxes for
+  the two factors, simple pairwise comparison brackets of one factor within
+  each level of the other (see \code{pwc.group.by}), and a subtitle from the
+  two-way ANOVA that names the interaction. In this mode the pairwise
+  \code{method} defaults to \code{"emmeans_test"} (pooled-model simple
+  comparisons), \code{p.adjust.method} to \code{"bonferroni"} and
+  \code{hide.ns} to \code{TRUE}; each remains overridable. The one-way path is
+  unchanged.}
 
 \item{ref.group}{a group level used as the reference; each other group is
 compared to it. See \code{\link{geom_pwc}()}.}
@@ -102,6 +114,11 @@ compactly, \code{"none"} keeps one per level. See \code{\link{geom_pwc}()}.}
 \item{omnibus.args}{additional arguments passed to
 \code{\link{add_test_label}()} (non-faceted plots) or the corresponding stat
 layer (faceted plots).}
+
+\item{pwc.group.by}{used only in the two-way (grouped) mode described below.
+Direction of the grouped pairwise comparisons: \code{"x.var"} (default)
+compares the second factor within each \code{x} group; \code{"legend.var"}
+compares the \code{x} groups within each level of the second factor.}
 
 \item{...}{additional arguments passed to the base builder (e.g.
 \code{ggboxplot}), such as \code{title}, \code{xlab}, \code{ylab}.}
@@ -146,6 +163,16 @@ ggcompare(df, x = "dose", y = "len",
 
 # Composed with a summary-statistics table
 ggsummarystats(df, x = "dose", y = "len", ggfunc = ggcompare)
+
+# Two-way / grouped design: a second factor mapped through `color` triggers
+# dodged boxes, simple pairwise brackets within each x group, and a subtitle
+# naming the interaction. (Uses emmeans_test by default, so guard on emmeans.)
+if (requireNamespace("emmeans", quietly = TRUE)) {
+  data("ToothGrowth")
+  tg <- ToothGrowth
+  tg$dose <- as.factor(tg$dose)
+  ggcompare(tg, x = "supp", y = "len", color = "dose")
+}
 
 }
 \seealso{

--- a/tests/testthat/test-ggcompare-two-way.R
+++ b/tests/testthat/test-ggcompare-two-way.R
@@ -1,0 +1,197 @@
+context("test-ggcompare-two-way")
+
+# jobsatisfaction (datarium) is the canonical two-way lesson dataset. Skip if it
+# is not installed rather than fail the suite.
+get_js <- function() {
+  testthat::skip_if_not_installed("datarium")
+  testthat::skip_if_not_installed("emmeans")
+  e <- new.env()
+  utils::data("jobsatisfaction", package = "datarium", envir = e)
+  e$jobsatisfaction
+}
+
+# Number of brackets drawn (GeomBracket draws 3 rows -- two tips + label -- per
+# bracket).
+n_brackets <- function(p) {
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))
+  if (length(i) == 0L) return(0L)
+  nrow(ggplot2::layer_data(p, i[1])) / 3
+}
+subtitle_text <- function(p) {
+  s <- ggplot2::ggplot_build(p)$plot$labels$subtitle
+  paste(deparse(s), collapse = "")
+}
+
+# ---- two-way mode composes the interaction figure ---------------------------
+test_that("ggcompare() enters two-way mode and reproduces the lesson numbers", {
+  js <- get_js()
+  p <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    omnibus = "anova")
+
+  # 3 education comparisons within each of the 2 genders = 6 brackets.
+  expect_equal(n_brackets(p), 6)
+
+  # The bracket p.adj must equal the pooled-model emmeans + Bonferroni values.
+  truth <- js %>%
+    dplyr::group_by(gender) %>%
+    rstatix::emmeans_test(score ~ education_level, p.adjust.method = "bonferroni")
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))
+  brk <- ggplot2::layer_data(p, i[1])
+  # one label row per bracket carries the significance stars
+  expect_setequal(sort(unique(brk$label)), sort(unique(truth$p.adj.signif)))
+
+  # Subtitle names the interaction with the exact ANOVA numbers.
+  st <- subtitle_text(p)
+  expect_match(st, "Interaction \\(gender")
+  expect_match(st, "education_level")
+  expect_match(st, "7.34")   # F(2,52) = 7.34
+  expect_match(st, "0.002")  # p = 0.002
+  expect_match(st, "0.22")   # ges = 0.22
+
+  # Caption describes the pairwise test.
+  cap <- ggplot2::ggplot_build(p)$plot$labels$caption
+  expect_match(paste(deparse(cap), collapse = ""), "Emmeans test")
+  expect_match(paste(deparse(cap), collapse = ""), "Bonferroni")
+
+  expect_silent(ggplot2::ggplotGrob(ggplot2::ggplot_build(p)))
+})
+
+test_that("two-way defaults (emmeans / bonferroni / hide.ns) are used, and overridable", {
+  js <- get_js()
+  # Default method is emmeans; overriding to t_test changes the p.adj values.
+  p_emm <- ggcompare(js, x = "gender", y = "score", color = "education_level")
+  p_t <- suppressWarnings(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      method = "t_test")
+  )
+  brk <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))
+    ggplot2::layer_data(p, i[1])$label
+  }
+  # Both fully significant here, but the underlying tests differ -> exercise both.
+  expect_equal(n_brackets(p_emm), 6)
+  expect_equal(n_brackets(p_t), 6)
+
+  # hide.ns defaults to TRUE in two-way: the legend.var direction hides the two
+  # ns gender contrasts, leaving one significant bracket; hide.ns=FALSE shows 3.
+  p_hidden <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    pwc.group.by = "legend.var")
+  p_shown <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    pwc.group.by = "legend.var", hide.ns = FALSE)
+  expect_equal(n_brackets(p_hidden), 1)
+  expect_equal(n_brackets(p_shown), 3)
+})
+
+test_that("brackets stay on the panel in both comparison directions", {
+  js <- get_js()
+  # Brackets must sit within the plotted x range (2 dodged gender clusters,
+  # roughly [0.5, 2.5]); a bracket positioned on the wrong (legend) grid would
+  # land near x = 3, off the panel.
+  brk_x <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBracket"), logical(1)))
+    d <- ggplot2::layer_data(p, i[1])
+    range(c(d$xmin, d$xmax), na.rm = TRUE)
+  }
+  p_x <- ggcompare(js, x = "gender", y = "score", color = "education_level")
+  p_leg <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    pwc.group.by = "legend.var", hide.ns = FALSE)
+  expect_true(brk_x(p_x)[1] >= 0.5 && brk_x(p_x)[2] <= 2.5)
+  expect_true(brk_x(p_leg)[1] >= 0.5 && brk_x(p_leg)[2] <= 2.5)
+  # The legend.var university bracket must span the two gender clusters
+  # (male university ~1.267 to female university ~2.267), not sit past them.
+  expect_gt(brk_x(p_leg)[2], 2)
+})
+
+test_that("two-way mode rejects facet.by with a clear error (no crash)", {
+  js <- get_js()
+  js$region <- factor(rep(c("north", "south"), length.out = nrow(js)))
+  expect_error(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      facet.by = "region"),
+    "not yet supported in two-way"
+  )
+})
+
+test_that("ref.group draws only comparisons to the reference level", {
+  js <- get_js()
+  p <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    ref.group = "school", hide.ns = FALSE)
+  # 2 non-reference levels x 2 genders = 4 brackets.
+  expect_equal(n_brackets(p), 4)
+})
+
+test_that("other bases and fill grouping work in two-way mode", {
+  js <- get_js()
+  for (b in c("violin", "stripchart")) {
+    p <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+      base = b, hide.ns = FALSE)
+    expect_equal(n_brackets(p), 6, info = b)
+    expect_silent(ggplot2::ggplotGrob(ggplot2::ggplot_build(p)))
+  }
+  p_fill <- ggcompare(js, x = "gender", y = "score", fill = "education_level",
+    hide.ns = FALSE)
+  expect_equal(n_brackets(p_fill), 6)
+})
+
+# ---- guards -----------------------------------------------------------------
+test_that("two-way mode refuses unsupported inputs with clear messages", {
+  js <- get_js()
+  expect_error(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      comparisons = list(c("school", "college"))),
+    "not supported in two-way"
+  )
+  expect_warning(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      effsize = TRUE),
+    "not supported in two-way"
+  )
+  myfun <- function(data, formula, ...) rstatix::t_test(data, formula, ...)
+  expect_error(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      method = myfun),
+    "function `method` is not supported"
+  )
+})
+
+# ---- the one-way path is untouched ------------------------------------------
+test_that("color == x does NOT trigger two-way mode", {
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  p <- ggcompare(df, x = "dose", y = "len", color = "dose")
+  # A one-way ANOVA subtitle has no interaction term.
+  expect_false(grepl("Interaction", subtitle_text(p)))
+})
+
+# ---- add_test_label() two-way effect naming ---------------------------------
+test_that("add_test_label(group.by=) names the interaction and selects effects", {
+  js <- get_js()
+  p <- ggboxplot(js, x = "gender", y = "score", color = "education_level")
+
+  # Default: the interaction, described "Interaction (gender x education_level)".
+  lab_int <- add_test_label(p, group.by = "education_level", type = "text")$labels$subtitle
+  expect_match(lab_int, "Interaction \\(gender")
+  expect_match(lab_int, "7.34")
+
+  # A specific main effect by term name.
+  lab_main <- add_test_label(p, group.by = "education_level", effect = "gender",
+    type = "text")$labels$subtitle
+  expect_false(grepl("Interaction", lab_main))
+
+  # effect = "all" -> multi-line (3 effect lines) in text mode.
+  lab_all <- add_test_label(p, group.by = "education_level", effect = "all",
+    type = "text")$labels$subtitle
+  expect_equal(length(strsplit(lab_all, "\n")[[1]]), 3)
+
+  # A non-existent term errors clearly.
+  expect_error(
+    add_test_label(p, group.by = "education_level", effect = "nope"),
+    "does not match an ANOVA term"
+  )
+
+  # kruskal + group.by warns and falls back to one-way (no interaction).
+  expect_warning(
+    add_test_label(p, method = "kruskal", group.by = "education_level"),
+    "requires method = 'anova'"
+  )
+})

--- a/vignettes/two-way-comparison.Rmd
+++ b/vignettes/two-way-comparison.Rmd
@@ -1,0 +1,118 @@
+---
+title: "Two-Way Comparison Figures with ggcompare()"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Two-Way Comparison Figures with ggcompare()}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+# Every computed chunk needs datarium (the example data) and emmeans (the
+# pooled-model simple comparisons). Skip gracefully if either is absent so the
+# vignette still builds.
+has_deps <- requireNamespace("datarium", quietly = TRUE) &&
+  requireNamespace("emmeans", quietly = TRUE)
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 5,
+  dpi = 96,
+  eval = has_deps
+)
+```
+
+```{r not-available, echo = FALSE, eval = !has_deps, results = "asis"}
+cat("> This vignette needs the **datarium** and **emmeans** packages, which are",
+    "not installed, so its output is not shown here.")
+```
+
+A common publication figure compares an outcome across **two** categorical
+factors at once -- for example a score across *gender* and *education level* --
+and annotates it with the interaction from a two-way ANOVA plus pairwise
+comparisons within each group. `ggcompare()` assembles this figure in a single
+call.
+
+## The one-call two-way figure
+
+Map the first factor to `x` and the second factor to `color` (or `fill`). That
+second mapping switches `ggcompare()` into its two-way mode.
+
+```{r two-way}
+library(ggpubr)
+library(rstatix)
+
+data("jobsatisfaction", package = "datarium")
+
+ggcompare(
+  jobsatisfaction,
+  x = "gender", y = "score", color = "education_level"
+)
+```
+
+The figure carries:
+
+- **dodged boxes** for the two factors, with jittered points and group means;
+- **pairwise comparison brackets** of the education levels *within each gender*;
+- a **subtitle** naming the two-way ANOVA interaction; and
+- a **caption** describing the pairwise test.
+
+In two-way mode the pairwise `method` defaults to `"emmeans_test"` (simple
+comparisons from the pooled model), `p.adjust.method` to `"bonferroni"`, and
+`hide.ns` to `TRUE`. Each of these is a default only -- pass the argument to
+override it.
+
+## It matches the by-hand analysis
+
+The annotation reproduces the numbers you would compute by hand. The subtitle is
+the interaction row of the two-way ANOVA:
+
+```{r anova}
+jobsatisfaction %>% anova_test(score ~ gender * education_level)
+```
+
+and the brackets are the pooled-model emmeans comparisons within each gender:
+
+```{r pwc}
+jobsatisfaction %>%
+  group_by(gender) %>%
+  emmeans_test(score ~ education_level, p.adjust.method = "bonferroni") %>%
+  select(gender, group1, group2, p.adj, p.adj.signif)
+```
+
+## Customizing
+
+Every element is overridable. For instance, compare the *genders within each
+education level* instead (swap the comparison direction with `pwc.group.by`),
+switch the base geometry, and show non-significant brackets:
+
+```{r customize}
+ggcompare(
+  jobsatisfaction,
+  x = "gender", y = "score", color = "education_level",
+  base = "violin",
+  pwc.group.by = "legend.var",
+  hide.ns = FALSE
+)
+```
+
+You can also compare each group to a reference level (`ref.group`), choose a
+different pairwise `method`/`p.adjust.method`, or pass extra styling through
+`pwc.args`, `add.params` and `...` (forwarded to the base builder). See
+`?ggcompare` for the full argument list.
+
+## Naming an effect on any plot
+
+The subtitle machinery is also available directly through `add_test_label()`.
+Given a plot with `x` and a second factor, `group.by` computes the two-way
+ANOVA and `effect` chooses which effect to report -- the interaction (default),
+a named term, or `"all"` for a multi-line label of both main effects and the
+interaction:
+
+```{r add-test-label}
+p <- ggboxplot(jobsatisfaction, x = "gender", y = "score",
+  color = "education_level")
+
+add_test_label(p, group.by = "education_level", effect = "all", type = "text")
+```


### PR DESCRIPTION
## Two-way / interaction comparison figures with `ggcompare()`

`ggcompare()` gains a two-way (grouped) mode, and `add_test_label()` can now name a
two-way ANOVA effect. This completes the comparison-figure story for designs with two
categorical factors (e.g. a score across *gender* and *education level*).

### `ggcompare()` two-way mode

Map the first factor to `x` and a second factor to `color` (or `fill`) and the figure is
composed in one call:

```r
ggcompare(jobsatisfaction, x = "gender", y = "score", color = "education_level")
```

- dodged boxes for the two factors, with jittered points and group means;
- simple pairwise comparison brackets of one factor within each level of the other
  (direction set by `pwc.group.by`, default compares the second factor within each `x`);
- a subtitle from the two-way ANOVA that names the interaction, e.g.
  *"Interaction (gender × education_level), F(2,52) = 7.34, p = 0.002, ges = 0.22"*;
- a caption describing the pairwise test.

In two-way mode the pairwise `method` defaults to `"emmeans_test"` (pooled-model simple
comparisons), `p.adjust.method` to `"bonferroni"`, and `hide.ns` to `TRUE`; each is a
default only and remains overridable. **The one-way behavior is unchanged** — the two-way
path is entered only when an explicit second factor is mapped.

### `add_test_label()` effect naming

New `group.by` and `effect` arguments compute a two-way `y ~ x * group.by` ANOVA and label
the selected effect — the interaction (default), a named term, or `"all"` for a multi-line
label of both main effects and the interaction.

### Docs

Adds the package's first vignette, *"Two-Way Comparison Figures with ggcompare()"*, a
worked example on the `jobsatisfaction` two-way dataset.

### Example output

`ggcompare(jobsatisfaction, x = "gender", y = "score", color = "education_level")`

![two-way ggcompare](https://i.imgur.com/5USf5Br.png)
