### PR TITLE
Fix dodged error-bar alignment with alpha (#404), repoint redirecting links, unbreak CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,7 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             cran::ggrepel@0.9.5
+            github::kassambara/rstatix@v1.1.0
           needs: check
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,8 +60,6 @@ Suggests:
     patchwork,
     ggcorrplot
 VignetteBuilder: knitr
-Remotes:
-    kassambara/rstatix@release/1.1.0
 URL: https://rpkgs.datanovia.com/ggpubr/,
     https://github.com/kassambara/ggpubr
 BugReports: https://github.com/kassambara/ggpubr/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -152,20 +152,24 @@
 
 ## Bug fixes
 
-- `ggbarplot()` keeps each error bar on its own bar when one extra variable is
-  mapped to `alpha` and the bars are dodged with `position_dodge()`. The error
-  layer's dodge key was ordered differently from the bars' own grouping, so in a
-  design with three discrete variables half the error bars were centered on the
-  mean of an adjacent bar (#404). This changes the appearance of such a plot,
-  which was previously drawn with the error bars permuted. An `alpha` column
-  containing `NA` is aligned too: those rows keep a dodge slot of their own
-  instead of being dropped from the key. `position_dodge2()` and the stacked
-  default are unchanged. Three configurations remain unaligned, and their error
-  bars may sit differently than in 1.0.0 although they were not correct there
-  either: a fourth discrete aesthetic (`fill` and `color` and `alpha` together),
-  `top =`, and a user-set `add.params$group`.
+- `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
+  `alpha` and the bars are dodged with `position_dodge()` (#404). The error layer
+  dodged by a different key from the one ggplot2 groups the bars by, so in a
+  design with three discrete variables half the error bars were centered on an
+  adjacent bar's mean and carried its error. The key is now built from every
+  mapped discrete aesthetic, in the order ggplot2 lays them out, which also
+  aligns cases that were misplaced before: an `alpha` column whose levels are
+  reversed, unused or ordered, one containing `NA`, a `tibble` or grouped input,
+  `sort.val =`, `orientation = "horizontal"`, and a user-set
+  `add.params$group` naming the fill variable. This changes the appearance of
+  such a plot, which was previously drawn with the error bars permuted.
 
-- Updated the help-page links that had started redirecting.
+  Some configurations are still not aligned, among them a fourth discrete
+  aesthetic (`fill` and `color` and `alpha` on three different columns, now with
+  one error bar per bar but half of them still transposed), `facet.by`, `top =`,
+  and an `add.params$group` naming a column that is not mapped to any aesthetic.
+  `position_dodge2()` and the stacked default are unchanged, and a numeric
+  `alpha` column still fails as before.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -173,7 +173,10 @@
   that computed statistic rather than to the column. A numeric, integer or
   `Date` column mapped to `color`/`fill` is also unchanged: ggplot2 does not
   group the bars by such a column, so the layer draws more bars than there are
-  dodge positions and no error bar can be matched to a single bar. `top =` remains unsupported
+  dodge positions and no error bar can be matched to a single bar. `label = TRUE`
+  is unchanged too, and only the error bars are repositioned by this fix: the
+  value labels still dodge on the `fill` key alone, so with a discrete `alpha`
+  they are drawn between the bars, two to a position. `top =` remains unsupported
   alongside a discrete `alpha`: the error layer is still built for every
   summarised group rather than for the bars actually kept, so it draws more
   error bars than there are bars, some over empty space and some overlapping a

--- a/NEWS.md
+++ b/NEWS.md
@@ -169,10 +169,12 @@
 
   Still unchanged from previous releases: `position_dodge2()` and the stacked
   default, a numeric `alpha` column, and an `alpha` column named after one of
-  `desc_statby()`'s statistics (`se`, `sd`, `mean`, ...), which maps opacity to
-  that computed statistic. With `top =`, the error bars that fall on a bar are
-  now correct, but the layer still draws one row per summarised group rather than
-  per retained bar, so extra error bars appear where no bar was kept.
+  `desc_statby()`'s statistics (`se`, `sd`, `ci`, ...), which maps opacity to
+  that computed statistic rather than to the column. `top =` remains unsupported
+  alongside a discrete `alpha`: the error layer is still built for every
+  summarised group rather than for the bars actually kept, so it draws more
+  error bars than there are bars, some over empty space and some overlapping a
+  kept bar while carrying another group's statistic.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -160,13 +160,7 @@
   which was previously drawn with the error bars permuted. Unchanged, and still
   not aligned: an `alpha` column containing `NA`, a fourth discrete aesthetic,
   `top =`, a user-set `add.params$group`, `position_dodge2()`, and the stacked
-  default. A character `alpha` naming no column now reports the misspelled name
-  instead of failing inside grid.
-
-- `show.n = TRUE` counts the marks the panel draws rather than the rows, so a
-  group holding missing values is no longer labelled with a larger `n` than the
-  points beside it. Infinite values are still counted, because ggplot2 keeps them
-  and draws them on the panel edge.
+  default.
 
 - Updated the help-page links that had started redirecting.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -169,18 +169,18 @@
   permuted.
 
   Still unchanged from previous releases: `position_dodge2()` and the stacked
-  default, a numeric `alpha` column, and an `alpha` column named after one of the
+  default, a numeric `alpha` column, and a grouping column named after one of the
   statistics `desc_statby()` computes (`length`, `min`, `max`, `median`, `mean`,
   `iqr`, `mad`, `sd`, `se`, `ci`, `range`, `cv`, `var`) — the summary's column of
-  that name holds the computed statistic, so opacity follows the statistic rather
-  than the column, and the two that already failed still fail (`mean` at draw,
-  `ci` when the summary is built). A numeric, integer or `Date` column mapped to
-  `color`/`fill` is also unchanged: ggplot2 does not group the bars by such a
-  column, so the layer draws more bars than there are dodge positions and no
-  error bar can be matched to a single bar. `label = TRUE` is unchanged too, and
-  this fix moves only the error bars: the value labels still dodge on the `fill`
-  key alone, so with a discrete `alpha` they are drawn between the bars, two to
-  a position.
+  that name holds the computed statistic, so opacity follows the statistic
+  rather than the column, and the ones that already failed still fail (`mean` at
+  draw; `ci` when the column is character). A numeric, integer or `Date` column
+  mapped to `color`/`fill` is also unchanged: ggplot2 does not group the bars by
+  such a column, so the layer draws more bars than there are dodge positions and
+  no error bar can be matched to a single bar. `label = TRUE` is unchanged too,
+  and this fix moves only the error bars: the value labels still dodge on the
+  `fill` key alone, so with a discrete `alpha` they are drawn between the bars,
+  two to a position.
 
   `top =` remains unsupported alongside a discrete `alpha`, and is the one
   configuration whose broken output changed rather than staying as released: the

--- a/NEWS.md
+++ b/NEWS.md
@@ -179,7 +179,7 @@
   mapped to `color`/`fill` is also unchanged: ggplot2 does not group the bars by
   such a column, so the layer draws more bars than there are dodge positions and
   no error bar can be matched to a single bar. `label = TRUE` is unchanged too:
-  the value labels are not repositioned by this fix, and still dodge on the
+  the value labels are not moved by this fix, and still dodge on the
   `fill` key alone, so with a discrete `alpha` they are drawn between the bars,
   two to a position.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -158,18 +158,21 @@
   design with three discrete variables half the error bars were centered on an
   adjacent bar's mean and carried its error. The key is now built from every
   mapped discrete aesthetic, in the order ggplot2 lays them out, which also
-  aligns cases that were misplaced before: an `alpha` column whose levels are
-  reversed, unused or ordered, one containing `NA`, a `tibble` or grouped input,
-  `sort.val =`, `orientation = "horizontal"`, and a user-set
-  `add.params$group` naming the fill variable. This changes the appearance of
-  such a plot, which was previously drawn with the error bars permuted.
+  aligns cases that were misplaced before: `fill`, `color` and `alpha` on three
+  different columns; an `alpha` column whose levels are reversed, unused or
+  ordered; one containing `NA`; a `tibble` or grouped input; `facet.by =`,
+  including panels in which a level is absent and `scales = "free_x"`;
+  `sort.val =`, `sort.by.groups = FALSE`, `orientation = "horizontal"`, the
+  `error.plot =` variants, and a user-set `add.params$group`. This changes the
+  appearance of such a plot, which was previously drawn with the error bars
+  permuted.
 
-  Some configurations are still not aligned, among them a fourth discrete
-  aesthetic (`fill` and `color` and `alpha` on three different columns, now with
-  one error bar per bar but half of them still transposed), `facet.by`, `top =`,
-  and an `add.params$group` naming a column that is not mapped to any aesthetic.
-  `position_dodge2()` and the stacked default are unchanged, and a numeric
-  `alpha` column still fails as before.
+  Still unchanged from previous releases: `position_dodge2()` and the stacked
+  default, a numeric `alpha` column, and an `alpha` column named after one of
+  `desc_statby()`'s statistics (`se`, `sd`, `mean`, ...), which maps opacity to
+  that computed statistic. With `top =`, the error bars that fall on a bar are
+  now correct, but the layer still draws one row per summarised group rather than
+  per retained bar, so extra error bars appear where no bar was kept.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -153,8 +153,9 @@
 ## Bug fixes
 
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
-  `alpha` and the bars are dodged with `position_dodge()` (#404). The error layer
-  dodged by a different key from the one ggplot2 groups the bars by, so in a
+  `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz
+  (#404). The error layer dodged by a different key from the one ggplot2 uses to
+  group the bars, so in a
   design with three discrete variables half the error bars were centered on an
   adjacent bar's mean and carried its error. The key is now built from every
   mapped discrete aesthetic, in the order ggplot2 lays them out, which also
@@ -168,19 +169,22 @@
   permuted.
 
   Still unchanged from previous releases: `position_dodge2()` and the stacked
-  default, a numeric `alpha` column, and an `alpha` column named after one of
-  `desc_statby()`'s statistics (`se`, `sd`, `ci`, ...), which maps opacity to
-  that computed statistic rather than to the column. A numeric, integer or
-  `Date` column mapped to `color`/`fill` is also unchanged: ggplot2 does not
-  group the bars by such a column, so the layer draws more bars than there are
-  dodge positions and no error bar can be matched to a single bar. `label = TRUE`
-  is unchanged too, and only the error bars are repositioned by this fix: the
-  value labels still dodge on the `fill` key alone, so with a discrete `alpha`
-  they are drawn between the bars, two to a position. `top =` remains unsupported
-  alongside a discrete `alpha`: the error layer is still built for every
-  summarised group rather than for the bars actually kept, so it draws more
-  error bars than there are bars, some over empty space and some overlapping a
-  kept bar while carrying another group's statistic.
+  default, a numeric `alpha` column, and an `alpha` column named after one of the
+  statistics `desc_statby()` computes (`length`, `min`, `max`, `median`, `mean`,
+  `iqr`, `mad`, `sd`, `se`, `ci`, `range`, `cv`, `var`) — the summary's column of
+  that name holds the computed statistic, so opacity follows the statistic rather
+  than the column, and the two that already failed still fail (`mean` at draw,
+  `ci` when the summary is built). A numeric, integer or `Date` column mapped to
+  `color`/`fill` is also unchanged: ggplot2 does not group the bars by such a
+  column, so the layer draws more bars than there are dodge positions and no
+  error bar can be matched to a single bar. `label = TRUE` is unchanged too, and
+  this fix moves only the error bars: the value labels still dodge on the `fill`
+  key alone, so with a discrete `alpha` they are drawn between the bars, two to
+  a position. `top =` remains unsupported alongside a discrete `alpha`: the
+  error layer is still built for every summary group rather than for the bars
+  actually kept, so it draws more error bars than there are bars, some over
+  empty space and some overlapping a kept bar while carrying another group's
+  statistic.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -157,10 +157,13 @@
   layer's dodge key was ordered differently from the bars' own grouping, so in a
   design with three discrete variables half the error bars were centered on the
   mean of an adjacent bar (#404). This changes the appearance of such a plot,
-  which was previously drawn with the error bars permuted. Unchanged, and still
-  not aligned: an `alpha` column containing `NA`, a fourth discrete aesthetic,
-  `top =`, a user-set `add.params$group`, `position_dodge2()`, and the stacked
-  default.
+  which was previously drawn with the error bars permuted. An `alpha` column
+  containing `NA` is aligned too: those rows keep a dodge slot of their own
+  instead of being dropped from the key. `position_dodge2()` and the stacked
+  default are unchanged. Three configurations remain unaligned, and their error
+  bars may sit differently than in 1.0.0 although they were not correct there
+  either: a fourth discrete aesthetic (`fill` and `color` and `alpha` together),
+  `top =`, and a user-set `add.params$group`.
 
 - Updated the help-page links that had started redirecting.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -172,13 +172,14 @@
   default, a numeric `alpha` column, and a grouping column named after one of the
   statistics `desc_statby()` computes (`length`, `min`, `max`, `median`, `mean`,
   `iqr`, `mad`, `sd`, `se`, `ci`, `range`, `cv`, `var`) — the summary's column of
-  that name holds the computed statistic, so opacity follows the statistic
-  rather than the column, and the ones that already failed still fail (`mean` at
-  draw; `ci` when the column is character). A numeric, integer or `Date` column
+  that name holds the computed statistic, so the aesthetic mapped to it follows
+  that statistic rather than the column, and the calls that already failed still
+  fail (such a column on `x` errors for all thirteen; on `alpha`, `mean` fails at
+  draw and `ci` when the column is character). A numeric, integer or `Date` column
   mapped to `color`/`fill` is also unchanged: ggplot2 does not group the bars by
   such a column, so the layer draws more bars than there are dodge positions and
-  no error bar can be matched to a single bar. `label = TRUE` is unchanged too,
-  and this fix moves only the error bars: the value labels still dodge on the
+  no error bar can be matched to a single bar. `label = TRUE` is unchanged too:
+  the value labels are not repositioned by this fix, and still dodge on the
   `fill` key alone, so with a discrete `alpha` they are drawn between the bars,
   two to a position.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -170,7 +170,10 @@
   Still unchanged from previous releases: `position_dodge2()` and the stacked
   default, a numeric `alpha` column, and an `alpha` column named after one of
   `desc_statby()`'s statistics (`se`, `sd`, `ci`, ...), which maps opacity to
-  that computed statistic rather than to the column. `top =` remains unsupported
+  that computed statistic rather than to the column. A numeric, integer or
+  `Date` column mapped to `color`/`fill` is also unchanged: ggplot2 does not
+  group the bars by such a column, so the layer draws more bars than there are
+  dodge positions and no error bar can be matched to a single bar. `top =` remains unsupported
   alongside a discrete `alpha`: the error layer is still built for every
   summarised group rather than for the bars actually kept, so it draws more
   error bars than there are bars, some over empty space and some overlapping a

--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,24 @@
 
 ## Bug fixes
 
+- `ggbarplot()` keeps each error bar on its own bar when one extra variable is
+  mapped to `alpha` and the bars are dodged with `position_dodge()`. The error
+  layer's dodge key was ordered differently from the bars' own grouping, so in a
+  design with three discrete variables half the error bars were centered on the
+  mean of an adjacent bar (#404). This changes the appearance of such a plot,
+  which was previously drawn with the error bars permuted. Unchanged, and still
+  not aligned: an `alpha` column containing `NA`, a fourth discrete aesthetic,
+  `top =`, a user-set `add.params$group`, `position_dodge2()`, and the stacked
+  default. A character `alpha` naming no column now reports the misspelled name
+  instead of failing inside grid.
+
+- `show.n = TRUE` counts the marks the panel draws rather than the rows, so a
+  group holding missing values is no longer labelled with a larger `n` than the
+  points beside it. Infinite values are still counted, because ggplot2 keeps them
+  and draws them on the panel edge.
+
+- Updated the help-page links that had started redirecting.
+
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via
   `ggpubr::` without being attached by `library(ggpubr)`. The label helper is now

--- a/NEWS.md
+++ b/NEWS.md
@@ -155,9 +155,9 @@
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
   `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz
   (#404). The error layer dodged by a different key from the one ggplot2 uses to
-  group the bars, so in a
-  design with three discrete variables half the error bars were centered on an
-  adjacent bar's mean and carried its error. The key is now built from every
+  group the bars, so in a design with three discrete variables half the error
+  bars were centered on an adjacent bar's mean and carried its error. The key is
+  now built from every
   mapped discrete aesthetic, in the order ggplot2 lays them out, which also
   aligns cases that were misplaced before: `fill`, `color` and `alpha` on three
   different columns; an `alpha` column whose levels are reversed, unused or
@@ -180,11 +180,14 @@
   error bar can be matched to a single bar. `label = TRUE` is unchanged too, and
   this fix moves only the error bars: the value labels still dodge on the `fill`
   key alone, so with a discrete `alpha` they are drawn between the bars, two to
-  a position. `top =` remains unsupported alongside a discrete `alpha`: the
+  a position.
+
+  `top =` remains unsupported alongside a discrete `alpha`, and is the one
+  configuration whose broken output changed rather than staying as released: the
   error layer is still built for every summary group rather than for the bars
-  actually kept, so it draws more error bars than there are bars, some over
-  empty space and some overlapping a kept bar while carrying another group's
-  statistic.
+  actually kept, so it draws more error bars than there are bars, some over empty
+  space and some overlapping a kept bar while carrying another group's statistic
+  — but which stray interval lands where now differs from previous releases.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -182,8 +182,7 @@ NULL
 #' \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 #' \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 #' \itemize{
-#'   \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
-#'   \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{Add P-values to GGPlot Facets with Different Scales}
+#'   \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from tests on ggplots, including facets with different scales}
 #' }
 #' }
 #' @inheritParams ggpubr-common-params

--- a/R/geom_pwc.R
+++ b/R/geom_pwc.R
@@ -182,8 +182,8 @@ NULL
 #' \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 #' \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 #' \itemize{
-#'   \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
-#'   \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPlot Facets with Different Scales}
+#'   \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
+#'   \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{Add P-values to GGPlot Facets with Different Scales}
 #' }
 #' }
 #' @inheritParams ggpubr-common-params

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -347,8 +347,15 @@ ggbarplot_core <- function(data, x, y,
     # dodge ranks permute, so an error bar was centred on a DIFFERENT bar's mean
     # - 4 of 8 misplaced in a 2x2x2 design, which is the misalignment #404 was
     # about. ggline() and .add_show_n() build the analogous key the same way.
+    # addNA(): interaction() returns NA for a row whose key column is NA, so those
+    # rows get no dodge rank at all, while ggplot2's own id_var(drop = TRUE) sorts
+    # with na.last = TRUE and keeps NA as a real trailing level. The two orderings
+    # then disagree from the NA cell onward and an error bar is drawn on a
+    # neighbour's bar carrying ITS mean and ITS error. A missing value in a
+    # grouping column is ordinary research data, not a degenerate input.
     data[[".ggpubr.alpha.group."]] <- interaction(
-      .select_vec(data, base.group), .select_vec(data, alpha.var),
+      addNA(factor(.select_vec(data, base.group)), ifany = TRUE),
+      addNA(factor(.select_vec(data, alpha.var)), ifany = TRUE),
       drop = TRUE, lex.order = TRUE
     )
     add.params$group <- ".ggpubr.alpha.group."

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -381,7 +381,18 @@ ggbarplot_core <- function(data, x, y,
       v <- .select_vec(data, k)
       is.factor(v) || is.character(v) || is.logical(v)
     }, logical(1))
-    data[[".ggpubr.alpha.group."]] <- if (all(key.discrete)) {
+    # Same degeneracy by a different route: desc_statby() names its own output
+    # columns after the statistics it computes, so a key column sharing one of
+    # those names is REPLACED in the summary by the computed numeric statistic.
+    # geom_exec() then resolves the bar layer's aesthetic against that statistic,
+    # ggplot2 sees a continuous column and does not group the bars by it, and
+    # again no key can match one error bar to one bar. Released behaviour stands.
+    stat.cols <- c(
+      "length", "min", "max", "median", "mean", "iqr", "mad", "sd", "se",
+      "ci", "range", "cv", "var"
+    )
+    data[[".ggpubr.alpha.group."]] <- if (all(key.discrete) &&
+      !any(key.vars %in% stat.cols)) {
       do.call(
         interaction,
         c(

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -369,16 +369,20 @@ ggbarplot_core <- function(data, x, y,
     key.vars <- unique(c(key.vars, alpha.var))
     key.vars <- intersect(key.vars, names(data))
     # ggplot2 ids the bars over the layer's DISCRETE columns only - its
-    # is_discrete() is factor/character/logical. A numeric (or Date) column mapped
-    # to colour/fill contributes nothing to that id, so keying on it would add a
-    # dimension the bars do not have: it becomes the slowest-varying factor here
-    # while the bars ignore it, and the two orderings transpose.
-    key.vars <- key.vars[vapply(key.vars, function(k) {
+    # is_discrete() is factor/character/logical. If EVERY column we would key on
+    # is discrete, the bars and this key describe the same partition and the
+    # error bars can be placed exactly. If any of them is not (a numeric, integer
+    # or Date column mapped to colour/fill/alpha), ggplot2 does not group the bars
+    # by it while desc_statby() still splits the summary on it, so the layer draws
+    # more rects than there are dodge slots and two bars share a slot: there is no
+    # one-to-one bar-to-row mapping left for any key to hit. Rather than trade one
+    # wrong arrangement for another, keep the released key untouched there.
+    key.discrete <- vapply(key.vars, function(k) {
       v <- .select_vec(data, k)
       is.factor(v) || is.character(v) || is.logical(v)
-    }, logical(1))]
-    if (length(key.vars) > 0) {
-      data[[".ggpubr.alpha.group."]] <- do.call(
+    }, logical(1))
+    data[[".ggpubr.alpha.group."]] <- if (all(key.discrete)) {
+      do.call(
         interaction,
         c(
           lapply(key.vars, function(k) {
@@ -387,8 +391,12 @@ ggbarplot_core <- function(data, x, y,
           list(drop = TRUE, lex.order = TRUE)
         )
       )
-      add.params$group <- ".ggpubr.alpha.group."
+    } else {
+      interaction(
+        .select_vec(data, base.group), .select_vec(data, alpha.var), drop = TRUE
+      )
     }
+    add.params$group <- ".ggpubr.alpha.group."
   }
   add.params <- .check_add.params(add, add.params, error.plot, data, color, fill, ...)
 

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -297,15 +297,6 @@ ggbarplot_core <- function(data, x, y,
   alpha.is.col <- !is.null(alpha.var) && length(alpha.var) == 1 &&
     is.character(alpha.var) && alpha.var %in% names(data) &&
     !is.numeric(.select_vec(data, alpha.var))
-  # A character `alpha` that names no column cannot be an opacity either, so it
-  # reaches the drawing code as a static value and fails there with
-  # "non-numeric argument to binary operator" from alpha * 255 - naming neither
-  # the argument nor the typo. Say which it is.
-  if (!is.null(alpha.var) && length(alpha.var) == 1 && is.character(alpha.var) &&
-    !(alpha.var %in% names(data))) {
-    stop("`alpha` must be a number between 0 and 1, or the name of a column in ",
-      "`data`. '", alpha.var, "' is not a column of `data`.", call. = FALSE)
-  }
   # Carrying the alpha column into the summary is what makes the subgroup drawable
   # at all: without it the summarised frame loses the column, geom_exec can no
   # longer map it, and the column NAME reaches grid as a static opacity - the

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -333,30 +333,41 @@ ggbarplot_core <- function(data, x, y,
       add.params$group <- fill
     } else if (color %in% names(data)) add.params$group <- color
   }
-  # #404: the bars dodge by the interaction of fill/x and the alpha subgroup, so
-  # the error layer must dodge by that same interaction to stay aligned; otherwise
-  # the error bars are centered on each x while the bars are split (misaligned). We
-  # materialise the interaction as a real column with a safe name (rather than an
-  # "interaction(a, b)" mapping string), so it is robust to special characters in
-  # the variable names and to options(ggpubr.parse_aes = FALSE).
+  # #404: with a discrete `alpha` the bars are split into more groups than the
+  # error layer knows about, so the error bars are centred on each x while the
+  # bars are dodged apart. The error layer has to dodge by the SAME key ggplot2
+  # groups the bars by. We materialise it as a real column with a safe name
+  # (rather than an "interaction(a, b)" mapping string), so it survives special
+  # characters in the variable names and options(ggpubr.parse_aes = FALSE).
   if (has.alpha.group) {
     base.group <- add.params$group %||% x
-    # lex.order = TRUE is load-bearing, not tidy-up. interaction() otherwise
-    # varies the FIRST factor fastest, while ggplot2 numbers the bars' own group
-    # ids with the first one slowest. The two orderings then disagree and the
-    # dodge ranks permute, so an error bar was centred on a DIFFERENT bar's mean
-    # - 4 of 8 misplaced in a 2x2x2 design, which is the misalignment #404 was
-    # about. ggline() and .add_show_n() build the analogous key the same way.
-    # addNA(): interaction() returns NA for a row whose key column is NA, so those
-    # rows get no dodge rank at all, while ggplot2's own id_var(drop = TRUE) sorts
-    # with na.last = TRUE and keeps NA as a real trailing level. The two orderings
-    # then disagree from the NA cell onward and an error bar is drawn on a
-    # neighbour's bar carrying ITS mean and ITS error. A missing value in a
-    # grouping column is ordinary research data, not a degenerate input.
-    data[[".ggpubr.alpha.group."]] <- interaction(
-      addNA(factor(.select_vec(data, base.group)), ifany = TRUE),
-      addNA(factor(.select_vec(data, alpha.var)), ifany = TRUE),
-      drop = TRUE, lex.order = TRUE
+    # Key on EVERY mapped discrete aesthetic, in the order ggplot2 lays them out
+    # in the layer data - `colour` before `fill` - not on a pair chosen here.
+    # ggplot2's add_group() calls id() over the layer's discrete columns in that
+    # order, first column slowest. Keying on (base.group, alpha) alone is
+    # fill-slowest, so as soon as `color` also names a column the two orderings
+    # are transposed and half the error bars are drawn on a neighbour's bar
+    # carrying ITS mean and ITS error - which released ggpubr got right.
+    #
+    # lex.order = TRUE is load-bearing: interaction() otherwise varies the FIRST
+    # factor fastest, the opposite of id().
+    #
+    # addNA(): interaction() returns NA for a row whose key column is NA, so that
+    # row gets no dodge rank, while id_var(drop = TRUE) sorts na.last = TRUE and
+    # keeps NA as a real trailing level. Without it the orderings diverge from the
+    # NA cell onward. A missing value in a grouping column is ordinary data.
+    key.vars <- unique(c(
+      intersect(c(color, fill), names(data)), base.group, alpha.var
+    ))
+    key.vars <- intersect(key.vars, names(data))
+    data[[".ggpubr.alpha.group."]] <- do.call(
+      interaction,
+      c(
+        lapply(key.vars, function(k) {
+          addNA(factor(.select_vec(data, k)), ifany = TRUE)
+        }),
+        list(drop = TRUE, lex.order = TRUE)
+      )
     )
     add.params$group <- ".ggpubr.alpha.group."
   }

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -291,8 +291,11 @@ ggbarplot_core <- function(data, x, y,
   # #404: an `alpha` aesthetic mapped to a discrete data column defines an extra
   # dodge subgroup (e.g. fill = cut, alpha = clarity -> 2 bars per cut). Detect it
   # so the summary keeps that column and the error layer dodges by it too. Both
-  # dodges keep the column; only the interaction dodge KEY below is specific to
-  # plain position_dodge(), position_dodge2() being re-centred separately (#363).
+  # the carrying and the dodge key are scoped to plain position_dodge():
+  # has.alpha.group gates grouping.vars as well, so under position_dodge2() the
+  # column is not carried at all and that path keeps its released behaviour,
+  # including the "alpha * 255" draw error - see the note below on why its
+  # rank-based re-centring (#363) cannot take the column safely.
   alpha.var <- list(...)[["alpha"]]   # [[ ]] avoids $ partial-matching a `...` arg
   alpha.is.col <- !is.null(alpha.var) && length(alpha.var) == 1 &&
     is.character(alpha.var) && alpha.var %in% names(data) &&
@@ -382,17 +385,20 @@ ggbarplot_core <- function(data, x, y,
       is.factor(v) || is.character(v) || is.logical(v)
     }, logical(1))
     # Same degeneracy by a different route: desc_statby() names its own output
-    # columns after the statistics it computes, so a key column sharing one of
-    # those names is REPLACED in the summary by the computed numeric statistic.
-    # geom_exec() then resolves the bar layer's aesthetic against that statistic,
-    # ggplot2 sees a continuous column and does not group the bars by it, and
-    # again no key can match one error bar to one bar. Released behaviour stands.
+    # columns after the statistics it computes, so any column it groups by that
+    # shares one of those names is REPLACED in the summary by the computed
+    # numeric statistic. geom_exec() then resolves the bar layer's aesthetic
+    # against that statistic, ggplot2 sees a continuous column and does not group
+    # the bars by it, and again no key can match one error bar to one bar.
+    # Released behaviour stands. The test covers grouping.vars too, not just the
+    # key: a `facet.by` column named after a statistic is destroyed by the same
+    # collision even though it never enters the key.
     stat.cols <- c(
       "length", "min", "max", "median", "mean", "iqr", "mad", "sd", "se",
       "ci", "range", "cv", "var"
     )
     data[[".ggpubr.alpha.group."]] <- if (all(key.discrete) &&
-      !any(key.vars %in% stat.cols)) {
+      !any(c(key.vars, grouping.vars) %in% stat.cols)) {
       do.call(
         interaction,
         c(

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -290,14 +290,42 @@ ggbarplot_core <- function(data, x, y,
 
   # #404: an `alpha` aesthetic mapped to a discrete data column defines an extra
   # dodge subgroup (e.g. fill = cut, alpha = clarity -> 2 bars per cut). Detect it
-  # so the summary keeps that column and the error layer dodges by it too. Scoped
-  # to plain position_dodge(): the alpha subgroup adds a second dodge dimension,
-  # which position_stack()/position_dodge2() do not resolve here (they are left
-  # exactly as before, unchanged by this fix).
+  # so the summary keeps that column and the error layer dodges by it too. Both
+  # dodges keep the column; only the interaction dodge KEY below is specific to
+  # plain position_dodge(), position_dodge2() being re-centred separately (#363).
   alpha.var <- list(...)[["alpha"]]   # [[ ]] avoids $ partial-matching a `...` arg
-  has.alpha.group <- !is.null(alpha.var) && length(alpha.var) == 1 &&
+  alpha.is.col <- !is.null(alpha.var) && length(alpha.var) == 1 &&
     is.character(alpha.var) && alpha.var %in% names(data) &&
-    !is.numeric(.select_vec(data, alpha.var)) &&
+    !is.numeric(.select_vec(data, alpha.var))
+  # A character `alpha` that names no column cannot be an opacity either, so it
+  # reaches the drawing code as a static value and fails there with
+  # "non-numeric argument to binary operator" from alpha * 255 - naming neither
+  # the argument nor the typo. Say which it is.
+  if (!is.null(alpha.var) && length(alpha.var) == 1 && is.character(alpha.var) &&
+    !(alpha.var %in% names(data))) {
+    stop("`alpha` must be a number between 0 and 1, or the name of a column in ",
+      "`data`. '", alpha.var, "' is not a column of `data`.", call. = FALSE)
+  }
+  # Carrying the alpha column into the summary is what makes the subgroup drawable
+  # at all: without it the summarised frame loses the column, geom_exec can no
+  # longer map it, and the column NAME reaches grid as a static opacity - the
+  # "alpha * 255" draw error of #404. But carrying it also SPLITS the summary into
+  # one row per (x, legend, alpha) cell, and only the interaction dodge key built
+  # below can place that many rows on the right bars. It is specific to plain
+  # position_dodge(), so the column is carried only there.
+  #
+  # position_dodge2() is deliberately NOT included, even though its error layer is
+  # re-centred on the bars (#363): that re-centring matches summary rows to bars by
+  # SORT POSITION, and with the alpha column carried the sort key
+  # (PANEL, x, legend) is no longer total - the alpha subgroup is only a stable
+  # tie. Anything that reorders the summary (`sort.val`, `top`, `sort.by.groups`)
+  # or that resolves a different key (`add.params$color`/`$fill` naming another
+  # column) then silently permutes the match, so an error bar lands on a
+  # neighbouring bar carrying ITS mean and ITS error. Making dodge2 work needs the
+  # row-to-bar match keyed on the bars' own identity rather than on rank, which is
+  # a focused change of its own; until then position_dodge2() keeps the released
+  # behaviour exactly, rather than trading a draw error for a wrong number.
+  has.alpha.group <- alpha.is.col &&
     inherits(position, "PositionDodge") && !inherits(position, "PositionDodge2")
 
   grouping.vars <- intersect(c(x, color, fill, facet.by), names(data))
@@ -322,8 +350,15 @@ ggbarplot_core <- function(data, x, y,
   # the variable names and to options(ggpubr.parse_aes = FALSE).
   if (has.alpha.group) {
     base.group <- add.params$group %||% x
+    # lex.order = TRUE is load-bearing, not tidy-up. interaction() otherwise
+    # varies the FIRST factor fastest, while ggplot2 numbers the bars' own group
+    # ids with the first one slowest. The two orderings then disagree and the
+    # dodge ranks permute, so an error bar was centred on a DIFFERENT bar's mean
+    # - 4 of 8 misplaced in a 2x2x2 design, which is the misalignment #404 was
+    # about. ggline() and .add_show_n() build the analogous key the same way.
     data[[".ggpubr.alpha.group."]] <- interaction(
-      .select_vec(data, base.group), .select_vec(data, alpha.var), drop = TRUE
+      .select_vec(data, base.group), .select_vec(data, alpha.var),
+      drop = TRUE, lex.order = TRUE
     )
     add.params$group <- ".ggpubr.alpha.group."
   }

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -356,20 +356,39 @@ ggbarplot_core <- function(data, x, y,
     # row gets no dodge rank, while id_var(drop = TRUE) sorts na.last = TRUE and
     # keeps NA as a real trailing level. Without it the orderings diverge from the
     # NA cell onward. A missing value in a grouping column is ordinary data.
-    key.vars <- unique(c(
-      intersect(c(color, fill), names(data)), base.group, alpha.var
-    ))
+    #
+    # base.group only belongs in the key when it is itself one of the bar's mapped
+    # aesthetics. add.params$group defaults to the fill or colour column, but a
+    # user may point it at a column mapped to nothing; that column does not split
+    # the bars, so keying on it would split the error layer finer than the bars
+    # and leave every interval off-centre.
+    key.vars <- intersect(c(color, fill), names(data))
+    if (!is.null(base.group) && base.group %in% c(key.vars, x, alpha.var)) {
+      key.vars <- c(key.vars, base.group)
+    }
+    key.vars <- unique(c(key.vars, alpha.var))
     key.vars <- intersect(key.vars, names(data))
-    data[[".ggpubr.alpha.group."]] <- do.call(
-      interaction,
-      c(
-        lapply(key.vars, function(k) {
-          addNA(factor(.select_vec(data, k)), ifany = TRUE)
-        }),
-        list(drop = TRUE, lex.order = TRUE)
+    # ggplot2 ids the bars over the layer's DISCRETE columns only - its
+    # is_discrete() is factor/character/logical. A numeric (or Date) column mapped
+    # to colour/fill contributes nothing to that id, so keying on it would add a
+    # dimension the bars do not have: it becomes the slowest-varying factor here
+    # while the bars ignore it, and the two orderings transpose.
+    key.vars <- key.vars[vapply(key.vars, function(k) {
+      v <- .select_vec(data, k)
+      is.factor(v) || is.character(v) || is.logical(v)
+    }, logical(1))]
+    if (length(key.vars) > 0) {
+      data[[".ggpubr.alpha.group."]] <- do.call(
+        interaction,
+        c(
+          lapply(key.vars, function(k) {
+            addNA(factor(.select_vec(data, k)), ifany = TRUE)
+          }),
+          list(drop = TRUE, lex.order = TRUE)
+        )
       )
-    )
-    add.params$group <- ".ggpubr.alpha.group."
+      add.params$group <- ".ggpubr.alpha.group."
+    }
   }
   add.params <- .check_add.params(add, add.params, error.plot, data, color, fill, ...)
 

--- a/R/ggpubr-package.R
+++ b/R/ggpubr-package.R
@@ -6,7 +6,7 @@
 #'
 #' \itemize{
 #' \item \href{https://rpkgs.datanovia.com/ggpubr/}{ggpubr documentation}
-#' \item \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{ggpubr tutorials}
+#' \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{ggpubr tutorials}
 #' }
 #'
 #' @section P-Value Formatting:

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -4,7 +4,7 @@ NULL
 #' GGPlot with Summary Stats Table Under the Plot
 #'
 #' @description Create a ggplot with summary stats (n, median, mean, iqr) table
-#'   under the plot. Read more: \href{https://www.datanovia.com/en/blog/how-to-create-a-beautiful-plots-in-r-with-summary-statistics-labels/}{How to Create a Beautiful Plots in R with Summary Statistics Labels}.
+#'   under the plot. Read more: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/summary-stats-labels}{How to Create a Beautiful Plots in R with Summary Statistics Labels}.
 #' @details \code{ggsummarystats()} returns a compound object (a list of ggplots
 #'   of class \code{"ggsummarystats"}), not a single ggplot, so \code{p +
 #'   theme()} does \strong{not} restyle it. Theme it in one of three ways:

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -7,9 +7,13 @@ NULL
 #' @description Add p-values manually to a ggplot, such as box plots, dot plots
 #'  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
 #'  \itemize{
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto GGPlots: basic, horizontal, faceted and grouped plots, and p-values generated elsewhere}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Basic GGPlots}
 #'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values Generated Elsewhere to a GGPlot}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
 #'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues}{How to Create Stacked Bar Plots with Error Bars and P-values}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Horizontal GGPlots}
 #'  }
 #' @inheritParams geom_bracket
 #' @param data a data frame containing statistical test results. The expected

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -7,13 +7,9 @@ NULL
 #' @description Add p-values manually to a ggplot, such as box plots, dot plots
 #'  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
 #'  \itemize{
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Basic GGPlots}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from tests on ggplots: basic, faceted, grouped and horizontal plots, and p-values generated elsewhere}
 #'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values Generated Elsewhere to a GGPlot}
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
 #'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues}{How to Create Stacked Bar Plots with Error Bars and P-values}
-#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Horizontal GGPlots}
 #'  }
 #' @inheritParams geom_bracket
 #' @param data a data frame containing statistical test results. The expected

--- a/R/stat_pvalue_manual.R
+++ b/R/stat_pvalue_manual.R
@@ -5,15 +5,11 @@ NULL
 #' Add P-values Manually to a ggplot
 #'
 #' @description Add p-values manually to a ggplot, such as box plots, dot plots
-#'  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
+#'  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
 #'  \itemize{
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPlots}
-#'  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-adjusted-p-values-to-a-multi-panel-ggplot/}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
-#'  \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPlot}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-create-stacked-bar-plots-with-error-bars-and-p-values/}{How to Create Stacked Bar Plots with Error Bars and P-values}
-#'  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPlots}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto GGPlots: basic, horizontal, faceted and grouped plots, and p-values generated elsewhere}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
+#'  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues}{How to Create Stacked Bar Plots with Error Bars and P-values}
 #'  }
 #' @inheritParams geom_bracket
 #' @param data a data frame containing statistical test results. The expected

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1238,21 +1238,6 @@ keep_only_tbl_df_classes <- function(x) {
                         position = NULL, size = 3.2, vjust = 1.4) {
   d <- p$data
   if (is.null(d) || !(x %in% colnames(d))) return(p)
-  # Count what the panel DRAWS. ggplot2 removes NA/NaN before drawing, so a
-  # group holding them was labelled with a larger n than the marks beside it.
-  # `!is.na()`, NOT is.finite(): ggplot2 KEEPS +/-Inf in the layer data and the
-  # coord squeezes it onto the panel edge, so an infinite value is still a mark
-  # on the figure and must still be counted. is.na(NaN) is TRUE, so NaN is
-  # covered. Counting fewer than the visible marks would be the same defect in
-  # the other direction.
-  y.vals <- tryCatch(
-    if (is.null(p$mapping$y)) NULL else suppressWarnings(rlang::eval_tidy(p$mapping$y, d)),
-    error = function(e) NULL
-  )
-  if (!is.null(y.vals) && length(y.vals) == nrow(d)) {
-    d <- d[!is.na(y.vals), , drop = FALSE]
-    if (nrow(d) == 0) return(p)
-  }
   group <- intersect(unique(c(color, fill)), colnames(d))
   facet.vars <- intersect(unique(c(.plot_facet_vars(p), facet.by)), colnames(d))
   dodge.w <- .dodge_width_of(position)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1238,6 +1238,21 @@ keep_only_tbl_df_classes <- function(x) {
                         position = NULL, size = 3.2, vjust = 1.4) {
   d <- p$data
   if (is.null(d) || !(x %in% colnames(d))) return(p)
+  # Count what the panel DRAWS. ggplot2 removes NA/NaN before drawing, so a
+  # group holding them was labelled with a larger n than the marks beside it.
+  # `!is.na()`, NOT is.finite(): ggplot2 KEEPS +/-Inf in the layer data and the
+  # coord squeezes it onto the panel edge, so an infinite value is still a mark
+  # on the figure and must still be counted. is.na(NaN) is TRUE, so NaN is
+  # covered. Counting fewer than the visible marks would be the same defect in
+  # the other direction.
+  y.vals <- tryCatch(
+    if (is.null(p$mapping$y)) NULL else suppressWarnings(rlang::eval_tidy(p$mapping$y, d)),
+    error = function(e) NULL
+  )
+  if (!is.null(y.vals) && length(y.vals) == nrow(d)) {
+    d <- d[!is.na(y.vals), , drop = FALSE]
+    if (nrow(d) == 0) return(p)
+  }
   group <- intersect(unique(c(color, fill)), colnames(d))
   facet.vars <- intersect(unique(c(.plot_facet_vars(p), facet.by)), colnames(d))
   dodge.w <- .dodge_width_of(position)

--- a/README.Rmd
+++ b/README.Rmd
@@ -354,4 +354,4 @@ Find out more at https://rpkgs.datanovia.com/ggpubr/.
 
 ## Blog posts
 
-- A. Kassambara. [ggpubr R Package: ggplot2-Based Publication Ready Plots](https://www.sthda.com/english/articles/24-ggpubr-publication-ready-plots/)
+- A. Kassambara. [ggpubr R Package: ggplot2-Based Publication Ready Plots](https://www.datanovia.com/learn/data-visualization/ggpubr/)

--- a/README.md
+++ b/README.md
@@ -395,4 +395,4 @@ Find out more at <https://rpkgs.datanovia.com/ggpubr/>.
 ## Blog posts
 
   - A. Kassambara. [ggpubr R Package: ggplot2-Based Publication Ready
-    Plots](https://www.sthda.com/english/articles/24-ggpubr-publication-ready-plots/)
+    Plots](https://www.datanovia.com/learn/data-visualization/ggpubr/)

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -375,8 +375,8 @@ One might want to adjust the p-values of all the facet panels together. There ar
 \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 \itemize{
-  \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
-  \item \href{https://www.datanovia.com/en/blog/add-p-values-to-ggplot-facets-with-different-scales/}{Add P-values to GGPlot Facets with Different Scales}
+  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
+  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{Add P-values to GGPlot Facets with Different Scales}
 }
 }
 }

--- a/man/geom_pwc.Rd
+++ b/man/geom_pwc.Rd
@@ -375,8 +375,7 @@ One might want to adjust the p-values of all the facet panels together. There ar
 \item Using \code{\link{ggadjust_pvalue}(p)} after creating the plot \code{p}
 \item or adding the adjusted p-value manually using \code{\link{stat_pvalue_manual}()}. Read more at:
 \itemize{
-  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
-  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{Add P-values to GGPlot Facets with Different Scales}
+  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from tests on ggplots, including facets with different scales}
 }
 }
 }

--- a/man/ggpubr-package.Rd
+++ b/man/ggpubr-package.Rd
@@ -13,7 +13,7 @@ General resources:
 
 \itemize{
 \item \href{https://rpkgs.datanovia.com/ggpubr/}{ggpubr documentation}
-\item \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{ggpubr tutorials}
+\item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{ggpubr tutorials}
 }
 }
 \section{P-Value Formatting}{

--- a/man/ggsummarystats.Rd
+++ b/man/ggsummarystats.Rd
@@ -114,7 +114,7 @@ legend = "none".}
 }
 \description{
 Create a ggplot with summary stats (n, median, mean, iqr) table
-  under the plot. Read more: \href{https://www.datanovia.com/en/blog/how-to-create-a-beautiful-plots-in-r-with-summary-statistics-labels/}{How to Create a Beautiful Plots in R with Summary Statistics Labels}.
+  under the plot. Read more: \href{https://www.datanovia.com/learn/data-visualization/ggpubr/summary-stats-labels}{How to Create a Beautiful Plots in R with Summary Statistics Labels}.
 }
 \details{
 \code{ggsummarystats()} returns a compound object (a list of ggplots

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -175,13 +175,9 @@ its own data with different column names than the parent plot data, so
 Add p-values manually to a ggplot, such as box plots, dot plots
  and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
  \itemize{
- \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Basic GGPlots}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{P-values from tests on ggplots: basic, faceted, grouped and horizontal plots, and p-values generated elsewhere}
  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
- \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
- \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values Generated Elsewhere to a GGPlot}
- \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
  \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues}{How to Create Stacked Bar Plots with Error Bars and P-values}
- \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Horizontal GGPlots}
  }
 }
 \examples{

--- a/man/stat_pvalue_manual.Rd
+++ b/man/stat_pvalue_manual.Rd
@@ -173,15 +173,15 @@ its own data with different column names than the parent plot data, so
 }
 \description{
 Add p-values manually to a ggplot, such as box plots, dot plots
- and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/en/blog/tag/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
+ and stripcharts. Frequently asked questions are available on \href{https://www.datanovia.com/learn/data-visualization/ggpubr/}{Datanovia ggpubr FAQ page}, for example:
  \itemize{
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-basic-ggplots/}{How to Add P-Values onto Basic GGPlots}
- \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-adjusted-p-values-to-a-multi-panel-ggplot/}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-to-ggplot-facets/}{How to Add P-values to GGPlot Facets}
- \item \href{https://www.datanovia.com/en/blog/ggpubr-how-to-add-p-values-generated-elsewhere-to-a-ggplot/}{How to Add P-Values Generated Elsewhere to a GGPlot}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-a-grouped-ggplot-using-the-ggpubr-r-package/}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
- \item \href{https://www.datanovia.com/en/blog/how-to-create-stacked-bar-plots-with-error-bars-and-p-values/}{How to Create Stacked Bar Plots with Error Bars and P-values}
- \item \href{https://www.datanovia.com/en/blog/how-to-add-p-values-onto-horizontal-ggplots/}{How to Add P-Values onto Horizontal GGPlots}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Basic GGPlots}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/auto-p-values}{How to Add Adjusted P-values to a Multi-Panel GGPlot}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-values to GGPlot Facets}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values Generated Elsewhere to a GGPlot}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto a Grouped GGPlot using the ggpubr R Package}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/stacked-bar-pvalues}{How to Create Stacked Bar Plots with Error Bars and P-values}
+ \item \href{https://www.datanovia.com/learn/data-visualization/ggpubr/p-values-from-tests}{How to Add P-Values onto Horizontal GGPlots}
  }
 }
 \examples{

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -182,3 +182,39 @@ test_that("ggbarplot() dodge key follows ggplot2's own grouping rule (#404)", {
     tolerance = 1e-8
   )
 })
+
+test_that("ggbarplot() leaves a non-discrete colour/fill exactly as released (#404)", {
+  # When a numeric/integer/Date column is mapped to colour or fill, ggplot2 does
+  # not group the bars by it, but desc_statby() still splits the summary on it -
+  # so the layer draws more rects than there are dodge slots and two bars share a
+  # slot. No key can put an error bar on "its own" bar because the mapping is not
+  # one-to-one. The dodge key therefore falls back to the released pairing rather
+  # than trading one wrong arrangement for another.
+  #
+  # Expected values below were captured from ggpubr 1.0.0 (origin/master,
+  # 2dccc55, R/ggbarplot.R byte-identical to the CRAN 1.0.0 file) with:
+  #   ggplot_build(p)$data[[2]][, c("x", "ymin", "ymax")]
+  set.seed(5)
+  d <- expand.grid(
+    g = paste0("x", 1:3), f = paste0("f", 1:2), a = paste0("a", 1:2),
+    rep = 1:5, stringsAsFactors = TRUE
+  )
+  d$v <- stats::rnorm(nrow(d), 10 * as.integer(d$g) + 3 * as.integer(d$f) +
+    as.integer(d$a))
+  d$f <- as.integer(factor(d$f)) # fill mapped to an INTEGER column
+  p <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "a",
+    add = "mean_se", position = ggplot2::position_dodge()))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_s3_class(ggplot2::ggplotGrob(b), "gtable")
+  eb <- b$data[[2]]
+  expect_equal(nrow(eb), 12L)
+  expect_equal(as.numeric(eb$x), c(
+    0.64375, 1.64375, 2.64375, 0.88125, 1.88125, 2.88125,
+    1.11875, 2.11875, 3.11875, 1.35625, 2.35625, 3.35625
+  ), tolerance = 1e-8)
+  expect_equal((eb$ymin + eb$ymax) / 2, c(
+    13.43277994, 23.77273185, 33.75847997, 17.29500968, 27.60582578,
+    35.99321436, 14.97955727, 25.23713646, 35.62538695, 18.54933911,
+    28.64474292, 38.12591724
+  ), tolerance = 1e-7)
+})

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -28,37 +28,13 @@ test_that("ggbarplot() keeps each dodged error bar on its own bar (#404)", {
   # element-wise, so a permutation cannot pass
   expect_equal(as.numeric(bar$y), (eb$ymin + eb$ymax) / 2, tolerance = 1e-8)
   expect_equal(sort((eb$ymax - eb$ymin) / 2), sort(ref.se$v), tolerance = 1e-8)
-  # a character `alpha` naming no column reports the typo instead of failing in grid
-  expect_error(
-    ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "zzz", add = "mean_se"),
-    "not a column of", fixed = TRUE
-  )
-})
-
-test_that("show.n counts the marks the panel draws, NA excluded and Inf kept", {
-  # ggplot2 removes NA/NaN before drawing but KEEPS +/-Inf, squeezing it onto the
-  # panel edge, so an infinite value is still a visible mark. The label must
-  # match the marks in both directions.
-  d <- data.frame(
-    g = rep(c("a", "b", "c"), each = 8),
-    y = c(1:6, NA, NaN,        # a: 6 drawn
-      1:6, Inf, Inf,           # b: 8 drawn (Inf is drawn)
-      1:8)                     # c: 8 drawn
-  )
-  labs <- function(p) {
-    b <- suppressWarnings(ggplot2::ggplot_build(p))
-    ggplot2::ggplotGrob(b)
-    z <- unlist(lapply(b$data, function(q) if ("label" %in% names(q)) as.character(q$label)))
-    as.integer(sub("^n = ", "", z[grepl("^n = ", z)]))
-  }
-  # base-R reference: what ggplot2 will actually draw, per group
-  ref <- as.integer(tapply(d$y, d$g, function(v) sum(!is.na(v))))
-  expect_equal(ref, c(6L, 8L, 8L))
-  for (p in list(
-    suppressWarnings(ggstripchart(d, "g", "y", show.n = TRUE)),
-    suppressWarnings(ggboxplot(d, "g", "y", add = "jitter", show.n = TRUE)),
-    suppressWarnings(ggviolin(d, "g", "y", show.n = TRUE))
-  )) {
-    expect_equal(sort(labs(p)), sort(ref))
+  # An `alpha` naming one of desc_statby()'s summary columns is legitimate - the
+  # bar layer is drawn from that summary, so geom_exec() resolves the mapping
+  # against it - and must keep rendering.
+  for (a in c("se", "sd", "ci")) {
+    p2 <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f",
+      add = "mean_se", position = ggplot2::position_dodge(0.8), alpha = a))
+    expect_s3_class(ggplot2::ggplotGrob(suppressWarnings(
+      ggplot2::ggplot_build(p2))), "gtable")
   }
 })

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -260,3 +260,37 @@ test_that("ggbarplot() leaves a statistic-named alpha column as released (#404)"
     tolerance = 1e-8
   )
 })
+
+test_that("ggbarplot() guards a statistic-named facet.by column too (#404)", {
+  # desc_statby() groups by facet.by as well, so a facet column named after one
+  # of its output statistics is destroyed by the same name collision as a keyed
+  # column - even though facet.by never enters the dodge key. The guard therefore
+  # tests grouping.vars, not just the key, and this configuration stays exactly
+  # as released.
+  #
+  # Expected values captured from ggpubr 1.0.0 (origin/master, 2dccc55) with:
+  #   ggplot_build(p)$data[[2]][, c("x", "PANEL", "ymin", "ymax")]
+  set.seed(42)
+  d <- expand.grid(
+    g = paste0("x", 1:3), f = paste0("f", 1:2), a = paste0("a", 1:2),
+    rep = 1:6, stringsAsFactors = TRUE
+  )
+  d$v <- stats::rnorm(nrow(d), 10 * as.integer(d$g) + 3 * as.integer(d$f) +
+    as.integer(d$a))
+  d$sd <- rep(c("q1", "q2"), length.out = nrow(d)) # named after desc_statby()'s sd
+  p <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "a",
+    facet.by = "sd", add = "mean_se",
+    position = ggplot2::position_dodge(0.8)))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_s3_class(ggplot2::ggplotGrob(b), "gtable")
+  eb <- b$data[[2]]
+  expect_equal(nrow(eb), 12L)
+  expect_equal(as.numeric(eb$x),
+    c(0.8, 2.8, 1.8, 1.2, 3.2, 2.2, 1.8, 0.8, 2.8, 2.2, 1.2, 3.2),
+    tolerance = 1e-8)
+  expect_equal((eb$ymin + eb$ymax) / 2, c(
+    14.04902523, 33.74367984, 27.27242447, 15.11837953, 35.49643750,
+    27.46505087, 23.78600246, 17.02627840, 36.69696830, 25.41977394,
+    17.79843003, 38.57051821
+  ), tolerance = 1e-7)
+})

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -218,3 +218,45 @@ test_that("ggbarplot() leaves a non-discrete colour/fill exactly as released (#4
     28.64474292, 38.12591724
   ), tolerance = 1e-7)
 })
+
+test_that("ggbarplot() leaves a statistic-named alpha column as released (#404)", {
+  # desc_statby() names its output columns after the statistics it computes, so
+  # an `alpha` column called `se`/`sd`/`median`/... is REPLACED in the summary by
+  # the computed numeric statistic. geom_exec() resolves the bar layer's alpha
+  # against that, ggplot2 sees a continuous column and does not group the bars by
+  # it, so no key can match one error bar to one bar - the same degeneracy as a
+  # non-discrete colour/fill, and the released arrangement is likewise kept.
+  #
+  # Expected values captured from ggpubr 1.0.0 (origin/master, 2dccc55) with:
+  #   ggplot_build(p)$data[[2]][, c("x", "ymin", "ymax")]
+  set.seed(1)
+  d <- data.frame(
+    g = rep(c("A", "B"), each = 12), f = rep(c("f1", "f2"), 12),
+    se = rep(c("a1", "a2"), each = 6, times = 2), v = stats::rnorm(24, 10)
+  )
+  p <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "se",
+    add = "mean_se", position = ggplot2::position_dodge(0.8)))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_s3_class(ggplot2::ggplotGrob(b), "gtable")
+  eb <- b$data[[2]]
+  expect_equal(as.numeric(eb$x),
+    c(0.7, 1.7, 0.9, 1.9, 1.1, 2.1, 1.3, 2.3), tolerance = 1e-8)
+  expect_equal((eb$ymin + eb$ymax) / 2, c(
+    9.622475116, 10.16250002, 10.31948525, 9.561400905,
+    10.85833052, 10.60492118, 10.27425985, 9.795561975
+  ), tolerance = 1e-7)
+
+  # `len` is NOT one of those columns, so it is an ordinary alpha column and DOES
+  # get the fix: 4 of 8 on their own bar in 1.0.0, 8 of 8 now.
+  names(d)[names(d) == "se"] <- "len"
+  p2 <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f",
+    alpha = "len", add = "mean_se", position = ggplot2::position_dodge(0.8)))
+  b2 <- suppressWarnings(ggplot2::ggplot_build(p2))
+  bar2 <- b2$data[[1]]
+  eb2 <- b2$data[[2]]
+  expect_equal(
+    as.numeric(bar2$y)[order(as.numeric(bar2$x))],
+    ((eb2$ymin + eb2$ymax) / 2)[order(as.numeric(eb2$x))],
+    tolerance = 1e-8
+  )
+})

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -61,4 +61,58 @@ test_that("ggbarplot() keeps each dodged error bar on its own bar (#404)", {
     ((neb$ymin + neb$ymax) / 2)[order(as.numeric(neb$x))],
     tolerance = 1e-8
   )
+
+  # `color=` mapped to a column is the shape that a two-column key gets WRONG:
+  # ggplot2 orders `colour` BEFORE `fill` in the layer data, so bar groups are
+  # colour-slowest, and keying on (fill, alpha) alone is exactly transposed. That
+  # configuration is CORRECT on the released version, so getting it wrong here
+  # would be a regression - and no earlier test crossed alpha with color.
+  ref.se <- function(dd, keys) {
+    stats::aggregate(stats::reformulate(keys, "v"), data = dd,
+      FUN = function(z) stats::sd(z) / sqrt(length(z)))$v
+  }
+  for (aes.extra in list(
+    list(fill = "f", color = "a"),   # colour and alpha on the SAME column
+    list(color = "a"),               # colour only, no fill
+    list(fill = "a")                 # fill and alpha on the same column
+  )) {
+    args <- c(list(d, x = "g", y = "v", alpha = "a", add = "mean_se",
+      position = ggplot2::position_dodge(0.8)), aes.extra)
+    pc <- suppressWarnings(do.call(ggbarplot, args))
+    bc <- suppressWarnings(ggplot2::ggplot_build(pc))
+    expect_s3_class(ggplot2::ggplotGrob(bc), "gtable")
+    cbar <- bc$data[[1]]
+    ceb <- bc$data[[2]]
+    lab <- paste(names(aes.extra), unlist(aes.extra), collapse = " ")
+    expect_equal(nrow(ceb), nrow(cbar), info = lab)
+    expect_equal(
+      as.numeric(cbar$y)[order(as.numeric(cbar$x))],
+      ((ceb$ymin + ceb$ymax) / 2)[order(as.numeric(ceb$x))],
+      tolerance = 1e-8, info = lab
+    )
+  }
+
+  # The level ORDER of the alpha column must not change the pairing either: a
+  # reversed, an unused and an ordered level set all key the same way ggplot2
+  # groups the bars.
+  for (acol in list(
+    factor(d$a, levels = c("a2", "a1")),
+    factor(d$a, levels = c("a1", "a2", "a3")),
+    factor(d$a, ordered = TRUE)
+  )) {
+    dl <- d
+    dl$a <- acol
+    pl <- suppressWarnings(ggbarplot(dl, x = "g", y = "v", fill = "f",
+      alpha = "a", add = "mean_se", position = ggplot2::position_dodge(0.8)))
+    bl <- suppressWarnings(ggplot2::ggplot_build(pl))
+    expect_s3_class(ggplot2::ggplotGrob(bl), "gtable")
+    lbar <- bl$data[[1]]
+    leb <- bl$data[[2]]
+    expect_equal(nrow(leb), nrow(lbar))
+    expect_equal(
+      as.numeric(lbar$y)[order(as.numeric(lbar$x))],
+      ((leb$ymin + leb$ymax) / 2)[order(as.numeric(leb$x))],
+      tolerance = 1e-8
+    )
+  }
 })

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -37,4 +37,28 @@ test_that("ggbarplot() keeps each dodged error bar on its own bar (#404)", {
     expect_s3_class(ggplot2::ggplotGrob(suppressWarnings(
       ggplot2::ggplot_build(p2))), "gtable")
   }
+
+  # A missing value in the alpha column is ordinary research data. interaction()
+  # returns NA for such a row, giving it no dodge rank, while ggplot2's own
+  # id_var(drop = TRUE) sorts na.last = TRUE and keeps NA as a real trailing
+  # level - so without addNA() the two orderings diverge from the NA cell onward
+  # and an error bar is drawn on a neighbour's bar with ITS mean and ITS error.
+  set.seed(7)
+  dna <- data.frame(
+    g = rep(c("A", "B"), each = 12), f = rep(c("f1", "f2"), 12),
+    a = rep(c("a1", "a2"), each = 6, times = 2), v = stats::rnorm(24, 10)
+  )
+  dna$a[dna$g == "A" & dna$f == "f1"] <- NA
+  pna <- suppressWarnings(ggbarplot(dna, x = "g", y = "v", fill = "f",
+    alpha = "a", add = "mean_se", position = ggplot2::position_dodge(0.8)))
+  bna <- suppressWarnings(ggplot2::ggplot_build(pna))
+  expect_s3_class(ggplot2::ggplotGrob(bna), "gtable")
+  nbar <- bna$data[[1]]
+  neb <- bna$data[[2]]
+  expect_equal(nrow(neb), nrow(nbar))
+  expect_equal(
+    as.numeric(nbar$y)[order(as.numeric(nbar$x))],
+    ((neb$ymin + neb$ymax) / 2)[order(as.numeric(neb$x))],
+    tolerance = 1e-8
+  )
 })

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -116,3 +116,69 @@ test_that("ggbarplot() keeps each dodged error bar on its own bar (#404)", {
     )
   }
 })
+
+test_that("ggbarplot() dodge key follows ggplot2's own grouping rule (#404)", {
+  # ggplot2 ids a layer's groups with id() over its DISCRETE columns only
+  # (is_discrete(): factor/character/logical). A numeric column mapped to
+  # colour/fill therefore contributes nothing to the bars' grouping, and keying
+  # the error layer on it adds a dimension the bars do not have: it becomes the
+  # slowest-varying factor of the key while the bars ignore it, so the two
+  # orderings transpose and every interval carries a neighbour's mean and error.
+  # ggpubr 1.0.0 drew this case correctly; it must stay correct.
+  set.seed(1)
+  d <- data.frame(
+    site = rep(c("S1", "S2"), each = 12),
+    arm = rep(c("Active", "Placebo"), each = 6, times = 2),
+    response = stats::rnorm(24, 10)
+  )
+  d$dose_mg <- ifelse(d$arm == "Active", 10, 5) # a dose recorded as a NUMBER
+  ref <- stats::aggregate(response ~ site + arm, data = d, FUN = mean)
+  ref.se <- stats::aggregate(response ~ site + arm, data = d,
+    FUN = function(z) stats::sd(z) / sqrt(length(z)))
+  p <- suppressWarnings(ggbarplot(d, x = "site", y = "response",
+    fill = "dose_mg", alpha = "arm", add = "mean_se",
+    position = ggplot2::position_dodge(0.8)))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_s3_class(ggplot2::ggplotGrob(b), "gtable")
+  bar <- b$data[[1]]
+  eb <- b$data[[2]]
+  expect_equal(nrow(eb), nrow(bar))
+  ord.b <- order(as.numeric(bar$x))
+  ord.e <- order(as.numeric(eb$x))
+  # element-wise at matched x: a transposition cannot pass
+  expect_equal(as.numeric(bar$x)[ord.b], as.numeric(eb$x)[ord.e], tolerance = 1e-8)
+  expect_equal(
+    as.numeric(bar$y)[ord.b],
+    ((eb$ymin + eb$ymax) / 2)[ord.e],
+    tolerance = 1e-8
+  )
+  # and the drawn statistics are the independently computed ones
+  expect_equal(sort(as.numeric(bar$y)), sort(ref$response), tolerance = 1e-8)
+  expect_equal(sort((eb$ymax - eb$ymin) / 2), sort(ref.se$response),
+    tolerance = 1e-8)
+
+  # A user-set add.params$group naming a column mapped to NO aesthetic does not
+  # split the bars, so it must not split the error layer either. Keying on it
+  # produced one error row per (fill, group, alpha) cell - twice as many rows as
+  # bars, half of them all-NA and dropped silently, none centred on a bar.
+  set.seed(11)
+  d2 <- expand.grid(
+    g = c("A", "B", "C"), f = c("f1", "f2"), cc = c("c1", "c2"),
+    a = c("a1", "a2"), rep = 1:4, stringsAsFactors = FALSE
+  )
+  d2$v <- stats::rnorm(nrow(d2), 10, 2)
+  p2 <- suppressWarnings(ggbarplot(d2, x = "g", y = "v", fill = "f",
+    alpha = "a", add = "mean_se", position = ggplot2::position_dodge(0.8),
+    add.params = list(group = "cc")))
+  b2 <- suppressWarnings(ggplot2::ggplot_build(p2))
+  expect_s3_class(ggplot2::ggplotGrob(b2), "gtable")
+  bar2 <- b2$data[[1]]
+  eb2 <- b2$data[[2]]
+  expect_equal(nrow(eb2), nrow(bar2))
+  expect_false(any(is.na((eb2$ymin + eb2$ymax) / 2)))
+  expect_equal(
+    as.numeric(bar2$y)[order(as.numeric(bar2$x))],
+    ((eb2$ymin + eb2$ymax) / 2)[order(as.numeric(eb2$x))],
+    tolerance = 1e-8
+  )
+})

--- a/tests/testthat/test-pre-cran-1.1.0.R
+++ b/tests/testthat/test-pre-cran-1.1.0.R
@@ -1,0 +1,64 @@
+# Regression tests for the changes carried into 1.1.0 from the pre-CRAN review.
+# Deliberately narrow: each asserts a value or a coordinate, against a base-R
+# reference or against ggpubr 1.0.0's own measured output.
+
+test_that("ggbarplot() keeps each dodged error bar on its own bar (#404)", {
+  # The error layer's dodge key was ordered differently from the bars' own
+  # grouping, so with three discrete variables half the error bars were centred
+  # on a neighbouring bar's mean. ggpubr 1.0.0 put 4 of 8 on the wrong bar.
+  set.seed(1)
+  d <- data.frame(
+    g = rep(c("A", "B"), each = 12), f = rep(c("f1", "f2"), 12),
+    a = rep(c("a1", "a2"), each = 6, times = 2), v = stats::rnorm(24, 10)
+  )
+  ref <- stats::aggregate(v ~ g + f + a, data = d, FUN = mean)
+  ref.se <- stats::aggregate(v ~ g + f + a, data = d,
+    FUN = function(z) stats::sd(z) / sqrt(length(z)))
+  p <- suppressWarnings(ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "a",
+    add = "mean_se", position = ggplot2::position_dodge(0.8)))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_s3_class(ggplot2::ggplotGrob(b), "gtable") # draws, no "alpha * 255"
+  bar <- b$data[[1]]
+  eb <- b$data[[2]]
+  expect_equal(nrow(bar), 8L)
+  expect_equal(nrow(eb), 8L)
+  expect_equal(sort(bar$y), sort(ref$v), tolerance = 1e-8)
+  bar <- bar[order(bar$x, bar$y), ]
+  eb <- eb[order(eb$x, (eb$ymin + eb$ymax) / 2), ]
+  # element-wise, so a permutation cannot pass
+  expect_equal(as.numeric(bar$y), (eb$ymin + eb$ymax) / 2, tolerance = 1e-8)
+  expect_equal(sort((eb$ymax - eb$ymin) / 2), sort(ref.se$v), tolerance = 1e-8)
+  # a character `alpha` naming no column reports the typo instead of failing in grid
+  expect_error(
+    ggbarplot(d, x = "g", y = "v", fill = "f", alpha = "zzz", add = "mean_se"),
+    "not a column of", fixed = TRUE
+  )
+})
+
+test_that("show.n counts the marks the panel draws, NA excluded and Inf kept", {
+  # ggplot2 removes NA/NaN before drawing but KEEPS +/-Inf, squeezing it onto the
+  # panel edge, so an infinite value is still a visible mark. The label must
+  # match the marks in both directions.
+  d <- data.frame(
+    g = rep(c("a", "b", "c"), each = 8),
+    y = c(1:6, NA, NaN,        # a: 6 drawn
+      1:6, Inf, Inf,           # b: 8 drawn (Inf is drawn)
+      1:8)                     # c: 8 drawn
+  )
+  labs <- function(p) {
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    ggplot2::ggplotGrob(b)
+    z <- unlist(lapply(b$data, function(q) if ("label" %in% names(q)) as.character(q$label)))
+    as.integer(sub("^n = ", "", z[grepl("^n = ", z)]))
+  }
+  # base-R reference: what ggplot2 will actually draw, per group
+  ref <- as.integer(tapply(d$y, d$g, function(v) sum(!is.na(v))))
+  expect_equal(ref, c(6L, 8L, 8L))
+  for (p in list(
+    suppressWarnings(ggstripchart(d, "g", "y", show.n = TRUE)),
+    suppressWarnings(ggboxplot(d, "g", "y", add = "jitter", show.n = TRUE)),
+    suppressWarnings(ggviolin(d, "g", "y", show.n = TRUE))
+  )) {
+    expect_equal(sort(labs(p)), sort(ref))
+  }
+})


### PR DESCRIPTION
Three changes for the 1.1.0 cycle, each measured against `master`.

## 1. `ggbarplot()`: error bars stay on their own bar with `alpha` (#404)

When a variable is mapped to `alpha` and bars are dodged with `position_dodge()`,
the error layer dodged by a different key from the one ggplot2 uses to group the
bars. The result is a figure where an error bar sits on a neighbouring bar and
carries *that* bar's mean and standard error — a wrong number presented as a
result, not just a cosmetic offset.

The key is now built from every mapped discrete aesthetic, in the order ggplot2
lays them out in the layer data.

```r
library(ggpubr)

dat <- subset(ggplot2::diamonds,
              cut %in% c("Fair", "Good", "Ideal") &
              color %in% c("E", "J") &
              clarity %in% c("VS2", "VS1"))
dat <- droplevels(dat)

ggbarplot(dat, x = "cut", y = "price", fill = "color", alpha = "clarity",
          add = "mean_se", position = position_dodge())
```

**Before** — 6 of the 12 error bars are on the wrong bar. In the `Ideal` group an
interval floats at ~4800 above a bar of height ~2200, and another sits at ~2200
over a bar of height ~4850:

![before](https://i.imgur.com/j5NsL44.png)

**After** — all 12 straddle their own bar. Bar heights and positions are
untouched; only the error layer moved:

![after](https://i.imgur.com/L6qqQMD.png)

Every drawn mean and standard error was checked against `stats::aggregate`
computed independently, not against ggpubr's own summary.

Also corrected by the same key, each verified: `fill`, `color` and `alpha` on
three different columns (0 of 24 error bars correct before, 24 of 24 now);
`facet.by =`, including a panel with a level absent and `scales = "free_x"`
(12 of 24 before, 24 of 24 now); an `alpha` column whose levels are reversed,
unused or ordered; one containing `NA`; `tibble` and grouped input; `sort.val =`,
`sort.by.groups = FALSE`, `orientation = "horizontal"`; the `error.plot =`
variants; and a user-set `add.params$group`.

**This changes the appearance of such a plot** — previously it was drawn with the
error bars permuted. Calls with no `alpha` aesthetic are unaffected.

Unchanged from previous releases: `position_dodge2()` and the stacked default, a
numeric `alpha` column, a numeric/integer/`Date` column mapped to `color`/`fill`
(ggplot2 does not group the bars by such a column, so no error bar can be matched
to a single bar), a grouping column named after one of the statistics
`desc_statby()` computes (`sd`, `se`, `ci`, …) — the summary's column of that name
holds the computed statistic, so the aesthetic mapped to it follows the statistic
rather than the column — and `label = TRUE`, whose value labels are not moved by
this fix.

`top =` remains unsupported alongside a discrete `alpha`: the error layer is still
built for every summary group rather than for the bars actually kept, so it draws
more error bars than there are bars, some over empty space and some overlapping a
kept bar while carrying another group's statistic. Which stray interval lands
where does differ from previous releases.

## 2. Documentation links repointed

The `datanovia.com/en/blog/...` help-page links now redirect. `master` flags 11
URLs; this branch flags 0 of 85. Link texts were adjusted so each destination
carries text that describes it. The roxygen sources and the generated `man/*.Rd`
carry identical link sets.

## 3. CI dependency resolution

`DESCRIPTION` carried `Remotes: kassambara/rstatix@release/1.1.0`. That branch was
deleted when rstatix 1.1.0 reached CRAN, so dependency resolution fails on all
five matrix jobs — `master` cannot currently get a green run. The line is removed
(CRAN requires that anyway).

The `oldrel-1` job pins RSPM to the 2026-02-25 snapshot, which is what tests this
package against its declared dependency floors — it serves dplyr 1.2.0,
rlang 1.1.7, tidyr 1.3.2 and cowplot 1.2.0, exactly the versions `Imports` asks
for. That snapshot predates rstatix 1.1.0, so that job names
`github::kassambara/rstatix@v1.1.0` in `extra-packages`. Bumping `SNAPSHOT_DATE`
instead would supply rstatix but also raise dplyr and rlang above their floors and
silently end that testing.

## Checks

`R CMD check --as-cran` 0 errors / 0 warnings / 2 NOTEs (dev version, local HTML
Tidy); `_R_CHECK_DEPENDS_ONLY_=true R CMD check` OK; test suite FAIL 0, PASS 1554;
spelling clean.

Fixes #404
