### PR TITLE
Document the development-cycle additions: vignettes, pkgdown reference, README

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # ggpubr 1.0.0.9000
 
+## Documentation
+
+- Three new vignettes: "Adding Statistical Test Results to Plots" (pairwise
+  brackets, compact letter display and omnibus labels, and when to use each),
+  "Forest and Estimation Plots with ggestimates()" (from a table or a fitted
+  model), and "ROC Curves and Diagnostic Accuracy with ggrocplot()".
+- The pkgdown reference index now lists the plot functions and helpers added in
+  this development cycle (`ggcompare()`, `ggrocplot()`, `ggestimates()`,
+  `ggraincloud()`, `ggvolcano()`, `stat_cld()`, `add_test_label()`,
+  `geom_violin_half()`, `style_scatterhist()`, `style_summarystats()`), and the
+  README highlights them.
+
 ## New features
 
 - New vignette "Combining ggpubr Plots with patchwork" shows how to arrange

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,19 @@ Find out more at https://rpkgs.datanovia.com/ggpubr/.
 
 ## Highlights in the development version
 
+New publication-ready plot types and figure builders:
+
+- `ggcompare()` — one-call group-comparison figures (box/violin/strip plus points, means, adjusted-p brackets and an omnibus test label), including two-way designs with simple main effects.
+- `ggrocplot()` — ROC curves with the AUC and its confidence interval, an optional optimal cut-point marker, and multi-marker overlays.
+- `ggestimates()` — forest and estimation plots (odds/hazard/risk ratios, regression coefficients, meta-analysis).
+- `ggraincloud()` — raincloud plots (half-violin plus box plus jittered points).
+- `ggvolcano()` — volcano plots for differential-expression results.
+- Statistical annotation helpers: `stat_cld()` (compact letter display), `add_test_label()` (omnibus test subtitle) and automatic bracket packing with `geom_pwc(pack = "auto")`.
+
+See the [articles](https://rpkgs.datanovia.com/ggpubr/articles/) for worked examples.
+
+Other updates:
+
 - Modern compatibility updates for current `ggplot2`, `dplyr`, and `tidyr`.
 - New p-value formatting helpers: `format_p_value()`, `get_p_format_style()`, `list_p_format_styles()`.
 - Extended p-value formatting parameters across statistical layers: `p.format.style`, `p.digits`, `p.leading.zero`, `p.min.threshold`, `p.decimal.mark`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ Find out more at <https://rpkgs.datanovia.com/ggpubr/>.
 
 ## Highlights in the development version
 
+New publication-ready plot types and figure builders:
+
+  - `ggcompare()` — one-call group-comparison figures (box/violin/strip
+    plus points, means, adjusted-p brackets and an omnibus test label),
+    including two-way designs with simple main effects.
+  - `ggrocplot()` — ROC curves with the AUC and its confidence interval,
+    an optional optimal cut-point marker, and multi-marker overlays.
+  - `ggestimates()` — forest and estimation plots (odds/hazard/risk
+    ratios, regression coefficients, meta-analysis).
+  - `ggraincloud()` — raincloud plots (half-violin plus box plus
+    jittered points).
+  - `ggvolcano()` — volcano plots for differential-expression results.
+  - Statistical annotation helpers: `stat_cld()` (compact letter
+    display), `add_test_label()` (omnibus test subtitle) and automatic
+    bracket packing with `geom_pwc(pack = "auto")`.
+
+See the [articles](https://rpkgs.datanovia.com/ggpubr/articles/) for
+worked examples.
+
+Other updates:
+
   - Modern compatibility updates for current `ggplot2`, `dplyr`, and
     `tidyr`.
   - New p-value formatting helpers: `format_p_value()`,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -23,6 +23,8 @@ reference:
     contents:
       - ggboxplot
       - ggviolin
+      - ggraincloud
+      - geom_violin_half
       - ggdotplot
       - ggstripchart
       - ggbarplot
@@ -32,6 +34,7 @@ reference:
       - ggdonutchart
       - ggdotchart
       - ggsummarystats
+      - style_summarystats
   - title: Plot Two Continuous Variables
     desc: Scatter plots
     contents:
@@ -40,12 +43,14 @@ reference:
       - stat_regline_equation
       - stat_stars
       - ggscatterhist
+      - style_scatterhist
   - title: Plot Paired Data
     desc: Paired data
     contents:
       - ggpaired
   - title: Comparing Means and Adding p-values
     contents:
+      - ggcompare
       - compare_means
       - stat_compare_means
       - stat_pvalue_manual
@@ -53,9 +58,19 @@ reference:
       - stat_kruskal_test
       - stat_welch_anova_test
       - stat_friedman_test
+      - stat_cld
       - geom_pwc
       - geom_bracket
+      - add_test_label
       - ggadjust_pvalue
+  - title: ROC Curves and Diagnostics
+    desc: Receiver operating characteristic (ROC) curves with AUC.
+    contents:
+      - ggrocplot
+  - title: Forest and Estimation Plots
+    desc: Point estimates with confidence intervals (odds/hazard/risk ratios, coefficients, meta-analysis).
+    contents:
+      - ggestimates
   - title: P-Value Formatting
     contents:
       - format_p_value
@@ -74,6 +89,7 @@ reference:
     desc: Plotting data obtained from genomic data analyses.
     contents:
       - ggmaplot
+      - ggvolcano
   - title: Themes
     contents:
       - theme_pubr
@@ -135,3 +151,19 @@ reference:
       - stat_mean
       - stat_central_tendency
       - reexports
+
+articles:
+  - title: Comparing groups
+    navbar: Comparisons
+    contents:
+      - statistical-annotations
+      - two-way-comparison
+  - title: Diagnostics and estimation
+    navbar: Diagnostics & estimation
+    contents:
+      - roc-curves
+      - forest-estimation-plots
+  - title: Composing figures
+    navbar: Composing figures
+    contents:
+      - ggpubr-with-patchwork

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -59,6 +59,7 @@ PuOr
 PuRd
 PubMed
 RColorBrewer
+README
 RMSD
 RNAseq
 RTCGA
@@ -115,6 +116,7 @@ cystadenocarcinoma
 desc
 df
 dfm
+discriminative
 donut
 dotdash
 dotplot
@@ -143,6 +145,7 @@ ggdotchart
 ggdotplot
 ggecdf
 ggerrorplot
+ggestimates
 gghistogram
 ggline
 ggmaplot
@@ -156,6 +159,7 @@ ggproto
 ggpubr's
 ggqqplot
 ggrepel
+ggrocplot
 ggscatter
 ggscatterhist
 ggsci
@@ -218,6 +222,7 @@ padj
 params
 pearson
 pes
+pkgdown
 plotmath
 png
 pointrange

--- a/vignettes/forest-estimation-plots.Rmd
+++ b/vignettes/forest-estimation-plots.Rmd
@@ -1,0 +1,155 @@
+---
+title: "Forest and Estimation Plots with ggestimates()"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Forest and Estimation Plots with ggestimates()}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+# The "from a fitted model" section uses datarium's example data; skip it
+# gracefully if datarium is not installed so the vignette still builds.
+has_datarium <- requireNamespace("datarium", quietly = TRUE)
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 6.5,
+  fig.height = 3.6,
+  dpi = 96,
+  message = FALSE,
+  warning = FALSE
+)
+```
+
+A **forest plot** shows a point estimate and its confidence interval for each of
+several groups or model terms on one axis, against a reference line -- the
+standard way to report odds/hazard/risk ratios, regression coefficients, or a
+meta-analysis. `ggestimates()` draws one from a data frame of **pre-computed**
+estimates: you supply the numbers, it draws a publication-ready figure with an
+optional right-hand column of the estimate and interval.
+
+Because it takes ready-made values, `ggestimates()` fits *any* source -- a model
+you fitted, a table from a paper, a meta-analysis -- with no modeling
+dependency of its own.
+
+```{r libs}
+library(ggpubr)
+```
+
+## From a table of estimates
+
+The simplest case: a data frame with an estimate and its confidence bounds. For
+**ratios** (odds/hazard/risk ratios) set `log.scale = TRUE` so the axis is
+symmetric around the null, and put the reference line at 1.
+
+```{r or}
+or <- data.frame(
+  term = c("Age (per year)", "Male sex", "BMI", "Current smoker", "Treatment"),
+  estimate = c(1.03, 1.45, 0.98, 2.10, 0.62),
+  conf.low = c(0.99, 1.05, 0.94, 1.40, 0.45),
+  conf.high = c(1.07, 2.00, 1.02, 3.15, 0.85)
+)
+
+ggestimates(or, label = "term", ref.line = 1, log.scale = TRUE,
+  xlab = "Odds ratio (95% CI)")
+```
+
+Each row shows the point estimate (filled square) and its 95% interval; the
+right-hand column prints the same numbers, and the dashed line marks the null
+(no effect). An interval that crosses the line is not significant at that level.
+
+## From a fitted model
+
+The usual workflow: fit a model, pull out the coefficients and confidence
+intervals, and hand them to `ggestimates()`. Here we model survival on the
+Titanic with logistic regression and plot the **odds ratios** -- all in base R.
+
+```{r model, eval = has_datarium}
+data("titanic.raw", package = "datarium")
+
+fit <- glm(Survived ~ Class + Sex + Age, data = titanic.raw,
+  family = binomial)
+
+# Odds ratios = exp(coefficients); 95% CI = exp(confint)
+est <- data.frame(
+  term = c("2nd class", "3rd class", "Crew", "Female", "Adult"),
+  estimate = exp(coef(fit))[-1],
+  conf.low = exp(confint.default(fit))[-1, 1],
+  conf.high = exp(confint.default(fit))[-1, 2]
+)
+
+ggestimates(est, label = "term", ref.line = 1, log.scale = TRUE,
+  sort = "estimate", xlab = "Odds ratio of survival (95% CI)",
+  title = "Titanic survival")
+```
+
+```{r model-note, echo = FALSE, eval = !has_datarium, results = "asis"}
+cat("> The fitted-model example needs the **datarium** package, which is not",
+    "installed, so its figure is not shown here.")
+```
+
+Read against the reference groups (1st class, male, child): women had far higher
+odds of survival, while 3rd-class passengers and adults had lower odds. The same
+recipe works for any model -- use `exp(coef)`/`exp(confint)` for a Cox or
+logistic model, or the raw coefficients (below) for a linear one.
+
+## Mean differences and linear coefficients
+
+For estimates on the **original (additive) scale** -- mean differences,
+linear-model coefficients -- keep `log.scale = FALSE` (the default) and put the
+reference line at 0.
+
+```{r md}
+md <- data.frame(
+  group = c("Low dose", "Medium dose", "High dose"),
+  estimate = c(1.8, 3.6, 5.9),
+  conf.low = c(0.4, 2.1, 4.0),
+  conf.high = c(3.2, 5.1, 7.8)
+)
+
+ggestimates(md, label = "group", color = "group", palette = "jco",
+  ref.line = 0, xlab = "Mean difference vs control (95% CI)")
+```
+
+## Sorting, banding, and the estimate column
+
+Order the rows by their estimate with `sort = "estimate"`, add zebra
+**banding** to guide the eye across a wide figure, and tune the right-hand
+estimate column with `ci.text.title` and `digits`:
+
+```{r styling, fig.height = 3.8}
+ggestimates(or, label = "term",
+  ref.line = 1, log.scale = TRUE,
+  sort = "estimate", descending = TRUE,
+  banding = TRUE,
+  ci.text.title = "OR (95% CI)", digits = 2,
+  xlab = "Odds ratio (95% CI)")
+```
+
+Turn the estimate column off with `ci.text = FALSE`, weight the point size by a
+column (e.g. a study's sample size) with `size =`, and see `?ggestimates` for
+the full argument list.
+
+## A meta-analysis forest
+
+The same primitive draws a meta-analysis: one row per study plus a pooled
+estimate. Weight the study markers by their precision with `size =`.
+
+```{r meta, fig.height = 3.8}
+meta <- data.frame(
+  study = c("Study A", "Study B", "Study C", "Study D", "Pooled"),
+  estimate = c(0.82, 0.75, 0.91, 0.68, 0.79),
+  conf.low = c(0.61, 0.55, 0.70, 0.48, 0.70),
+  conf.high = c(1.10, 1.02, 1.18, 0.96, 0.89),
+  weight = c(0.8, 1.0, 0.9, 0.7, 2.2)
+)
+
+ggestimates(meta, label = "study", size = "weight",
+  ref.line = 1, log.scale = TRUE,
+  ci.text.title = "RR (95% CI)",
+  xlab = "Risk ratio (95% CI)")
+```
+
+The larger pooled marker sits below the individual studies with a tighter
+interval -- the familiar bottom row of a meta-analysis forest.

--- a/vignettes/roc-curves.Rmd
+++ b/vignettes/roc-curves.Rmd
@@ -1,0 +1,117 @@
+---
+title: "ROC Curves and Diagnostic Accuracy with ggrocplot()"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{ROC Curves and Diagnostic Accuracy with ggrocplot()}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 5.5,
+  fig.height = 5,
+  dpi = 96,
+  message = FALSE,
+  warning = FALSE
+)
+```
+
+A **receiver operating characteristic (ROC) curve** shows how well a continuous
+marker or score separates two groups, across every possible cut-point. The area
+under the curve (**AUC**) summarizes it in one number: 0.5 is no better than
+chance, 1.0 is perfect. `ggrocplot()` draws a publication-ready ROC with the AUC
+and its confidence interval annotated, and can overlay several markers for
+comparison -- all in base R, with no modeling dependency.
+
+```{r libs}
+library(ggpubr)
+
+# A small biomarker study: disease status and two candidate markers
+set.seed(2024)
+n <- 120
+dx <- data.frame(
+  status = factor(
+    rep(c("healthy", "diseased"), each = n / 2),
+    levels = c("healthy", "diseased") # "diseased" = the positive class
+  ),
+  marker_A = c(rnorm(n / 2, 0), rnorm(n / 2, 1.4)),
+  marker_B = c(rnorm(n / 2, 0), rnorm(n / 2, 0.6))
+)
+```
+
+## A single ROC curve
+
+Pass the outcome (`response`) and the marker (`predictor`). The AUC and its 95%
+confidence interval -- computed in closed form (Hanley and McNeil, 1982) -- are
+printed on the plot.
+
+```{r single}
+ggrocplot(dx, response = "status", predictor = "marker_A")
+```
+
+The curve bows toward the top-left corner; the further from the diagonal (the
+grey chance line), the better the marker. Here the AUC is well above 0.5, so
+higher `marker_A` values indicate disease.
+
+### Which way round? The positive class and AUC below 0.5
+
+`ggrocplot()` treats the **second factor level** of `response` as the positive
+class and assumes **higher predictor values** indicate it -- it never silently
+flips the curve. If a marker is *lower* in cases, its AUC comes out below 0.5 and
+you get a message suggesting you reverse the predictor (or the factor levels):
+
+```{r reversed, message = TRUE}
+# A protective marker: LOWER values indicate disease
+dx$marker_low <- c(rnorm(n / 2, 1), rnorm(n / 2, 0))
+
+ggrocplot(dx, response = "status", predictor = "marker_low")
+```
+
+Negate the predictor to orient it (`transform()` a new column, or pass a
+pre-negated one) and the AUC flips above 0.5:
+
+```{r reversed-fixed}
+dx$marker_low_rev <- -dx$marker_low
+ggrocplot(dx, response = "status", predictor = "marker_low_rev")
+```
+
+## The optimal cut-point
+
+For a diagnostic threshold, `youden = TRUE` marks the point that maximizes the
+**Youden index** (sensitivity + specificity - 1) -- the cut-point furthest above
+the chance line -- and labels its value:
+
+```{r youden}
+ggrocplot(dx, response = "status", predictor = "marker_A", youden = TRUE)
+```
+
+## Comparing several markers
+
+Pass several predictors to overlay their curves on one plot; the legend shows
+each marker's AUC and CI, so you can compare discriminative ability at a glance:
+
+```{r compare, fig.width = 6}
+ggrocplot(
+  dx,
+  response = "status",
+  predictor = c("marker_A", "marker_B"),
+  palette = "jco"
+)
+```
+
+`marker_A` (the higher AUC) is the better discriminator. Customize with
+`palette`, `linetype`, `size`, `legend`/`legend.title`, and toggle the diagonal
+(`diag`), the AUC print-out (`print.auc`) or the CI (`ci`).
+
+## Notes
+
+- The empirical ROC, the AUC (equal to the Mann-Whitney statistic) and the
+  large-sample CI are all computed in base R, so `ggrocplot()` has no modeling
+  dependency and runs in lightweight environments.
+- For DeLong or bootstrap confidence intervals, ROC smoothing, or formal tests
+  between curves, use the `pROC` package.
+
+See `?ggrocplot` for the full argument list.

--- a/vignettes/statistical-annotations.Rmd
+++ b/vignettes/statistical-annotations.Rmd
@@ -1,0 +1,150 @@
+---
+title: "Adding Statistical Test Results to Plots"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Adding Statistical Test Results to Plots}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 6,
+  fig.height = 4,
+  dpi = 96,
+  message = FALSE,
+  warning = FALSE
+)
+```
+
+A publication figure should carry its own statistics. `ggpubr` gives you three
+complementary ways to put a test result on a plot, and the right choice depends
+on how many groups you have and what you want the reader to see:
+
+- **Pairwise brackets** -- one bracket per comparison, with a p-value or
+  significance stars (`geom_pwc()`, `stat_compare_means()`). Best for a **few
+  groups** where every pair matters.
+- **Compact letter display** -- one letter per group; groups that share a letter
+  are not significantly different (`stat_cld()`). Best for **many groups**, where
+  a full set of brackets becomes unreadable.
+- **An omnibus label** -- the single overall test (ANOVA / Kruskal-Wallis) as a
+  subtitle (`add_test_label()`). Answers "is there *any* difference?" before the
+  pairwise detail.
+
+This vignette shows each, and when to reach for which. All the examples use
+`rstatix` under the hood (already a `ggpubr` dependency).
+
+```{r libs}
+library(ggpubr)
+
+data("ToothGrowth")
+tg <- ToothGrowth
+tg$dose <- factor(tg$dose)
+```
+
+## Pairwise brackets
+
+`geom_pwc()` ("pairwise comparisons") adds a bracket for every pair of groups,
+with the adjusted p-value or significance stars. Add it to any `ggpubr` plot.
+
+```{r brackets-basic, fig.height = 4.2}
+ggboxplot(tg, x = "dose", y = "len", color = "dose", palette = "jco") +
+  geom_pwc(method = "t_test", label = "p.adj.format")
+```
+
+### Automatic bracket packing
+
+With several groups the brackets stack into a tall tower. `pack = "auto"` packs
+non-overlapping comparisons onto the same level, so the figure stays compact --
+compare the two panels below (same comparisons, packed on the right):
+
+```{r brackets-pack, fig.width = 7, fig.height = 4}
+p <- ggboxplot(tg, x = "dose", y = "len", color = "dose", palette = "jco")
+
+ggarrange(
+  p + geom_pwc(method = "t_test", label = "p.adj.signif") +
+    labs(title = "pack = \"none\" (default)"),
+  p + geom_pwc(method = "t_test", label = "p.adj.signif", pack = "auto") +
+    labs(title = "pack = \"auto\""),
+  ncol = 2, common.legend = TRUE, legend = "bottom"
+)
+```
+
+Hide the non-significant brackets with `hide.ns = TRUE`, and append an effect
+size with the `{effsize}` token:
+
+```{r brackets-effsize, fig.height = 4.2}
+ggboxplot(tg, x = "dose", y = "len", color = "dose", palette = "jco") +
+  geom_pwc(
+    method = "t_test", label = "{p.adj.signif} (d = {effsize})",
+    hide.ns = TRUE
+  )
+```
+
+## Compact letter display
+
+When you have **many** groups, a full set of pairwise brackets is unreadable.
+A **compact letter display** (CLD) is the standard alternative: each group gets
+one or more letters, and **groups that share a letter are not significantly
+different**. `stat_cld()` computes the letters from all-pairwise comparisons and
+places one label above each group.
+
+`InsectSprays` has six groups -- far too many for brackets, ideal for letters:
+
+```{r cld, fig.width = 6.5, fig.height = 4.2}
+ggboxplot(InsectSprays, x = "spray", y = "count",
+  color = "spray", palette = "jco") +
+  stat_cld() +
+  scale_y_continuous(expand = expansion(mult = c(0.05, 0.1))) +
+  labs(x = "Spray", y = "Insect count")
+```
+
+Read it as: sprays sharing a letter (e.g. the group labelled `a`) are
+statistically indistinguishable, while sprays with no letter in common differ.
+Switch the underlying test with `method =` (e.g. `"dunn_test"` for a
+non-parametric analysis), and set a common label height with `label.y`.
+
+### Brackets or letters?
+
+| Situation | Use |
+|---|---|
+| 2-4 groups, every pair of interest | pairwise **brackets** (`geom_pwc()`) |
+| 5+ groups, or a crowded bracket tower | **compact letters** (`stat_cld()`) |
+| You only need "is there any difference?" | **omnibus label** (below) |
+
+## The omnibus label
+
+Before the pairwise detail, readers often want the single overall test.
+`add_test_label()` adds it as a subtitle -- pass the plot in, get the plot back:
+
+```{r omnibus, fig.height = 4.2}
+p <- ggboxplot(tg, x = "dose", y = "len", color = "dose", palette = "jco") +
+  geom_pwc(method = "t_test", label = "p.adj.signif", hide.ns = TRUE)
+
+add_test_label(p, method = "anova")
+```
+
+Use `method = "kruskal"` for the non-parametric Kruskal-Wallis test. When a
+second factor is mapped, `group.by =` computes a two-way ANOVA and names the
+effect -- by default the interaction:
+
+```{r omnibus-twoway, fig.width = 7, fig.height = 4.2}
+p2 <- ggboxplot(tg, x = "supp", y = "len", color = "dose", palette = "jco")
+
+add_test_label(p2, group.by = "dose", type = "text")
+```
+
+## All three in one call
+
+`ggcompare()` assembles the whole figure -- base plot, jittered points, group
+means, packed adjusted-p brackets, and the omnibus subtitle -- in a single call:
+
+```{r ggcompare, fig.height = 4.5}
+ggcompare(tg, x = "dose", y = "len")
+```
+
+See the *"Two-Way Comparison Figures with ggcompare()"* vignette for the grouped
+(two-way) design, and `?geom_pwc`, `?stat_cld`, `?add_test_label` for the full
+argument lists.


### PR DESCRIPTION
Makes the plot functions and helpers added in this development cycle **discoverable and documented**, and adds three worked-example vignettes. Documentation only — no package code changes.

### New vignettes
- **Adding Statistical Test Results to Plots** — pairwise brackets with automatic packing (`geom_pwc(pack = "auto")`), compact letter display (`stat_cld()`), and omnibus test labels (`add_test_label()`), with guidance on when to use each (brackets for a few groups, letters for many).
- **Forest and Estimation Plots with `ggestimates()`** — from a table of estimates or a fitted model (a logistic-regression odds-ratio forest, mean differences, and a weighted meta-analysis).
- **ROC Curves and Diagnostic Accuracy with `ggrocplot()`** — AUC with its confidence interval, the optimal cut-point (Youden), and multi-marker overlays.

### Reference index and README
- Adds the new exports to the `_pkgdown.yml` reference index (`ggcompare`, `ggrocplot`, `ggestimates`, `ggraincloud`, `ggvolcano`, `stat_cld`, `add_test_label`, `geom_violin_half`, `style_scatterhist`, `style_summarystats`) — previously none of them appeared on the docs site — with two new sections (ROC/diagnostics, forest/estimation) and an `articles:` index grouping the vignettes.
- Refreshes the README highlights to name the new plot types.

All three vignettes build under `R CMD check` and its depends-only flavor (the one fitted-model example is gated on `datarium`); the others need only base R and existing dependencies. No R code, NAMESPACE, or DESCRIPTION changes.