### PR TITLE
Add simple.effects option to ggcompare() two-way mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@
   facet panel, and a compact interaction label is drawn in each panel (in place
   of the single pooled subtitle used without faceting) (#769).
 
+- `ggcompare()` two-way (grouped) mode gains an opt-in `simple.effects`
+  argument. With `simple.effects = TRUE`, each x group's simple main effect of
+  the compared factor is drawn above its brackets, computed with the pooled
+  error term from the full two-way model so the denominator degrees of freedom
+  are the full-model residual df. Default `FALSE` (existing output unchanged).
+
 - The "Two-Way Comparison Figures with ggcompare()" vignette gains a section
   showing how to add per-group simple main effects to the figure, computed with
   the pooled error from the full two-way model (`anova_test(..., error = model)`)

--- a/R/ggcompare.R
+++ b/R/ggcompare.R
@@ -54,7 +54,10 @@ NULL
 #'   \code{hide.ns} to \code{TRUE}; each remains overridable. With \code{facet.by}
 #'   the pairwise comparisons and the two-way interaction are computed \emph{per
 #'   panel}, and a compact interaction label is drawn inside each panel (in place
-#'   of the single pooled subtitle). The one-way path is unchanged.
+#'   of the single pooled subtitle). Set \code{simple.effects = TRUE} to also draw
+#'   each \code{x} group's simple main effect of the compared factor above its
+#'   brackets, computed with the pooled error from the full two-way model. The
+#'   one-way path is unchanged.
 #' @param ref.group a group level used as the reference; each other group is
 #'   compared to it. See \code{\link{geom_pwc}()}.
 #' @param method the pairwise comparison test. Default \code{"t_test"}. See
@@ -84,6 +87,13 @@ NULL
 #'   Direction of the grouped pairwise comparisons: \code{"x.var"} (default)
 #'   compares the second factor within each \code{x} group; \code{"legend.var"}
 #'   compares the \code{x} groups within each level of the second factor.
+#' @param simple.effects logical, used only in the two-way (grouped) mode. When
+#'   \code{TRUE}, the simple main effect of the compared factor within each
+#'   \code{x} group is drawn above that group's brackets, computed with the
+#'   pooled error term from the full two-way model (so its denominator degrees of
+#'   freedom are the full-model residual df). Default \code{FALSE}. Supported for
+#'   the default \code{pwc.group.by = "x.var"} direction and without
+#'   \code{facet.by}; other configurations issue a warning and are skipped.
 #' @param ... additional arguments passed to the base builder (e.g.
 #'   \code{ggboxplot}), such as \code{title}, \code{xlab}, \code{ylab}.
 #' @return a single customizable \code{ggplot}.
@@ -114,6 +124,9 @@ NULL
 #'   tg <- ToothGrowth
 #'   tg$dose <- as.factor(tg$dose)
 #'   ggcompare(tg, x = "supp", y = "len", color = "dose")
+#'
+#'   # Add each x group's simple main effect (pooled-error F) above its brackets
+#'   ggcompare(tg, x = "supp", y = "len", color = "dose", simple.effects = TRUE)
 #' }
 #'
 #' @export
@@ -130,7 +143,8 @@ ggcompare <- function(data, x, y,
                       pack = c("auto", "none"), pwc.args = list(),
                       omnibus = c("anova", "kruskal", "none"),
                       omnibus.args = list(),
-                      pwc.group.by = c("x.var", "legend.var"), ...) {
+                      pwc.group.by = c("x.var", "legend.var"),
+                      simple.effects = FALSE, ...) {
   base <- match.arg(base)
   pack <- match.arg(pack)
   omnibus <- match.arg(omnibus)
@@ -173,6 +187,10 @@ ggcompare <- function(data, x, y,
     if (method.missing) method <- "emmeans_test"
     if (padj.missing) p.adjust.method <- "bonferroni"
     if (hide.ns.missing) hide.ns <- TRUE
+  }
+  if (isTRUE(simple.effects) && !two.way) {
+    warning("`simple.effects` applies only in two-way (grouped) mode ",
+      "(map a second factor via `color`/`fill`); ignoring it.", call. = FALSE)
   }
 
   if (missing(ggtheme) && !is.null(facet.by)) {
@@ -310,6 +328,22 @@ ggcompare <- function(data, x, y,
       p <- p + ggplot2::labs(caption = rstatix::get_pwc_label(pwc, type = cap.type))
     }
 
+    # Optional per-group simple main effects drawn above each cluster's brackets.
+    # Supported for the default comparison direction (grp.var = the x axis) and
+    # without facets; other configurations warn and are skipped rather than
+    # placing a label with no clear anchor.
+    if (isTRUE(simple.effects)) {
+      if (!is.null(facet.by)) {
+        warning("`simple.effects` is not supported together with `facet.by`; ",
+          "ignoring it.", call. = FALSE)
+      } else if (pwc.group.by != "x.var") {
+        warning("`simple.effects = TRUE` is only supported with ",
+          "`pwc.group.by = \"x.var\"`; ignoring it.", call. = FALSE)
+      } else {
+        p <- .add_simple_effect_labels(p, data, x, y, group.var, grp.var, comp.var, pwc)
+      }
+    }
+
     # Omnibus test. Without facets, one subtitle names the pooled two-way
     # interaction. With facets, the interaction is per panel, so a compact label
     # is drawn inside each panel instead (a single subtitle would misleadingly
@@ -427,4 +461,60 @@ ggcompare <- function(data, x, y,
       vjust = 1.4, size = 3
     ) +
     ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0.05, 0.15)))
+}
+
+
+# Draw per-group simple-main-effect F labels above each cluster's brackets. The
+# simple main effect of `comp.var` within each level of `grp.var` is computed
+# with the pooled error term from the full two-way model
+# lm(y ~ x * group.var), so its denominator df is the full-model residual df
+# (not a smaller per-subset df). `grp.var` is the x-axis variable (the default
+# pwc.group.by = "x.var" direction), so each label sits at that x position, just
+# above the tallest bracket of the cluster (read from the already-positioned
+# `pwc`). Returns the updated plot; a degenerate group with no estimable simple
+# effect is skipped rather than labelled "F(NA,NA)".
+.add_simple_effect_labels <- function(p, data, x, y, group.var, grp.var, comp.var, pwc) {
+  model <- stats::lm(
+    stats::as.formula(paste(y, "~", x, "*", group.var)), data = data
+  )
+  grouped <- dplyr::group_by(data, dplyr::across(dplyr::all_of(grp.var)))
+  sme <- tryCatch(
+    rstatix::get_anova_table(rstatix::anova_test(
+      grouped, stats::as.formula(paste(y, "~", comp.var)), error = model
+    )),
+    error = function(e) NULL
+  )
+  if (is.null(sme) || nrow(sme) == 0L) {
+    return(p)
+  }
+  sme <- as.data.frame(sme)
+  # Format one compact "F(df1,df2) = F, p" label per group, matching the
+  # documented simple-effects recipe.
+  fmt.p <- function(pv) {
+    ifelse(pv < 1e-4, "p < 0.0001", paste0("p = ", signif(pv, 2)))
+  }
+  lv <- levels(factor(data[[grp.var]]))
+  # Key the tallest-bracket height by the integer x position (the midpoint of
+  # each bracket's xmin/xmax) rather than by pwc[[grp.var]]: add_xy_position()
+  # adds synthetic columns (x, xmin, xmax, groups, ...) that can shadow the
+  # grouping column when the x variable is itself named, e.g., "x".
+  x.idx <- round((pwc$xmin + pwc$xmax) / 2)
+  tops <- tapply(pwc$y.position, x.idx, max)
+  gap <- 0.06 * diff(range(data[[y]], na.rm = TRUE))
+  sme$.x <- match(as.character(sme[[grp.var]]), lv)
+  sme$.y <- as.numeric(tops[as.character(sme$.x)]) + gap
+  sme$.label <- sprintf(
+    "F(%g,%g) = %.3g, %s", sme$DFn, sme$DFd, sme$F, fmt.p(sme$p)
+  )
+  sme <- sme[is.finite(sme$.y) & is.finite(sme$F) & !is.na(sme$.label), , drop = FALSE]
+  if (nrow(sme) == 0L) {
+    return(p)
+  }
+  p +
+    ggplot2::geom_text(
+      data = sme, inherit.aes = FALSE,
+      ggplot2::aes(x = .data[[".x"]], y = .data[[".y"]], label = .data[[".label"]]),
+      size = 3, vjust = 0, fontface = "italic"
+    ) +
+    ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0.05, 0.28)))
 }

--- a/man/ggcompare.Rd
+++ b/man/ggcompare.Rd
@@ -30,6 +30,7 @@ ggcompare(
   omnibus = c("anova", "kruskal", "none"),
   omnibus.args = list(),
   pwc.group.by = c("x.var", "legend.var"),
+  simple.effects = FALSE,
   ...
 )
 }
@@ -79,7 +80,10 @@ builder (e.g. \code{"jitter"}, \code{"mean"}, \code{"mean_sd"}). Default
   \code{hide.ns} to \code{TRUE}; each remains overridable. With \code{facet.by}
   the pairwise comparisons and the two-way interaction are computed \emph{per
   panel}, and a compact interaction label is drawn inside each panel (in place
-  of the single pooled subtitle). The one-way path is unchanged.}
+  of the single pooled subtitle). Set \code{simple.effects = TRUE} to also draw
+  each \code{x} group's simple main effect of the compared factor above its
+  brackets, computed with the pooled error from the full two-way model. The
+  one-way path is unchanged.}
 
 \item{ref.group}{a group level used as the reference; each other group is
 compared to it. See \code{\link{geom_pwc}()}.}
@@ -121,6 +125,14 @@ layer (faceted plots).}
 Direction of the grouped pairwise comparisons: \code{"x.var"} (default)
 compares the second factor within each \code{x} group; \code{"legend.var"}
 compares the \code{x} groups within each level of the second factor.}
+
+\item{simple.effects}{logical, used only in the two-way (grouped) mode. When
+\code{TRUE}, the simple main effect of the compared factor within each
+\code{x} group is drawn above that group's brackets, computed with the
+pooled error term from the full two-way model (so its denominator degrees of
+freedom are the full-model residual df). Default \code{FALSE}. Supported for
+the default \code{pwc.group.by = "x.var"} direction and without
+\code{facet.by}; other configurations issue a warning and are skipped.}
 
 \item{...}{additional arguments passed to the base builder (e.g.
 \code{ggboxplot}), such as \code{title}, \code{xlab}, \code{ylab}.}
@@ -174,6 +186,9 @@ if (requireNamespace("emmeans", quietly = TRUE)) {
   tg <- ToothGrowth
   tg$dose <- as.factor(tg$dose)
   ggcompare(tg, x = "supp", y = "len", color = "dose")
+
+  # Add each x group's simple main effect (pooled-error F) above its brackets
+  ggcompare(tg, x = "supp", y = "len", color = "dose", simple.effects = TRUE)
 }
 
 }

--- a/tests/testthat/test-ggcompare-two-way.R
+++ b/tests/testthat/test-ggcompare-two-way.R
@@ -206,3 +206,90 @@ test_that("add_test_label(group.by=) names the interaction and selects effects",
     "requires method = 'anova'"
   )
 })
+
+# ---- simple.effects: per-group simple main effects on the plot --------------
+# Number of GeomText layers (the simple-effect F labels), excluding the mean and
+# bracket layers.
+n_text_layers <- function(p) {
+  sum(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+}
+text_labels <- function(p) {
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  if (length(i) == 0L) return(character(0))
+  as.character(p$layers[[i[1]]]$data$.label)
+}
+
+test_that("simple.effects = TRUE draws pooled-error simple main effects (132 / 62.8)", {
+  js <- get_js()
+  p <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+    simple.effects = TRUE)
+
+  # Exactly one GeomText layer carrying one label per x group (2 genders).
+  expect_equal(n_text_layers(p), 1)
+  labs <- text_labels(p)
+  expect_equal(length(labs), 2)
+
+  # The labels reproduce the pooled-error simple main effects from the lesson:
+  # F(2,52) for BOTH genders (the full-model residual df, not a per-subset df).
+  expect_true(all(grepl("F\\(2,52\\)", labs)))
+  expect_true(any(grepl("132", labs)))    # male
+  expect_true(any(grepl("62.8", labs)))   # female
+
+  # Cross-check against the direct pooled-error computation.
+  model <- stats::lm(score ~ gender * education_level, data = js)
+  truth <- js %>%
+    dplyr::group_by(gender) %>%
+    rstatix::anova_test(score ~ education_level, error = model) %>%
+    rstatix::get_anova_table()
+  expect_equal(sort(truth$DFd), c(52, 52))
+  expect_equal(round(truth$F[truth$gender == "male"]), 132)
+  expect_equal(round(truth$F[truth$gender == "female"], 1), 62.8)
+})
+
+test_that("simple.effects default (FALSE) adds no text layer (no regression)", {
+  js <- get_js()
+  p <- ggcompare(js, x = "gender", y = "score", color = "education_level")
+  expect_equal(n_text_layers(p), 0)
+})
+
+test_that("simple.effects warns and is skipped outside its supported config", {
+  js <- get_js()
+
+  # One-way mode: no second factor -> warn, no text.
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  expect_warning(
+    p1 <- ggcompare(df, x = "dose", y = "len", simple.effects = TRUE),
+    "only in two-way"
+  )
+  expect_equal(n_text_layers(p1), 0)
+
+  # legend.var direction -> warn, no text.
+  expect_warning(
+    p2 <- ggcompare(js, x = "gender", y = "score", color = "education_level",
+      pwc.group.by = "legend.var", simple.effects = TRUE),
+    "pwc.group.by"
+  )
+  expect_equal(n_text_layers(p2), 0)
+
+  # With facet.by -> warn.
+  js$grp <- rep(c("A", "B"), length.out = nrow(js))
+  expect_warning(
+    ggcompare(js, x = "gender", y = "score", color = "education_level",
+      facet.by = "grp", simple.effects = TRUE),
+    "not supported together with `facet.by`"
+  )
+})
+
+test_that("simple.effects is robust to an x column named like add_xy_position's synthetic columns", {
+  js <- get_js()
+  # Name the x-axis factor literally "x" (collides with add_xy_position's `x`).
+  names(js)[names(js) == "gender"] <- "x"
+  p <- ggcompare(js, x = "x", y = "score", color = "education_level",
+    simple.effects = TRUE)
+  labs <- text_labels(p)
+  # The labels must still be drawn (not silently dropped) with the right numbers.
+  expect_equal(length(labs), 2)
+  expect_true(any(grepl("132", labs)))
+  expect_true(any(grepl("62.8", labs)))
+})


### PR DESCRIPTION
Adds an opt-in `simple.effects` argument to the two-way (grouped) mode of `ggcompare()`.

When the interaction is significant, the recommended follow-up is to report each group's **simple main effect** — the effect of the compared factor *within each level* of the other. With `simple.effects = TRUE`, `ggcompare()` draws each x group's simple main effect F above that group's brackets, computed with the **pooled error term** from the full two-way model `lm(y ~ x * group.var)`, so the denominator degrees of freedom are the full-model residual df rather than a smaller per-subset df.

```r
ggcompare(jobsatisfaction, x = "gender", y = "score",
  color = "education_level", simple.effects = TRUE)
#> draws male F(2,52) = 132, female F(2,52) = 62.8 above each cluster
```

- **Default `FALSE`** — existing output is unchanged (the one-way path and the default two-way path are byte-identical).
- Supported for the default `pwc.group.by = "x.var"` direction and without `facet.by`; other configurations issue a warning and are skipped.
- The label height is anchored to each cluster's tallest bracket by x position, so it is robust to an x variable whose name collides with `add_xy_position()`'s internal columns.

Follows the recently documented simple-main-effects recipe in the "Two-Way Comparison Figures with `ggcompare()`" vignette, promoting it to a one-argument option. Includes regression and no-regression tests.