### PR TITLE
Mark the optimal cut-point (Youden's J) on ggrocplot() ROC curves

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@
   bootstrap intervals, ROC smoothing, or tests between curves, use the `pROC`
   package. When a predictor's AUC falls below 0.5 (higher values indicate the
   negative class), a message hints that the predictor or the response levels may
-  need reversing; the curve is never flipped automatically.
+  need reversing; the curve is never flipped automatically. Set `youden = TRUE`
+  to mark the optimal cut-point (the operating point maximizing the Youden index,
+  sensitivity + specificity - 1) on each curve and label its threshold.
 
 - New `ggestimates()` draws a publication-ready forest plot: one row per group
   with a point estimate, its confidence interval, a reference (null) line and an

--- a/R/ggrocplot.R
+++ b/R/ggrocplot.R
@@ -42,6 +42,13 @@ NULL
 #' @param diag logical. If \code{TRUE} (default) the diagonal no-discrimination
 #'   reference line is drawn.
 #' @param diag.color,diag.linetype color and line type of the diagonal reference.
+#' @param youden logical. If \code{TRUE}, the optimal cut-point is marked on each
+#'   curve - the operating point maximizing the Youden index (\eqn{J =
+#'   sensitivity + specificity - 1}) - and its predictor threshold is labelled.
+#'   Default \code{FALSE}. A predictor with AUC \eqn{\le} 0.5 has no meaningful
+#'   cut-point and is not marked.
+#' @param youden.color the color of the optimal cut-point marker and label for a
+#'   single curve (several curves are colored by predictor).
 #' @param legend the legend position. Allowed values: "top", "bottom", "left",
 #'   "right" or "none". Passed to \code{\link{ggpar}}.
 #' @param legend.title the legend title used when several predictors are compared.
@@ -75,6 +82,9 @@ NULL
 #' # Single ROC curve with AUC + 95% CI annotated
 #' ggrocplot(df, response = "outcome", predictor = "marker1")
 #'
+#' # Mark the optimal cut-point (the Youden index) with its threshold
+#' ggrocplot(df, response = "outcome", predictor = "marker1", youden = TRUE)
+#'
 #' # Compare two markers on the same axes
 #' ggrocplot(
 #'   df,
@@ -89,6 +99,7 @@ ggrocplot <- function(data, response, predictor,
                       linetype = "solid", size = NULL,
                       print.auc = TRUE, ci = TRUE, conf.level = 0.95,
                       diag = TRUE, diag.color = "grey60", diag.linetype = "dashed",
+                      youden = FALSE, youden.color = "grey30",
                       title = NULL, xlab = "1 - Specificity", ylab = "Sensitivity",
                       legend = "right", legend.title = "Model",
                       ggtheme = theme_pubr(),
@@ -144,6 +155,47 @@ ggrocplot <- function(data, response, predictor,
   line.args <- list(linewidth = size %||% 0.8, linetype = linetype)
   if (!multi) line.args$color <- color %||% "#2E9FDF"
   p <- p + do.call(geom_line, line.args)
+
+  # Optimal-cutpoint marker (the Youden index J = sensitivity + specificity - 1): the
+  # operating point maximizing tpr - fpr, drawn on top of the curve with its
+  # threshold labelled. Drawn per model (colored to match) and skipped for a
+  # predictor with no meaningful cutpoint (AUC <= 0.5, marked NA upstream).
+  if (youden) {
+    yd <- summ[!is.na(summ$youden.fpr), , drop = FALSE]
+    if (nrow(yd) > 0) {
+      yd$.label <- formatC(yd$youden.threshold, format = "g", digits = 3)
+      if (multi) {
+        yd$.model <- factor(yd$model, levels = summ$model, labels = labels)
+        p <- p +
+          geom_point(
+            data = yd, inherit.aes = FALSE, show.legend = FALSE,
+            aes(x = .data[["youden.fpr"]], y = .data[["youden.tpr"]],
+              color = .data[[".model"]]),
+            shape = 21, fill = "white", size = 2.6, stroke = 1
+          ) +
+          geom_text(
+            data = yd, inherit.aes = FALSE, show.legend = FALSE,
+            aes(x = .data[["youden.fpr"]], y = .data[["youden.tpr"]],
+              label = .data[[".label"]], color = .data[[".model"]]),
+            nudge_x = 0.025, nudge_y = -0.03, hjust = 0, vjust = 1, size = 3
+          )
+      } else {
+        p <- p +
+          geom_point(
+            data = yd, inherit.aes = FALSE,
+            aes(x = .data[["youden.fpr"]], y = .data[["youden.tpr"]]),
+            shape = 21, fill = "white", color = youden.color, size = 2.8, stroke = 1
+          ) +
+          geom_text(
+            data = yd, inherit.aes = FALSE,
+            aes(x = .data[["youden.fpr"]], y = .data[["youden.tpr"]],
+              label = .data[[".label"]]),
+            nudge_x = 0.025, nudge_y = -0.03, hjust = 0, vjust = 1,
+            size = 3.1, color = youden.color
+          )
+      }
+    }
+  }
 
   # AUC annotation for a single curve (multi-curve carries it in the legend).
   # Pin it to the bottom-right of the panel (Inf/-Inf) so it stays visible even
@@ -238,7 +290,10 @@ ggrocplot <- function(data, response, predictor,
   c(lo = max(0, auc - z * se), hi = min(1, auc + z * se))
 }
 
-# Empirical ROC operating points (fpr, tpr), tie-collapsed, with (0,0) prepended.
+# Empirical ROC operating points (fpr, tpr), tie-collapsed, with (0,0)
+# prepended. `threshold` is the predictor value at each point (predict positive
+# when the score is >= it); the (0,0) origin corresponds to +Inf (nothing
+# classified positive).
 .roc_points <- function(d01, score) {
   o <- order(score, decreasing = TRUE)
   d <- d01[o]
@@ -250,7 +305,24 @@ ggrocplot <- function(data, response, predictor,
   keep <- c(s[-length(s)] != s[-1], TRUE) # last index of each tied score run
   data.frame(
     fpr = c(0, fp[keep] / n0),
-    tpr = c(0, tp[keep] / n1)
+    tpr = c(0, tp[keep] / n1),
+    threshold = c(Inf, s[keep])
+  )
+}
+
+# Youden-optimal operating point: the point maximizing J = sensitivity +
+# specificity - 1 = tpr - fpr. Returns the point with its threshold, sensitivity
+# and specificity, or NULL when the optimum is a trivial corner (J <= 0, e.g. a
+# curve on/under the diagonal) where no meaningful cutpoint exists.
+.roc_youden <- function(pts) {
+  j <- pts$tpr - pts$fpr
+  k <- which.max(j)
+  if (length(k) == 0 || j[k] <= 0 || !is.finite(pts$threshold[k])) {
+    return(NULL)
+  }
+  data.frame(
+    fpr = pts$fpr[k], tpr = pts$tpr[k], threshold = pts$threshold[k],
+    sensitivity = pts$tpr[k], specificity = 1 - pts$fpr[k]
   )
 }
 
@@ -273,10 +345,16 @@ ggrocplot <- function(data, response, predictor,
     auc <- .auc_mannwhitney(d01, score)
     ci <- .auc_ci_hanley(auc, n1, n0, conf.level)
     pts <- .roc_points(d01, score)
+    # No meaningful optimal cut-point for a predictor that is not better than
+    # chance (AUC <= 0.5); such a predictor is flagged separately as reversed.
+    y <- if (auc > 0.5) .roc_youden(pts) else NULL
     pts$.model <- pv
-    curve.list[[pv]] <- pts
+    curve.list[[pv]] <- pts[, c("fpr", "tpr", ".model")]
     summary.list[[pv]] <- data.frame(
       model = pv, auc = auc, lo = ci[["lo"]], hi = ci[["hi"]],
+      youden.fpr = if (is.null(y)) NA_real_ else y$fpr,
+      youden.tpr = if (is.null(y)) NA_real_ else y$tpr,
+      youden.threshold = if (is.null(y)) NA_real_ else y$threshold,
       stringsAsFactors = FALSE
     )
   }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -82,6 +82,7 @@ YlGn
 YlGnBu
 YlOrBr
 YlOrRd
+Youden
 aaas
 aes
 al

--- a/man/ggrocplot.Rd
+++ b/man/ggrocplot.Rd
@@ -18,6 +18,8 @@ ggrocplot(
   diag = TRUE,
   diag.color = "grey60",
   diag.linetype = "dashed",
+  youden = FALSE,
+  youden.color = "grey30",
   title = NULL,
   xlab = "1 - Specificity",
   ylab = "Sensitivity",
@@ -68,6 +70,15 @@ is computed (Hanley-McNeil) and shown next to the AUC.}
 reference line is drawn.}
 
 \item{diag.color, diag.linetype}{color and line type of the diagonal reference.}
+
+\item{youden}{logical. If \code{TRUE}, the optimal cut-point is marked on each
+curve - the operating point maximizing the Youden index (\eqn{J =
+sensitivity + specificity - 1}) - and its predictor threshold is labelled.
+Default \code{FALSE}. A predictor with AUC \eqn{\le} 0.5 has no meaningful
+cut-point and is not marked.}
+
+\item{youden.color}{the color of the optimal cut-point marker and label for a
+single curve (several curves are colored by predictor).}
 
 \item{title}{plot main title.}
 
@@ -128,6 +139,9 @@ df <- data.frame(
 
 # Single ROC curve with AUC + 95\% CI annotated
 ggrocplot(df, response = "outcome", predictor = "marker1")
+
+# Mark the optimal cut-point (the Youden index) with its threshold
+ggrocplot(df, response = "outcome", predictor = "marker1", youden = TRUE)
 
 # Compare two markers on the same axes
 ggrocplot(

--- a/tests/testthat/test-ggrocplot.R
+++ b/tests/testthat/test-ggrocplot.R
@@ -107,6 +107,76 @@ test_that("a predictor with AUC < 0.5 triggers a 'reversed' hint message", {
   expect_s3_class(p, "ggplot")
 })
 
+test_that("the Youden optimal cut-point maximizes sensitivity + specificity - 1", {
+  d <- data.frame(
+    y = factor(c("n", "n", "n", "p", "p", "p"), levels = c("n", "p")),
+    x = c(1, 2, 3, 2, 4, 5)
+  )
+  s <- .compute_roc(d, "y", "x", 0.95)$summary
+  # Recompute J over all operating points and confirm the marked point is the max.
+  pts <- ggpubr:::.roc_points(ggpubr:::.roc_binarize(d$y), d$x)
+  jmax <- max(pts$tpr - pts$fpr)
+  expect_equal(s$youden.tpr - s$youden.fpr, jmax, tolerance = 1e-9)
+  # sensitivity = tpr, specificity = 1 - fpr at the marked point.
+  expect_true(s$youden.tpr >= 0 && s$youden.tpr <= 1)
+  expect_true(s$youden.threshold %in% d$x) # threshold is an observed score
+})
+
+test_that("the Youden point matches pROC coords(best, youden)", {
+  skip_if_not_installed("pROC")
+  set.seed(3)
+  n <- 50
+  d <- data.frame(
+    y = factor(rep(c("ctrl", "case"), each = n), levels = c("ctrl", "case")),
+    x = c(stats::rnorm(n), stats::rnorm(n, 1))
+  )
+  s <- .compute_roc(d, "y", "x", 0.95)$summary
+  r <- pROC::roc(d$y, d$x, levels = c("ctrl", "case"), direction = "<", quiet = TRUE)
+  co <- pROC::coords(r, "best", best.method = "youden",
+    ret = c("sensitivity", "specificity"), transpose = FALSE)
+  # Our sensitivity/specificity equal one of pROC's best points (ties possible).
+  expect_true(any(
+    abs(co$sensitivity - s$youden.tpr) < 1e-9 &
+      abs(co$specificity - (1 - s$youden.fpr)) < 1e-9
+  ))
+})
+
+test_that("youden = TRUE adds a marker + label; default draws neither", {
+  set.seed(1)
+  n <- 30
+  d <- data.frame(
+    y = factor(rep(c("n", "p"), each = n), levels = c("n", "p")),
+    x1 = c(stats::rnorm(n), stats::rnorm(n, 1)),
+    x2 = c(stats::rnorm(n), stats::rnorm(n, 0.6))
+  )
+  has_geom <- function(p, g) any(vapply(p$layers, function(l) inherits(l$geom, g), logical(1)))
+  expect_false(has_geom(ggrocplot(d, "y", "x1"), "GeomPoint"))
+  p1 <- ggrocplot(d, "y", "x1", youden = TRUE)
+  expect_true(has_geom(p1, "GeomPoint"))
+  expect_true(has_geom(p1, "GeomText"))
+  # One marked point per predictor with AUC > 0.5 (multi).
+  pm <- ggrocplot(d, "y", c("x1", "x2"), youden = TRUE)
+  i <- which(vapply(pm$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1)))
+  expect_equal(nrow(ggplot2::layer_data(pm, i[1])), 2)
+})
+
+test_that("a predictor with AUC <= 0.5 gets no Youden point", {
+  # Negatively-associated (AUC < 0.5) and constant (AUC = 0.5) predictors.
+  d <- data.frame(
+    y = factor(rep(c("n", "p"), each = 15), levels = c("n", "p")),
+    neg = c(seq(2, 3, length.out = 15), seq(0, 1, length.out = 15)),
+    const = rep(5, 30)
+  )
+  s <- suppressMessages(.compute_roc(d, "y", c("neg", "const"), 0.95)$summary)
+  expect_true(all(is.na(s$youden.fpr)))
+  # No marker layer rows for an AUC<=0.5 predictor even with youden = TRUE.
+  p <- suppressMessages(ggrocplot(d, "y", "const", youden = TRUE))
+  no_point <- !any(vapply(p$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1))) ||
+    nrow(ggplot2::layer_data(p,
+      which(vapply(p$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1)))[1])) == 0
+  expect_true(no_point)
+})
+
 test_that("the ROC axes use collision-free breaks and the multi legend wraps", {
   set.seed(1)
   n <- 30


### PR DESCRIPTION
## `ggrocplot()`: mark the optimal cut-point (Youden's J)

Adds an opt-in `youden = TRUE`. When set, the operating point that maximizes Youden's index
(sensitivity + specificity − 1) is marked on each ROC curve, and its predictor threshold is
labelled.

```r
ggrocplot(df, "outcome", c("marker1", "marker2"), palette = "jco", youden = TRUE)
```

![ggrocplot youden](https://i.imgur.com/fNN6Pas.png)

- Several curves are marked in their own color; the legend is unchanged.
- A predictor with AUC ≤ 0.5 has no meaningful cut-point and is left unmarked.
- The optimal point's sensitivity and specificity match `pROC::coords(roc, "best", best.method = "youden")`
  exactly; the labelled threshold is the observed predictor score (predict positive when the score is
  at or above it).

The default (`youden = FALSE`) output is unchanged (byte-identical). Purely additive.
