### PR TITLE
Hint when a ggrocplot() predictor has AUC below 0.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,9 @@
   McNeil, 1982) are all computed in base R, so the function has no modeling
   dependency and runs in lightweight environments such as WebR. For DeLong or
   bootstrap intervals, ROC smoothing, or tests between curves, use the `pROC`
-  package.
+  package. When a predictor's AUC falls below 0.5 (higher values indicate the
+  negative class), a message hints that the predictor or the response levels may
+  need reversing; the curve is never flipped automatically.
 
 - New `ggestimates()` draws a publication-ready forest plot: one row per group
   with a point estimate, its confidence interval, a reference (null) line and an

--- a/R/ggrocplot.R
+++ b/R/ggrocplot.R
@@ -21,7 +21,10 @@ NULL
 #' @param predictor the name of one or more numeric predictor columns (a marker
 #'   or a fitted probability). A \strong{higher} predictor value is taken to
 #'   indicate the positive class. Passing several columns overlays one curve per
-#'   predictor for model comparison.
+#'   predictor for model comparison. A predictor whose AUC falls below 0.5 is
+#'   negatively associated with the positive class; the curve and AUC are drawn
+#'   as computed (no automatic flipping) and a message notes that the predictor
+#'   or the response levels may need reversing.
 #' @param color line color, used when a single \code{predictor} is drawn. Ignored
 #'   when several predictors are compared (they are colored by predictor).
 #' @param palette the color palette to be used when several predictors are
@@ -99,6 +102,20 @@ ggrocplot <- function(data, response, predictor,
   curve <- roc$curve
   summ <- roc$summary
   multi <- nrow(summ) > 1
+
+  # A predictor whose AUC is below 0.5 is negatively associated with the
+  # positive class: higher values point to the negative class. The curve and
+  # AUC are honest (there is no silent auto-flip), so hint - not warn - that the
+  # predictor or the response levels may need reversing. Suppressible with
+  # suppressMessages().
+  low <- which(summ$auc < 0.5)
+  for (i in low) {
+    message(
+      "ggrocplot: predictor '", summ$model[i], "' has an AUC below 0.5; higher ",
+      "values indicate the negative class. If unexpected, reverse the predictor ",
+      "or set the response factor levels so the positive class is the second level."
+    )
+  }
 
   # Legend labels: append the AUC (+ CI) to each model when several are compared.
   if (multi) {

--- a/man/ggrocplot.Rd
+++ b/man/ggrocplot.Rd
@@ -38,7 +38,10 @@ negative one. Set the factor levels explicitly to control this.}
 \item{predictor}{the name of one or more numeric predictor columns (a marker
 or a fitted probability). A \strong{higher} predictor value is taken to
 indicate the positive class. Passing several columns overlays one curve per
-predictor for model comparison.}
+predictor for model comparison. A predictor whose AUC falls below 0.5 is
+negatively associated with the positive class; the curve and AUC are drawn
+as computed (no automatic flipping) and a message notes that the predictor
+or the response levels may need reversing.}
 
 \item{color}{line color, used when a single \code{predictor} is drawn. Ignored
 when several predictors are compared (they are colored by predictor).}

--- a/tests/testthat/test-ggrocplot.R
+++ b/tests/testthat/test-ggrocplot.R
@@ -89,6 +89,24 @@ test_that("a predictor whose NAs remove a whole class errors, not NaN", {
   expect_error(ggrocplot(d, "y", "x"), "both outcome classes")
 })
 
+test_that("a predictor with AUC < 0.5 triggers a 'reversed' hint message", {
+  set.seed(1)
+  n <- 40
+  # x is NEGATIVELY associated with the positive class -> AUC < 0.5.
+  d <- data.frame(
+    y = factor(rep(c("n", "p"), each = n), levels = c("n", "p")),
+    x = c(stats::rnorm(n, 1), stats::rnorm(n, 0)),
+    xpos = c(stats::rnorm(n, 0), stats::rnorm(n, 1)) # AUC > 0.5
+  )
+  expect_message(ggrocplot(d, "y", "x"), "below 0.5")
+  expect_message(ggrocplot(d, "y", "x"), "reverse the predictor")
+  # A well-oriented predictor stays silent (no message).
+  expect_no_message(ggrocplot(d, "y", "xpos"))
+  # The plot object is unaffected by the message (same as suppressing it).
+  p <- suppressMessages(ggrocplot(d, "y", "x"))
+  expect_s3_class(p, "ggplot")
+})
+
 test_that("the ROC axes use collision-free breaks and the multi legend wraps", {
   set.seed(1)
   n <- 30


### PR DESCRIPTION
## `ggrocplot()`: hint when a predictor's AUC is below 0.5

When a predictor is negatively associated with the positive class its AUC falls below 0.5
and its curve sits below the diagonal. `ggrocplot()` draws this honestly (there is no
automatic flipping), which can surprise a user who mapped the predictor the wrong way
round. This adds an informative, suppressible message in that case:

```
ggrocplot: predictor 'x' has an AUC below 0.5; higher values indicate the negative
class. If unexpected, reverse the predictor or set the response factor levels so the
positive class is the second level.
```

The message is a pure side effect — the returned `ggplot`, the curve and the AUC are
unchanged (byte-identical). It fires once per below-0.5 predictor and can be silenced with
`suppressMessages()`. Documented in `?ggrocplot`.
