### PR TITLE
Wrap the two-way interaction subtitle onto two lines

### DIFF
--- a/R/add_test_label.R
+++ b/R/add_test_label.R
@@ -46,6 +46,9 @@ NULL
 #'   group.by)}), \code{"all"} (a multi-line label with both main effects and the
 #'   interaction), or a term name (e.g. \code{"gender"} or
 #'   \code{"gender:education_level"}) or a numeric row index of the ANOVA table.
+#'   The default interaction label is drawn on two lines (the effect name above
+#'   the statistics) so it does not overflow at single-column figure widths; a
+#'   caller-supplied \code{description} keeps it on one line.
 #' @param ... additional arguments passed to
 #'   \code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}, or
 #'   \code{description} to override the auto-derived effect name).
@@ -210,7 +213,28 @@ add_test_label <- function(p, method = c("anova", "kruskal"),
     do.call(rstatix::get_test_label, args)
   }
 
+  # Two-line variant: the effect description on its own line above the
+  # statistics. A one-line interaction label ("Interaction (A x B), F(...), ...,
+  # n = N") overflows the right edge at single-column figure widths; wrapping
+  # keeps it fully visible with no loss of information.
+  wrap_label <- function(row) {
+    desc <- describe_term(terms[row])
+    stats <- do.call(rstatix::get_test_label, c(
+      list(res.aov, row = row, detailed = detailed, type = type, description = ""),
+      dots
+    ))
+    if (type == "text") {
+      return(paste(desc, stats, sep = "\n"))
+    }
+    substitute(atop(d, s), list(d = desc, s = stats))
+  }
+
   if (length(rows) == 1L) {
+    # Wrap only the (long) default interaction label. A short main-effect label,
+    # or a caller-supplied `description`, stays on a single line.
+    if (!user.description && grepl(":", terms[rows])) {
+      return(wrap_label(rows))
+    }
     return(make_label(rows))
   }
   # Multi-line: stack one line per effect. Plain text joins with newlines;

--- a/man/add_test_label.Rd
+++ b/man/add_test_label.Rd
@@ -58,7 +58,10 @@ effect (see \code{effect}). Only used when \code{method = "anova"}. Default
 \code{x:group.by} row, described as \dQuote{Interaction (x \eqn{\times}
 group.by)}), \code{"all"} (a multi-line label with both main effects and the
 interaction), or a term name (e.g. \code{"gender"} or
-\code{"gender:education_level"}) or a numeric row index of the ANOVA table.}
+\code{"gender:education_level"}) or a numeric row index of the ANOVA table.
+The default interaction label is drawn on two lines (the effect name above
+the statistics) so it does not overflow at single-column figure widths; a
+caller-supplied \code{description} keeps it on one line.}
 
 \item{...}{additional arguments passed to
 \code{\link[rstatix]{get_test_label}} (e.g. \code{style = "apa"}, or

--- a/tests/testthat/test-ggcompare-two-way.R
+++ b/tests/testthat/test-ggcompare-two-way.R
@@ -293,3 +293,33 @@ test_that("simple.effects is robust to an x column named like add_xy_position's 
   expect_true(any(grepl("132", labs)))
   expect_true(any(grepl("62.8", labs)))
 })
+
+# ---- two-way interaction subtitle wraps to two lines ------------------------
+test_that("the default two-way interaction subtitle wraps onto two lines", {
+  js <- get_js()
+  p <- ggboxplot(js, x = "gender", y = "score", color = "education_level")
+
+  # Expression mode: the wrapped label is an atop() call (line 1 = the effect
+  # name, line 2 = the statistics) so it does not overflow at narrow widths.
+  expr <- add_test_label(p, group.by = "education_level")$labels$subtitle
+  expect_true(is.call(expr) && identical(expr[[1]], as.name("atop")))
+
+  # Text mode: two newline-separated lines, description above the statistics,
+  # with every value retained (F, p, ges, n).
+  txt <- add_test_label(p, group.by = "education_level", type = "text")$labels$subtitle
+  lines <- strsplit(txt, "\n")[[1]]
+  expect_equal(length(lines), 2)
+  expect_match(lines[1], "^Interaction \\(gender")
+  expect_match(lines[2], "F\\(2,52\\)")
+  expect_match(lines[2], "n = 58")
+
+  # A main-effect label is short, so it stays on one line (no wrap).
+  main <- add_test_label(p, group.by = "education_level", effect = "gender",
+    type = "text")$labels$subtitle
+  expect_false(grepl("\n", main))
+
+  # A caller-supplied description keeps the single-line form (escape hatch).
+  usr <- add_test_label(p, group.by = "education_level", description = "Int",
+    type = "text")$labels$subtitle
+  expect_false(grepl("\n", usr))
+})


### PR DESCRIPTION
The default two-way ANOVA interaction subtitle from `add_test_label()` (and, through it, `ggcompare()`'s two-way mode) is a long single line — e.g. *"Interaction (gender × education_level), F(2,52) = 7.34, p = 0.002, η²g = 0.22, n = 58"*. At single-column figure widths (≤ ~6.5 in) it overflowed the right edge and could render a **truncated, misleading value** — a clipped `n = 58` reading as a plausible-but-false `n = 5`.

This draws the default interaction label on **two lines** instead — the effect name above the statistics — so the full label stays visible at narrow widths with **no loss of information** (every value is retained; only the `", "` separator becomes a line break). It uses the same `atop()` / newline mechanism the function already uses for `effect = "all"`.

Scope:
- Only the default **interaction** label wraps. A short **main-effect** label and a **caller-supplied `description`** stay on one line (the latter is the escape hatch for anyone wanting a single line).
- The **one-way** path and the two-way **non-interaction** paths are byte-identical to before (verified).

Both `ggcompare()` and `add_test_label()` are exported but were introduced this development cycle and are **not on CRAN** (not in v1.0.0), so this refines a default before its first release — no released-user impact. Includes a regression test (asserts the two-line shape, that all values are retained, and that main-effect / user-description labels stay single-line).