### PR TITLE
Document simple main effects on the two-way comparison figure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@
   facet panel, and a compact interaction label is drawn in each panel (in place
   of the single pooled subtitle used without faceting) (#769).
 
+- The "Two-Way Comparison Figures with ggcompare()" vignette gains a section
+  showing how to add per-group simple main effects to the figure, computed with
+  the pooled error from the full two-way model (`anova_test(..., error = model)`)
+  and drawn above each group's brackets.
+
 - New `ggrocplot()` draws a publication-ready ROC curve with the area under the
   curve (AUC) and its confidence interval computed and annotated on the plot;
   passing several predictor columns overlays one curve per model for comparison,

--- a/vignettes/two-way-comparison.Rmd
+++ b/vignettes/two-way-comparison.Rmd
@@ -81,6 +81,67 @@ jobsatisfaction %>%
   select(gender, group1, group2, p.adj, p.adj.signif)
 ```
 
+## Simple main effects on the plot
+
+When the interaction is significant, interpret it by breaking it into **simple
+main effects** -- the effect of the focal factor *within each level* of the
+other. Group by the moderator and run a one-way `anova_test()`, passing the full
+two-way model as `error` so the test borrows the **pooled error term** from the
+whole design:
+
+```{r simple-effects}
+model <- lm(score ~ gender * education_level, data = jobsatisfaction)
+
+sme <- jobsatisfaction %>%
+  group_by(gender) %>%
+  anova_test(score ~ education_level, error = model)
+sme
+```
+
+The pooled error is what keeps the denominator degrees of freedom at the
+full-model residual df -- here `F(2, 52)` for both genders. Dropping
+`error = model` would instead use each subset's own residuals, giving a
+different (smaller) df and a different F, so keep the `error` argument when you
+report a simple main effect.
+
+Layer those per-group F values onto the `ggcompare()` figure with a
+`geom_text()`, placing each label above its cluster's brackets:
+
+```{r simple-effects-plot}
+p <- ggcompare(
+  jobsatisfaction,
+  x = "gender", y = "score", color = "education_level"
+)
+
+# position each label just above that group's tallest bracket
+pwc <- jobsatisfaction %>%
+  group_by(gender) %>%
+  emmeans_test(score ~ education_level, p.adjust.method = "bonferroni") %>%
+  add_xy_position(x = "gender")
+tops <- tapply(pwc$y.position, pwc$gender, max)
+
+sme_lab <- transform(
+  sme,
+  x = as.integer(factor(gender, levels = levels(jobsatisfaction$gender))),
+  y = tops[as.character(gender)] + 0.4,
+  label = sprintf(
+    "F(%g,%g) = %.3g, %s", DFn, DFd, F,
+    ifelse(p < 0.0001, "p < 0.0001", paste0("p = ", signif(p, 2)))
+  )
+)
+
+p +
+  geom_text(
+    data = sme_lab, inherit.aes = FALSE,
+    aes(x = x, y = y, label = label), size = 3, fontface = "italic"
+  ) +
+  scale_y_continuous(expand = expansion(mult = c(0.05, 0.28)))
+```
+
+The figure now reports itself completely: the interaction on top, each gender's
+simple main effect of education above its boxes, and which education levels
+differ within each gender marked by the brackets.
+
 ## Customizing
 
 Every element is overridable. For instance, compare the *genders within each


### PR DESCRIPTION
Extends the **"Two-Way Comparison Figures with `ggcompare()`"** vignette with a section on **simple main effects**.

When a two-way interaction is significant, the recommended follow-up is to break it into simple main effects — the effect of the focal factor *within each level* of the moderator. The new section shows how to:

- compute each group's simple main effect with the **pooled error term** from the full two-way model, `anova_test(score ~ education_level, error = model)`, so the denominator degrees of freedom stay at the full-model residual df (`F(2, 52)` for both groups) rather than a smaller per-subset df; and
- draw those per-group F values on the `ggcompare()` figure with a `geom_text()` overlay placed above each group's comparison brackets.

The recipe reproduces the standard worked example (`jobsatisfaction`): males `F(2, 52) = 132, p < .0001`, females `F(2, 52) = 62.8, p < .0001`.

Docs only — no package R code changes, existing output is unaffected. The new chunks are gated behind the vignette's existing `datarium`/`emmeans` availability check, so the vignette still builds under `R CMD check`'s depends-only flavor.