### PR TITLE
Support facet.by in ggcompare() two-way mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## New features
 
+- `ggcompare()` two-way (grouped) mode now supports `facet.by`. The simple
+  pairwise comparisons and the two-way interaction are computed within each
+  facet panel, and a compact interaction label is drawn in each panel (in place
+  of the single pooled subtitle used without faceting) (#769).
+
 - New `ggrocplot()` draws a publication-ready ROC curve with the area under the
   curve (AUC) and its confidence interval computed and annotated on the plot;
   passing several predictor columns overlays one curve per model for comparison,

--- a/R/ggcompare.R
+++ b/R/ggcompare.R
@@ -51,8 +51,10 @@ NULL
 #'   two-way ANOVA that names the interaction. In this mode the pairwise
 #'   \code{method} defaults to \code{"emmeans_test"} (pooled-model simple
 #'   comparisons), \code{p.adjust.method} to \code{"bonferroni"} and
-#'   \code{hide.ns} to \code{TRUE}; each remains overridable. The one-way path is
-#'   unchanged.
+#'   \code{hide.ns} to \code{TRUE}; each remains overridable. With \code{facet.by}
+#'   the pairwise comparisons and the two-way interaction are computed \emph{per
+#'   panel}, and a compact interaction label is drawn inside each panel (in place
+#'   of the single pooled subtitle). The one-way path is unchanged.
 #' @param ref.group a group level used as the reference; each other group is
 #'   compared to it. See \code{\link{geom_pwc}()}.
 #' @param method the pairwise comparison test. Default \code{"t_test"}. See
@@ -247,11 +249,6 @@ ggcompare <- function(data, x, y,
   # computed directly here because geom_pwc()'s internal grouped test does not
   # reproduce them for a multi-level legend.
   if (two.way) {
-    if (!is.null(facet.by)) {
-      stop("`facet.by` is not yet supported in two-way (grouped) mode. Draw the ",
-        "grouped figure without faceting, or facet a one-way plot.",
-        call. = FALSE)
-    }
     if (isTRUE(effsize)) {
       warning("`effsize` is not supported in two-way (grouped) mode; ignoring it.",
         call. = FALSE)
@@ -281,10 +278,12 @@ ggcompare <- function(data, x, y,
     }
     test.fun2 <- get(method.name, envir = asNamespace("rstatix"))
     test.formula <- stats::as.formula(paste(y, "~", comp.var))
-    call.args <- c(
-      list(dplyr::group_by(data, .data[[grp.var]]), test.formula),
-      method.args
+    # Group by the faceting variable(s) as well, so the pairwise test is run
+    # per panel; facet.by is NULL for a single (non-faceted) panel.
+    grouped.data <- dplyr::group_by(
+      data, dplyr::across(dplyr::all_of(c(facet.by, grp.var)))
     )
+    call.args <- c(list(grouped.data, test.formula), method.args)
     if ("p.adjust.method" %in% names(formals(test.fun2))) {
       call.args$p.adjust.method <- p.adjust.method
     }
@@ -311,13 +310,21 @@ ggcompare <- function(data, x, y,
       p <- p + ggplot2::labs(caption = rstatix::get_pwc_label(pwc, type = cap.type))
     }
 
-    if (omnibus == "anova") {
-      p <- do.call(
-        add_test_label,
-        c(list(p, method = "anova", group.by = group.var), omnibus.args)
-      )
-    } else if (omnibus == "kruskal") {
-      p <- do.call(add_test_label, c(list(p, method = "kruskal"), omnibus.args))
+    # Omnibus test. Without facets, one subtitle names the pooled two-way
+    # interaction. With facets, the interaction is per panel, so a compact label
+    # is drawn inside each panel instead (a single subtitle would misleadingly
+    # pool the panels).
+    if (is.null(facet.by)) {
+      if (omnibus == "anova") {
+        p <- do.call(
+          add_test_label,
+          c(list(p, method = "anova", group.by = group.var), omnibus.args)
+        )
+      } else if (omnibus == "kruskal") {
+        p <- do.call(add_test_label, c(list(p, method = "kruskal"), omnibus.args))
+      }
+    } else if (omnibus == "anova") {
+      p <- .add_faceted_interaction_labels(p, data, x, y, group.var, facet.by)
     }
     return(p)
   }
@@ -374,4 +381,50 @@ ggcompare <- function(data, x, y,
   }
 
   p
+}
+
+
+# Draw a compact two-way interaction label inside each facet panel: for a
+# faceted grouped comparison, the interaction (x * group.var) is computed per
+# panel and placed at the top-center of the panel. Returns the updated plot.
+.add_faceted_interaction_labels <- function(p, data, x, y, group.var, facet.by) {
+  fmt.p <- function(pv) {
+    if (is.na(pv)) return("p = NA")
+    if (pv < 0.001) "p < 0.001" else paste0("p = ", formatC(pv, format = "fg", digits = 2))
+  }
+  one <- function(df) {
+    at <- rstatix::get_anova_table(rstatix::anova_test(
+      df, stats::as.formula(paste(y, "~", x, "*", group.var))
+    ))
+    ir <- which(grepl(":", at$Effect))[1]
+    # A degenerate panel (aliased/empty design) has no estimable interaction:
+    # omit its label rather than print "F(NA,NA) = NA".
+    if (is.na(ir) || is.na(at$F[ir])) return(NA_character_)
+    sprintf("Interaction: F(%g,%g) = %.2f, %s",
+      at$DFn[ir], at$DFd[ir], at$F[ir], fmt.p(at$p[ir]))
+  }
+  groups <- do.call(paste, c(data[, facet.by, drop = FALSE], sep = "\r"))
+  parts <- split(seq_len(nrow(data)), groups)
+  labs <- lapply(parts, function(idx) {
+    d <- data[idx, , drop = FALSE]
+    lab <- d[1, facet.by, drop = FALSE]
+    lab$.label <- one(d)
+    lab
+  })
+  labs <- do.call(rbind, labs)
+  labs <- labs[!is.na(labs$.label), , drop = FALSE]
+  if (nrow(labs) == 0L) {
+    return(p + ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0.05, 0.15))))
+  }
+  # Center on the discrete x axis; y = Inf pins to the panel top (extra top
+  # expansion keeps the label clear of the brackets).
+  n.x <- nlevels(factor(data[[x]]))
+  labs$.x <- (1 + n.x) / 2
+  p +
+    ggplot2::geom_text(
+      data = labs, inherit.aes = FALSE,
+      ggplot2::aes(x = .data[[".x"]], y = Inf, label = .data[[".label"]]),
+      vjust = 1.4, size = 3
+    ) +
+    ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0.05, 0.15)))
 }

--- a/man/ggcompare.Rd
+++ b/man/ggcompare.Rd
@@ -76,8 +76,10 @@ builder (e.g. \code{"jitter"}, \code{"mean"}, \code{"mean_sd"}). Default
   two-way ANOVA that names the interaction. In this mode the pairwise
   \code{method} defaults to \code{"emmeans_test"} (pooled-model simple
   comparisons), \code{p.adjust.method} to \code{"bonferroni"} and
-  \code{hide.ns} to \code{TRUE}; each remains overridable. The one-way path is
-  unchanged.}
+  \code{hide.ns} to \code{TRUE}; each remains overridable. With \code{facet.by}
+  the pairwise comparisons and the two-way interaction are computed \emph{per
+  panel}, and a compact interaction label is drawn inside each panel (in place
+  of the single pooled subtitle). The one-way path is unchanged.}
 
 \item{ref.group}{a group level used as the reference; each other group is
 compared to it. See \code{\link{geom_pwc}()}.}

--- a/tests/testthat/test-ggcompare-two-way.R
+++ b/tests/testthat/test-ggcompare-two-way.R
@@ -102,14 +102,25 @@ test_that("brackets stay on the panel in both comparison directions", {
   expect_gt(brk_x(p_leg)[2], 2)
 })
 
-test_that("two-way mode rejects facet.by with a clear error (no crash)", {
+test_that("faceted two-way draws per-panel brackets and interaction labels", {
   js <- get_js()
   js$region <- factor(rep(c("north", "south"), length.out = nrow(js)))
-  expect_error(
-    ggcompare(js, x = "gender", y = "score", color = "education_level",
-      facet.by = "region"),
-    "not yet supported in two-way"
-  )
+  p <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    facet.by = "region")
+  expect_silent(ggplot2::ggplotGrob(ggplot2::ggplot_build(p)))
+  # Brackets are computed per panel: 3 education comparisons x 2 genders x 2
+  # regions = 12 (before hide.ns).
+  expect_equal(n_brackets(ggcompare(js, x = "gender", y = "score",
+    color = "education_level", facet.by = "region", hide.ns = FALSE)), 12)
+  # One per-panel interaction label per region.
+  ti <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  labs <- ggplot2::layer_data(p, ti[1])
+  expect_equal(nrow(labs), 2)
+  expect_true(all(grepl("^Interaction: F", labs$label)))
+  # omnibus = "none" drops the interaction labels.
+  p0 <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    facet.by = "region", omnibus = "none")
+  expect_false(any(vapply(p0$layers, function(l) inherits(l$geom, "GeomText"), logical(1))))
 })
 
 test_that("ref.group draws only comparisons to the reference level", {


### PR DESCRIPTION
## `ggcompare()`: faceted two-way comparisons

The two-way (grouped) mode of `ggcompare()` now supports `facet.by` (it previously raised a
"not yet supported" error). Everything is computed **per panel**: the simple pairwise comparison
brackets are run within each facet panel, and a compact two-way interaction label is drawn in each
panel (in place of the single pooled subtitle used without faceting).

```r
data("jobsatisfaction", package = "datarium")
js <- jobsatisfaction
js$region <- factor(rep(c("north", "south"), length.out = nrow(js)))
ggcompare(js, x = "gender", y = "score", color = "education_level", facet.by = "region")
```

![faceted two-way ggcompare](https://i.imgur.com/7s8i3Fi.png)

- Per-panel brackets carry the facet variable, so they land in the correct panel over the correct
  groups; `hide.ns` and `pwc.group.by` work as in the non-faceted case.
- The per-panel interaction label ("Interaction: F(df1, df2) = .., p = ..") is a separate two-way
  ANOVA computed on each facet subset. `omnibus = "none"`/`"kruskal"` draw no interaction label.
- A panel with no estimable interaction is left unlabelled.

The one-way and non-faceted two-way paths are unchanged (byte-identical).
