### PR TITLE
Fix r-devel Rd-contents NOTE on ggpubr_args

### DIFF
--- a/R/ggpubr_args.R
+++ b/R/ggpubr_args.R
@@ -1,55 +1,68 @@
 #' ggpubr General Arguments Description
 #'
-#' @param data a data frame
-#' @param x character string containing the name of x variable.
-#' @param y character vector containing one or more variables to plot
-#' @param combine logical value. Default is FALSE. Used only when y is a vector
-#'  containing multiple variables to plot. If TRUE, create a multi-panel plot by
-#'  combining the plot of y variables.
-#' @param merge logical or character value. Default is FALSE. Used only when y is
-#'  a vector containing multiple variables to plot. If TRUE, merge multiple y
-#'  variables in the same plotting area. Allowed values include also "asis"
-#'  (TRUE) and "flip". If merge = "flip", then y variables are used as x tick
-#'  labels and the x variable is used as grouping variable.
-#' @param color outline color.
-#' @param fill fill color.
-#' @param palette the color palette to be used for coloring or filling by groups.
-#'  Allowed values include "grey" for grey color palettes; brewer palettes e.g.
-#'  "RdBu", "Blues", ...; or custom color palette e.g. c("blue", "red"); and
-#'  scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
-#'  "lancet", "jco", "ucscgb", "uchicago", "simpsons" and "rickandmorty".
-#' @param linetype line types.
-#' @param size Numeric value (e.g.: size = 1). change the size of points and
-#'  outlines.
-#' @param select character vector specifying which items to display.
-#' @param remove character vector specifying which items to remove from the plot.
-#' @param order character vector specifying the order of items.
-#' @param add character vector for adding another plot element (e.g.: dot plot or
-#'  error bars). Allowed values are one or the combination of: "none",
-#'  "dotplot", "jitter", "boxplot", "point", "mean", "mean_se", "mean_sd",
-#'  "mean_ci", "mean_range", "median", "median_iqr", "median_mad",
-#'  "median_range"; see ?desc_statby for more details.
-#' @param add.params parameters (color, shape, size, fill, linetype) for the
-#'  argument 'add'; e.g.: add.params = list(color = "red").
-#' @param error.plot plot type used to visualize error. Allowed values are one of
-#'  c("pointrange", "linerange", "crossbar", "errorbar", "upper_errorbar",
-#'  "lower_errorbar", "upper_pointrange", "lower_pointrange", "upper_linerange",
-#'  "lower_linerange"). Default value is "pointrange" or "errorbar". Used only
-#'  when add != "none" and add contains one "mean_*" or "med_*" where "*" = sd,
-#'  se, ....
-#' @param font.label a list which can contain the combination of the following elements: the size
-#'  (e.g.: 14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and
-#'  the color (e.g.: "red") of labels. For example font.label = list(size = 14,
-#'  face = "bold", color ="red"). To specify only the size and the style, use font.label =
-#'  list(size = 14, face = "plain").
-#' @param title plot main title.
-#' @param xlab character vector specifying x axis labels. Use xlab
-#'   = FALSE to hide xlab.
-#' @param ylab character vector specifying y axis labels. Use ylab = FALSE to
-#'   hide ylab.
-#' @param ggtheme function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-#'  Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-#'  theme_minimal(), theme_classic(), theme_void(), ....
+#' @description A reference list of the general arguments shared across the
+#'   \code{ggpubr} plotting functions. These are documented on each individual
+#'   function; this page gathers them in one place. It is a reference page only
+#'   (no function to call).
+#'
+#' @section General arguments:
+#' \describe{
+#'   \item{\code{data}}{a data frame}
+#'   \item{\code{x}}{character string containing the name of x variable.}
+#'   \item{\code{y}}{character vector containing one or more variables to plot}
+#'   \item{\code{combine}}{logical value. Default is FALSE. Used only when y is a
+#'     vector containing multiple variables to plot. If TRUE, create a
+#'     multi-panel plot by combining the plot of y variables.}
+#'   \item{\code{merge}}{logical or character value. Default is FALSE. Used only
+#'     when y is a vector containing multiple variables to plot. If TRUE, merge
+#'     multiple y variables in the same plotting area. Allowed values include
+#'     also "asis" (TRUE) and "flip". If merge = "flip", then y variables are
+#'     used as x tick labels and the x variable is used as grouping variable.}
+#'   \item{\code{color}}{outline color.}
+#'   \item{\code{fill}}{fill color.}
+#'   \item{\code{palette}}{the color palette to be used for coloring or filling
+#'     by groups. Allowed values include "grey" for grey color palettes; brewer
+#'     palettes e.g. "RdBu", "Blues", ...; or custom color palette e.g.
+#'     c("blue", "red"); and scientific journal palettes from ggsci R package,
+#'     e.g.: "npg", "aaas", "lancet", "jco", "ucscgb", "uchicago", "simpsons"
+#'     and "rickandmorty".}
+#'   \item{\code{linetype}}{line types.}
+#'   \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
+#'     and outlines.}
+#'   \item{\code{select}}{character vector specifying which items to display.}
+#'   \item{\code{remove}}{character vector specifying which items to remove from
+#'     the plot.}
+#'   \item{\code{order}}{character vector specifying the order of items.}
+#'   \item{\code{add}}{character vector for adding another plot element (e.g.: dot
+#'     plot or error bars). Allowed values are one or the combination of: "none",
+#'     "dotplot", "jitter", "boxplot", "point", "mean", "mean_se", "mean_sd",
+#'     "mean_ci", "mean_range", "median", "median_iqr", "median_mad",
+#'     "median_range"; see ?desc_statby for more details.}
+#'   \item{\code{add.params}}{parameters (color, shape, size, fill, linetype) for
+#'     the argument 'add'; e.g.: add.params = list(color = "red").}
+#'   \item{\code{error.plot}}{plot type used to visualize error. Allowed values
+#'     are one of c("pointrange", "linerange", "crossbar", "errorbar",
+#'     "upper_errorbar", "lower_errorbar", "upper_pointrange", "lower_pointrange",
+#'     "upper_linerange", "lower_linerange"). Default value is "pointrange" or
+#'     "errorbar". Used only when add != "none" and add contains one "mean_*" or
+#'     "med_*" where "*" = sd, se, ....}
+#'   \item{\code{font.label}}{a list which can contain the combination of the
+#'     following elements: the size (e.g.: 14), the style (e.g.: "plain", "bold",
+#'     "italic", "bold.italic") and the color (e.g.: "red") of labels. For
+#'     example font.label = list(size = 14, face = "bold", color ="red"). To
+#'     specify only the size and the style, use font.label = list(size = 14,
+#'     face = "plain").}
+#'   \item{\code{title}}{plot main title.}
+#'   \item{\code{xlab}}{character vector specifying x axis labels. Use xlab =
+#'     FALSE to hide xlab.}
+#'   \item{\code{ylab}}{character vector specifying y axis labels. Use ylab =
+#'     FALSE to hide ylab.}
+#'   \item{\code{ggtheme}}{function, ggplot2 theme name. Default value is
+#'     theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the
+#'     plot keeps ggplot2 default theme or the theme set globally via
+#'     theme_set(). Allowed values include ggplot2 official themes: theme_gray(),
+#'     theme_bw(), theme_minimal(), theme_classic(), theme_void(), ....}
+#' }
 #' @name ggpubr_args
 #' @rdname ggpubr_args
 NULL

--- a/man/ggpubr_args.Rd
+++ b/man/ggpubr_args.Rd
@@ -3,78 +3,70 @@
 \name{ggpubr_args}
 \alias{ggpubr_args}
 \title{ggpubr General Arguments Description}
-\arguments{
-\item{data}{a data frame}
-
-\item{x}{character string containing the name of x variable.}
-
-\item{y}{character vector containing one or more variables to plot}
-
-\item{combine}{logical value. Default is FALSE. Used only when y is a vector
-containing multiple variables to plot. If TRUE, create a multi-panel plot by
-combining the plot of y variables.}
-
-\item{merge}{logical or character value. Default is FALSE. Used only when y is
-a vector containing multiple variables to plot. If TRUE, merge multiple y
-variables in the same plotting area. Allowed values include also "asis"
-(TRUE) and "flip". If merge = "flip", then y variables are used as x tick
-labels and the x variable is used as grouping variable.}
-
-\item{color}{outline color.}
-
-\item{fill}{fill color.}
-
-\item{palette}{the color palette to be used for coloring or filling by groups.
-Allowed values include "grey" for grey color palettes; brewer palettes e.g.
-"RdBu", "Blues", ...; or custom color palette e.g. c("blue", "red"); and
-scientific journal palettes from ggsci R package, e.g.: "npg", "aaas",
-"lancet", "jco", "ucscgb", "uchicago", "simpsons" and "rickandmorty".}
-
-\item{linetype}{line types.}
-
-\item{size}{Numeric value (e.g.: size = 1). change the size of points and
-outlines.}
-
-\item{select}{character vector specifying which items to display.}
-
-\item{remove}{character vector specifying which items to remove from the plot.}
-
-\item{order}{character vector specifying the order of items.}
-
-\item{add}{character vector for adding another plot element (e.g.: dot plot or
-error bars). Allowed values are one or the combination of: "none",
-"dotplot", "jitter", "boxplot", "point", "mean", "mean_se", "mean_sd",
-"mean_ci", "mean_range", "median", "median_iqr", "median_mad",
-"median_range"; see ?desc_statby for more details.}
-
-\item{add.params}{parameters (color, shape, size, fill, linetype) for the
-argument 'add'; e.g.: add.params = list(color = "red").}
-
-\item{error.plot}{plot type used to visualize error. Allowed values are one of
-c("pointrange", "linerange", "crossbar", "errorbar", "upper_errorbar",
-"lower_errorbar", "upper_pointrange", "lower_pointrange", "upper_linerange",
-"lower_linerange"). Default value is "pointrange" or "errorbar". Used only
-when add != "none" and add contains one "mean_*" or "med_*" where "*" = sd,
-se, ....}
-
-\item{font.label}{a list which can contain the combination of the following elements: the size
-(e.g.: 14), the style (e.g.: "plain", "bold", "italic", "bold.italic") and
-the color (e.g.: "red") of labels. For example font.label = list(size = 14,
-face = "bold", color ="red"). To specify only the size and the style, use font.label =
-list(size = 14, face = "plain").}
-
-\item{title}{plot main title.}
-
-\item{xlab}{character vector specifying x axis labels. Use xlab
-= FALSE to hide xlab.}
-
-\item{ylab}{character vector specifying y axis labels. Use ylab = FALSE to
-hide ylab.}
-
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the plot keeps ggplot2 default theme or the theme set globally via theme_set().
-Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
-theme_minimal(), theme_classic(), theme_void(), ....}
-}
 \description{
-ggpubr General Arguments Description
+A reference list of the general arguments shared across the
+  \code{ggpubr} plotting functions. These are documented on each individual
+  function; this page gathers them in one place. It is a reference page only
+  (no function to call).
 }
+\section{General arguments}{
+
+\describe{
+  \item{\code{data}}{a data frame}
+  \item{\code{x}}{character string containing the name of x variable.}
+  \item{\code{y}}{character vector containing one or more variables to plot}
+  \item{\code{combine}}{logical value. Default is FALSE. Used only when y is a
+    vector containing multiple variables to plot. If TRUE, create a
+    multi-panel plot by combining the plot of y variables.}
+  \item{\code{merge}}{logical or character value. Default is FALSE. Used only
+    when y is a vector containing multiple variables to plot. If TRUE, merge
+    multiple y variables in the same plotting area. Allowed values include
+    also "asis" (TRUE) and "flip". If merge = "flip", then y variables are
+    used as x tick labels and the x variable is used as grouping variable.}
+  \item{\code{color}}{outline color.}
+  \item{\code{fill}}{fill color.}
+  \item{\code{palette}}{the color palette to be used for coloring or filling
+    by groups. Allowed values include "grey" for grey color palettes; brewer
+    palettes e.g. "RdBu", "Blues", ...; or custom color palette e.g.
+    c("blue", "red"); and scientific journal palettes from ggsci R package,
+    e.g.: "npg", "aaas", "lancet", "jco", "ucscgb", "uchicago", "simpsons"
+    and "rickandmorty".}
+  \item{\code{linetype}}{line types.}
+  \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
+    and outlines.}
+  \item{\code{select}}{character vector specifying which items to display.}
+  \item{\code{remove}}{character vector specifying which items to remove from
+    the plot.}
+  \item{\code{order}}{character vector specifying the order of items.}
+  \item{\code{add}}{character vector for adding another plot element (e.g.: dot
+    plot or error bars). Allowed values are one or the combination of: "none",
+    "dotplot", "jitter", "boxplot", "point", "mean", "mean_se", "mean_sd",
+    "mean_ci", "mean_range", "median", "median_iqr", "median_mad",
+    "median_range"; see ?desc_statby for more details.}
+  \item{\code{add.params}}{parameters (color, shape, size, fill, linetype) for
+    the argument 'add'; e.g.: add.params = list(color = "red").}
+  \item{\code{error.plot}}{plot type used to visualize error. Allowed values
+    are one of c("pointrange", "linerange", "crossbar", "errorbar",
+    "upper_errorbar", "lower_errorbar", "upper_pointrange", "lower_pointrange",
+    "upper_linerange", "lower_linerange"). Default value is "pointrange" or
+    "errorbar". Used only when add != "none" and add contains one "mean_*" or
+    "med_*" where "*" = sd, se, ....}
+  \item{\code{font.label}}{a list which can contain the combination of the
+    following elements: the size (e.g.: 14), the style (e.g.: "plain", "bold",
+    "italic", "bold.italic") and the color (e.g.: "red") of labels. For
+    example font.label = list(size = 14, face = "bold", color ="red"). To
+    specify only the size and the style, use font.label = list(size = 14,
+    face = "plain").}
+  \item{\code{title}}{plot main title.}
+  \item{\code{xlab}}{character vector specifying x axis labels. Use xlab =
+    FALSE to hide xlab.}
+  \item{\code{ylab}}{character vector specifying y axis labels. Use ylab =
+    FALSE to hide ylab.}
+  \item{\code{ggtheme}}{function, ggplot2 theme name. Default value is
+    theme_pubr(). Set ggtheme = NULL to skip applying a ggpubr theme, so the
+    plot keeps ggplot2 default theme or the theme set globally via
+    theme_set(). Allowed values include ggplot2 official themes: theme_gray(),
+    theme_bw(), theme_minimal(), theme_classic(), theme_void(), ....}
+}
+}
+


### PR DESCRIPTION
Clears the CRAN r-devel check NOTE:

```
Check: Rd contents
Result: NOTE
  Rd files without \usage:
    ‘ggpubr_args.Rd’
  \arguments should not be documented without \usage.
```

`ggpubr_args` is a shared-arguments **reference page** (a documentation-only object). It documented its arguments with roxygen `@param`, so the generated `.Rd` carried an `\arguments{}` section with no `\usage{}` (there is no function to call) — which r-devel's stricter *Rd contents* check flags.

This renders the identical content under a **`\section{General arguments}`** (a `\describe` list) instead of `\arguments`, so the `?ggpubr_args` page reads the same for users but no longer trips the check. `R CMD check --as-cran` now reports `checking Rd contents ... OK`.

Documentation only — every argument description is preserved verbatim, the page still resolves in the pkgdown reference index, and there are no package code, NAMESPACE, or test changes.