### PR TITLE
Title each free panel with the group it actually draws

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,17 @@
 
 ## Bug fixes
 
+- `ggsummarystats(free.panels = TRUE)` now titles every panel with the group
+  whose data it draws. The panel label was taken from a split that sorts its rows
+  before building the label but attaches it to the unsorted data, so the panels
+  could be titled with each other's names: with `facet.by` naming a character
+  column whose groups are not in alphabetical order, a panel headed `East` drew
+  `North`'s boxes, and the summary table under it carried `North`'s n, median and
+  IQR. The label is now built from the grouping key that travels with each
+  panel's own rows, so it cannot drift. This affected `labeller = "label_both"`
+  even when the facet column was a factor. Panel order and label formatting are
+  unchanged.
+
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
   `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz
   (#404). The error layer dodged by a different key from the one ggplot2 uses to

--- a/NEWS.md
+++ b/NEWS.md
@@ -154,14 +154,26 @@
 
 - `ggsummarystats(free.panels = TRUE)` now titles every panel with the group
   whose data it draws. The panel label was taken from a split that sorts its rows
-  before building the label but attaches it to the unsorted data, so the panels
-  could be titled with each other's names: with `facet.by` naming a character
-  column whose groups are not in alphabetical order, a panel headed `East` drew
-  `North`'s boxes, and the summary table under it carried `North`'s n, median and
-  IQR. The label is now built from the grouping key that travels with each
-  panel's own rows, so it cannot drift. This affected `labeller = "label_both"`
-  even when the facet column was a factor. Panel order and label formatting are
-  unchanged.
+  before building the label but attaches it to the unsorted data, so panels were
+  titled with each other's names: a panel headed `East` drew `North`'s boxes, and
+  the summary table under it carried `North`'s n, median and IQR. The label is now
+  built from the grouping key that travels with each panel's own rows, so it
+  cannot drift.
+
+  This affected **any** `facet.by` column whose groups do not already appear in
+  sorted order — a character column that is not alphabetical, a factor whose
+  levels are ordered differently from the rows, and numeric, integer, logical and
+  `Date` columns — as well as every `labeller = "label_both"` call, and any data
+  containing `NA` in the facet column. Only a column whose groups happen to appear
+  in sorted order was safe, which is why the faceted example on
+  `?ggsummarystats` showed it: all four of its panels were transposed. If you
+  have produced such a figure, it is worth re-checking.
+
+  Each panel keeps its position and its data; what changes is the name written on
+  it, so the titles now read in data order rather than sorted order. Label
+  formatting is unchanged, with one exception: a facet column named `label` with
+  `labeller = "label_both"` now gets the `label:` prefix it asks for, which was
+  previously dropped.
 
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
   `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz

--- a/NEWS.md
+++ b/NEWS.md
@@ -160,20 +160,31 @@
   built from the grouping key that travels with each panel's own rows, so it
   cannot drift.
 
-  This affected **any** `facet.by` column whose groups do not already appear in
-  sorted order — a character column that is not alphabetical, a factor whose
-  levels are ordered differently from the rows, and numeric, integer, logical and
-  `Date` columns — as well as every `labeller = "label_both"` call, and any data
-  containing `NA` in the facet column. Only a column whose groups happen to appear
-  in sorted order was safe, which is why the faceted example on
-  `?ggsummarystats` showed it: all four of its panels were transposed. If you
-  have produced such a figure, it is worth re-checking.
+  This affected any `facet.by` column whose groups do not already appear in sorted
+  order: a character column that is not alphabetical, a factor whose levels are
+  ordered differently from its rows, numeric, integer, logical and `Date` columns,
+  and a frame whose `NA` group is not last. A column whose groups happen to appear
+  in sorted order was unaffected. `labeller = "label_both"` was hit more often,
+  because it sorts the formatted `variable:value` strings rather than the
+  underlying values, so it also transposed factor and numeric columns that
+  `label_value` got right. The faceted example on `?ggsummarystats` had all four
+  of its panels transposed; if you have produced such a figure it is worth
+  re-checking.
 
   Each panel keeps its position and its data; what changes is the name written on
-  it, so the titles now read in data order rather than sorted order. Label
-  formatting is unchanged, with one exception: a facet column named `label` with
-  `labeller = "label_both"` now gets the `label:` prefix it asks for, which was
-  previously dropped.
+  it, so the titles now read in the order the groups appear in the data rather
+  than in sorted order. Label formatting is otherwise unchanged, except where a
+  facet column is named after something the label machinery uses internally: a
+  column named `label` now keeps the `label:` prefix that `label_both` asks for,
+  and keeps the other facet variables in the label under `label_value`, where
+  both were previously dropped; and a column named `panel` is no longer formatted
+  twice.
+
+  The underlying defect was reported upstream (rstatix issue 324) and is fixed in
+  rstatix's development version, so with that installed the labels were already
+  right. ggpubr requires `rstatix (>= 1.1.0)`, the released version carrying the
+  defect, and the cases above involving a facet column named `panel` or `label`
+  are wrong on any rstatix version, so the fix is applied here regardless.
 
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
   `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,9 +167,9 @@
   in sorted order was unaffected. `labeller = "label_both"` was hit more often,
   because it sorts the formatted `variable:value` strings rather than the
   underlying values, so it also transposed factor and numeric columns that
-  `label_value` got right. The faceted example on `?ggsummarystats` had all four
-  of its panels transposed; if you have produced such a figure it is worth
-  re-checking.
+  `label_value` got right. A two-variable case such as
+  `facet.by = c("supp", "qc")` with `free.panels = TRUE` had all four of its
+  panels transposed; if you have produced such a figure it is worth re-checking.
 
   Each panel keeps its position and its data; what changes is the name written on
   it, so the titles now read in the order the groups appear in the data rather

--- a/NEWS.md
+++ b/NEWS.md
@@ -174,17 +174,18 @@
   Each panel keeps its position and its data; what changes is the name written on
   it, so the titles now read in the order the groups appear in the data rather
   than in sorted order. Label formatting is otherwise unchanged, except where a
-  facet column is named after something the label machinery uses internally: a
-  column named `label` now keeps the `label:` prefix that `label_both` asks for,
-  and keeps the other facet variables in the label under `label_value`, where
-  both were previously dropped; and a column named `panel` is no longer formatted
-  twice.
+  facet column is named `label`, which the label machinery uses internally: such
+  a column now keeps the `label:` prefix that `label_both` asks for, and keeps
+  the other facet variables in the label under `label_value`. Both were dropped
+  before, so `facet.by = c("region", "label")` returned two panels named `p` and
+  two named `q` with `region` missing from all four, and only the first of each
+  pair could be reached by name.
 
   The underlying defect was reported upstream (rstatix issue 324) and is fixed in
   rstatix's development version, so with that installed the labels were already
   right. ggpubr requires `rstatix (>= 1.1.0)`, the released version carrying the
-  defect, and the cases above involving a facet column named `panel` or `label`
-  are wrong on any rstatix version, so the fix is applied here regardless.
+  defect, and the `label`-column case above is wrong on any rstatix version, so
+  the fix is applied here regardless.
 
 - `ggbarplot()` keeps each error bar on its own bar when a variable is mapped to
   `alpha` and the bars are dodged with `position_dodge()`. Thanks to @zuooonz

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -293,11 +293,17 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
   if (identical(labeller, "label_both")) {
     values <- Map(function(g, v) paste0(g, ":", v), groups, values)
   }
-  # unname(): Map() names its result after `groups`, and do.call would then hand
-  # those names to paste() as arguments - so a facet column called `sep`,
-  # `collapse` or `recycle0` would collide with paste()'s own formals, erroring
-  # on two of them and silently blanking every label on the third.
-  labels <- do.call(paste, c(unname(values), list(sep = ", ")))
+  # Join by folding rather than do.call(paste, values): the facet variables name
+  # the list, and do.call would hand those names to paste() as arguments, so a
+  # column called `sep`, `collapse` or `recycle0` collided with paste()'s own
+  # formals - two errored and the third silently blanked every label. A fold
+  # cannot reach a formal by name, so the whole class goes away.
+  # paste() on the first element too, not just between elements: it is what turns
+  # a missing group into the string "NA", which is how such a panel has always
+  # been titled. Reduce() alone would return a single vector untouched and leave
+  # the label NA, which factor() then drops instead of levelling.
+  labels <- paste(values[[1]])
+  for (v in values[-1]) labels <- paste(labels, v, sep = ", ")
   factor(labels, levels = unique(labels))
 }
 

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -271,8 +271,14 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
 # Build one panel label per row of a df_split_by() result, from that row's own
 # grouping key, so the label cannot drift away from the data beside it. Mirrors
 # rstatix's labellers: "label_value" joins the key values with ", ";
-# "label_both" prefixes each with "<variable>:". Levels follow the row order, as
-# df_unite_factors() does, so panel order is unchanged.
+# "label_both" prefixes each with "<variable>:".
+#
+# Levels follow the ROW order, which is the order the groups appear in the data
+# and therefore the order the panels are drawn in. That is deliberately NOT what
+# df_unite_factors() does - it arrange()s first, so its levels are sorted - and
+# it is the reason a title used to be able to name a different panel from the one
+# it sat on. Only one level is ever present in a given sub-plot, so the level set
+# is not drawn; it is the label VALUES that must track the rows.
 .panel_label <- function(grouped, groups, labeller = "label_value") {
   values <- lapply(groups, function(g) as.character(grouped[[g]]))
   if (identical(labeller, "label_both")) {
@@ -287,7 +293,12 @@ ggsummarystats_free_facet <- function(data, x, y, facet.by, labeller = "label_va
     label_both = rstatix::df_label_both,
     label_value = rstatix::df_label_value
   )
-  groups <- facet.by
+  # Normalise exactly as df_split_by() does internally (df_get_var_names() takes
+  # unique(), and names on the vector become the grouped column's name), so the
+  # key read below and the split stay in lockstep by construction. Without this a
+  # duplicated facet.by nests two columns of the same name, and a named one nests
+  # the key under that name, neither of which df_split_by() itself does.
+  groups <- unique(unname(facet.by))
   # Read the grouping keys BEFORE splitting. df_split_by() writes its label into
   # the column named by label_col, so a facet variable that is itself called
   # "panel" has its key overwritten by the label - and re-formatting that yields

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -288,19 +288,27 @@ ggsummarystats_free_facet <- function(data, x, y, facet.by, labeller = "label_va
     label_value = rstatix::df_label_value
   )
   groups <- facet.by
+  # Read the grouping keys BEFORE splitting. df_split_by() writes its label into
+  # the column named by label_col, so a facet variable that is itself called
+  # "panel" has its key overwritten by the label - and re-formatting that yields
+  # "panel:panel:East", or "Alpha, p, p" with two facet variables. df_split_by()
+  # nests first and its labeller only mutates, so df_nest_by() returns the same
+  # rows in the same order with the keys still intact.
+  panel <- .panel_label(
+    rstatix::df_nest_by(data, vars = groups), groups, labeller
+  )
   data.grouped <- data %>%
     df_split_by(vars = groups, label_col = "panel", labeller = labeller_func)
   # A panel must be titled with the name of the group whose rows it draws.
   # rstatix's df_unite_factors() sorts the rows with arrange() before building
   # the label, and the label is then assigned back onto the *unsorted* nested
   # frame - so whenever that sort reorders the groups, every panel is titled with
-  # another group's name while drawing this one's data. It bites for a character
-  # facet column that is not in alphabetical order, and for labeller =
-  # "label_both" even when the column is a factor. The grouping key that
-  # df_split_by() returns beside each nested frame IS aligned with it, so rebuild
-  # the label from that. Where rstatix's own ordering already agrees, this
-  # reproduces its label and its factor levels exactly.
-  panel <- .panel_label(data.grouped, groups, labeller)
+  # another group's name while drawing this one's data. It bites for any facet
+  # column whose sorted order differs from the order the groups appear in, and
+  # for labeller = "label_both" even when that column is a factor. The keys read
+  # above ARE aligned with the nested frames, so the label is rebuilt from them.
+  # Where rstatix's own ordering already agrees, this reproduces its label and
+  # its factor levels exactly.
   data.grouped$panel <- panel
   data.grouped$data <- map2(
     data.grouped$data, as.character(panel),

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -268,6 +268,20 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
 }
 
 
+# Build one panel label per row of a df_split_by() result, from that row's own
+# grouping key, so the label cannot drift away from the data beside it. Mirrors
+# rstatix's labellers: "label_value" joins the key values with ", ";
+# "label_both" prefixes each with "<variable>:". Levels follow the row order, as
+# df_unite_factors() does, so panel order is unchanged.
+.panel_label <- function(grouped, groups, labeller = "label_value") {
+  values <- lapply(groups, function(g) as.character(grouped[[g]]))
+  if (identical(labeller, "label_both")) {
+    values <- Map(function(g, v) paste0(g, ":", v), groups, values)
+  }
+  labels <- do.call(paste, c(values, list(sep = ", ")))
+  factor(labels, levels = unique(labels))
+}
+
 ggsummarystats_free_facet <- function(data, x, y, facet.by, labeller = "label_value", ...) {
   labeller_func <- switch(labeller,
     label_both = rstatix::df_label_both,
@@ -275,7 +289,27 @@ ggsummarystats_free_facet <- function(data, x, y, facet.by, labeller = "label_va
   )
   groups <- facet.by
   data.grouped <- data %>%
-    df_split_by(vars = groups, label_col = "panel", labeller = labeller_func) %>%
+    df_split_by(vars = groups, label_col = "panel", labeller = labeller_func)
+  # A panel must be titled with the name of the group whose rows it draws.
+  # rstatix's df_unite_factors() sorts the rows with arrange() before building
+  # the label, and the label is then assigned back onto the *unsorted* nested
+  # frame - so whenever that sort reorders the groups, every panel is titled with
+  # another group's name while drawing this one's data. It bites for a character
+  # facet column that is not in alphabetical order, and for labeller =
+  # "label_both" even when the column is a factor. The grouping key that
+  # df_split_by() returns beside each nested frame IS aligned with it, so rebuild
+  # the label from that. Where rstatix's own ordering already agrees, this
+  # reproduces its label and its factor levels exactly.
+  panel <- .panel_label(data.grouped, groups, labeller)
+  data.grouped$panel <- panel
+  data.grouped$data <- map2(
+    data.grouped$data, as.character(panel),
+    function(d, lab) {
+      d[["panel"]] <- factor(lab, levels = levels(panel))
+      d
+    }
+  )
+  data.grouped <- data.grouped %>%
     mutate(
       plots = map(data, ggsummarystats_core, x = x, y = y, facet.by = "panel", ...)
     )

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -280,11 +280,24 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
 # it sat on. Only one level is ever present in a given sub-plot, so the level set
 # is not drawn; it is the label VALUES that must track the rows.
 .panel_label <- function(grouped, groups, labeller = "label_value") {
+  # A facet.by that resolves to no grouping column at all - character(0), or ""
+  # which groups by nothing - still yields one panel, labelled "". Drop such
+  # entries rather than building a zero-length label that cannot be assigned back.
+  groups <- groups[vapply(
+    groups, function(g) length(grouped[[g]]) == nrow(grouped), logical(1)
+  )]
+  if (!length(groups)) {
+    return(factor(rep("", nrow(grouped))))
+  }
   values <- lapply(groups, function(g) as.character(grouped[[g]]))
   if (identical(labeller, "label_both")) {
     values <- Map(function(g, v) paste0(g, ":", v), groups, values)
   }
-  labels <- do.call(paste, c(values, list(sep = ", ")))
+  # unname(): Map() names its result after `groups`, and do.call would then hand
+  # those names to paste() as arguments - so a facet column called `sep`,
+  # `collapse` or `recycle0` would collide with paste()'s own formals, erroring
+  # on two of them and silently blanking every label on the third.
+  labels <- do.call(paste, c(unname(values), list(sep = ", ")))
   factor(labels, levels = unique(labels))
 }
 

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -9,3 +9,50 @@ test_that("ggsummarytable forwards angle to the text layer (#595)", {
   p0 <- ggsummarytable(ToothGrowth, x = "dose", y = "len", summaries = "mean")
   expect_true(all(ggplot2::layer_data(p0, 1)$angle == 0))
 })
+
+test_that("ggsummarystats(free.panels) titles each panel with its own group", {
+  # Each panel must be named for the group whose rows it draws. rstatix's
+  # df_unite_factors() sorts the rows before building the label and the label is
+  # assigned back onto the unsorted nested frame, so the panel titled "East" drew
+  # North's data - a mislabelled result, with the summary table under it carrying
+  # the transposed medians too. Bites for a character facet column that is not in
+  # alphabetical order, and for labeller = "label_both" even with a factor.
+  set.seed(1)
+  d <- data.frame(
+    region = rep(c("North", "East", "South"), each = 12),
+    grp = rep(c("a", "b"), 18),
+    val = c(stats::rnorm(12, 100), stats::rnorm(12, 10), stats::rnorm(12, 50)),
+    stringsAsFactors = FALSE
+  )
+  truth <- tapply(d$val, d$region, mean) # independent reference
+
+  for (lab in c("label_value", "label_both")) {
+    for (as.factor.x in c(FALSE, TRUE)) {
+      dd <- d
+      if (as.factor.x) {
+        dd$region <- factor(dd$region, levels = c("North", "East", "South"))
+      }
+      p <- suppressWarnings(ggsummarystats(dd, x = "grp", y = "val",
+        facet.by = "region", free.panels = TRUE, labeller = lab))
+      # panel order follows the data, not the alphabet, and the labeller's
+      # own formatting is preserved
+      expect_equal(
+        names(p),
+        if (lab == "label_both") {
+          c("region:North", "region:East", "region:South")
+        } else {
+          c("North", "East", "South")
+        }
+      )
+      for (nm in names(p)) {
+        grp <- sub("^region:", "", nm)
+        built <- suppressWarnings(ggplot2::ggplot_build(p[[nm]]$main.plot))
+        # the strip actually drawn over the panel carries this group's name
+        expect_equal(as.character(built$layout$layout$panel), nm)
+        # and the boxes sit at this group's level, not another's
+        expect_equal(mean(built$data[[1]]$middle), unname(truth[[grp]]),
+          tolerance = 1)
+      }
+    }
+  }
+})

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -269,3 +269,33 @@ test_that("ggsummarystats(free.panels) survives facet columns named like paste()
     expect_equal(names(p2), "")
   }
 })
+
+test_that("ggsummarystats(free.panels) titles a missing group 'NA' and draws its rows", {
+  # A missing group is titled with the string "NA" - that is how paste() renders
+  # it and how such a panel has always been labelled. Joining the facet variables
+  # without paste()-ing the first one would leave the label a real NA, which
+  # factor() drops rather than levels, losing the panel's title entirely.
+  set.seed(3)
+  d <- data.frame(
+    region = rep(c("North", "East", "South"), each = 8),
+    grp = rep(c("a", "b"), 12), stringsAsFactors = FALSE
+  )
+  d$val <- rep(c(100, 200, 300), each = 8) + stats::rnorm(24)
+  d$region[c(1, 9)] <- NA # NA group is NOT last, so the old path transposed it
+
+  p <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val",
+    facet.by = "region", free.panels = TRUE))
+  expect_true("NA" %in% names(p))
+  expect_false(any(is.na(names(p))))
+
+  truth <- tapply(d$val, addNA(d$region), stats::median)
+  for (nm in names(p)) {
+    rows <- if (nm == "NA") is.na(d$region) else !is.na(d$region) & d$region == nm
+    cell <- d[rows, ]
+    expected <- sort(as.numeric(tapply(cell$val, cell$grp, stats::median)))
+    built <- suppressWarnings(ggplot2::ggplot_build(p[[nm]]$main.plot))
+    expect_equal(as.character(built$layout$layout$panel), nm)
+    expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
+      tolerance = 1e-8)
+  }
+})

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -141,3 +141,100 @@ test_that("the faceted ?ggsummarystats example labels all four panels correctly"
       tolerance = 1e-8)
   }
 })
+
+test_that("ggsummarystats(free.panels) survives facet columns named like internals", {
+  # These configurations are wrong on the old code path regardless of which
+  # rstatix is installed, because the label is written into a column named
+  # "panel" and rstatix's labeller has a local variable named `label`. With
+  # facet.by = c("panel", "label") the "panel" variable used to vanish from every
+  # title and the returned names came out DUPLICATED ("q", "p", "q", "p"), so
+  # p[["q"]] could only ever reach the first of the two.
+  set.seed(4)
+  d <- data.frame(
+    panel = rep(c("Z", "Y"), each = 12),
+    label = rep(c("q", "p"), 12),
+    grp = rep(c("a", "b"), 12),
+    stringsAsFactors = FALSE
+  )
+  d$val <- ifelse(d$panel == "Z", 0, 30) + stats::rnorm(24)
+
+  p <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val",
+    facet.by = c("panel", "label"), free.panels = TRUE, labeller = "label_both"))
+  expect_equal(
+    names(p),
+    c("panel:Z, label:q", "panel:Z, label:p", "panel:Y, label:q", "panel:Y, label:p")
+  )
+  expect_false(any(duplicated(names(p))))
+
+  pv <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val",
+    facet.by = c("panel", "label"), free.panels = TRUE, labeller = "label_value"))
+  expect_equal(names(pv), c("Z, q", "Z, p", "Y, q", "Y, p"))
+
+  # every panel draws its own cell, checked against base R
+  for (nm in names(pv)) {
+    parts <- strsplit(nm, ", ", fixed = TRUE)[[1]]
+    cell <- d[d$panel == parts[1] & d$label == parts[2], ]
+    expected <- sort(as.numeric(tapply(cell$val, cell$grp, stats::median)))
+    built <- suppressWarnings(ggplot2::ggplot_build(pv[[nm]]$main.plot))
+    expect_equal(as.character(built$layout$layout$panel), nm)
+    expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
+      tolerance = 1e-8)
+  }
+
+  # a facet column named `label` keeps the prefix label_both asks for; rstatix's
+  # own labeller has it shadowed by the data column and silently drops it
+  d2 <- data.frame(
+    label = rep(c("North", "East"), each = 12), grp = rep(c("a", "b"), 12),
+    val = c(stats::rnorm(12, 100), stats::rnorm(12, 10)), stringsAsFactors = FALSE
+  )
+  p2 <- suppressWarnings(ggsummarystats(d2, x = "grp", y = "val",
+    facet.by = "label", free.panels = TRUE, labeller = "label_both"))
+  expect_equal(names(p2), c("label:North", "label:East"))
+
+  # a duplicated or named facet.by must keep working (df_split_by normalises both)
+  d3 <- data.frame(
+    region = rep(c("North", "East"), each = 12), grp = rep(c("a", "b"), 12),
+    val = c(stats::rnorm(12, 100), stats::rnorm(12, 10)), stringsAsFactors = FALSE
+  )
+  expect_equal(
+    names(suppressWarnings(ggsummarystats(d3, x = "grp", y = "val",
+      facet.by = c("region", "region"), free.panels = TRUE))),
+    c("North", "East")
+  )
+  expect_equal(
+    names(suppressWarnings(ggsummarystats(d3, x = "grp", y = "val",
+      facet.by = c(a = "region"), free.panels = TRUE))),
+    c("North", "East")
+  )
+})
+
+test_that("ggsummarystats(free.panels) panel titles follow the data, not the alphabet", {
+  # Deliberate choice, pinned here: panels are returned in the order the groups
+  # appear in the data (which is the order they have always been drawn in), and
+  # each title names the panel it sits on. Before, the titles came from a sorted
+  # copy, so they read in sorted order while the panels did not - which is how a
+  # title came to name a different panel from the one it was drawn over.
+  set.seed(1)
+  d <- data.frame(
+    region = rep(c("North", "East", "South"), each = 12),
+    grp = rep(c("a", "b"), 18),
+    val = c(stats::rnorm(12, 100), stats::rnorm(12, 10), stats::rnorm(12, 50)),
+    stringsAsFactors = FALSE
+  )
+  p <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val",
+    facet.by = "region", free.panels = TRUE))
+
+  # data order, not sort order
+  expect_equal(names(p), c("North", "East", "South"))
+  expect_false(identical(names(p), sort(names(p))))
+
+  # and the panel each title sits on draws that group's rows
+  for (nm in names(p)) {
+    cell <- d[d$region == nm, ]
+    expected <- sort(as.numeric(tapply(cell$val, cell$grp, stats::median)))
+    built <- suppressWarnings(ggplot2::ggplot_build(p[[nm]]$main.plot))
+    expect_equal(as.character(built$layout$layout$panel), nm)
+    expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
+      tolerance = 1e-8)
+  }
+})

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -24,7 +24,10 @@ test_that("ggsummarystats(free.panels) titles each panel with its own group", {
     val = c(stats::rnorm(12, 100), stats::rnorm(12, 10), stats::rnorm(12, 50)),
     stringsAsFactors = FALSE
   )
-  truth <- tapply(d$val, d$region, mean) # independent reference
+  # independent reference: the median of each (region, grp) cell, which is what
+  # the box middles draw. Compared exactly - a relative tolerance of 1 would
+  # accept a 100% error and certify nothing.
+  truth <- tapply(d$val, list(d$region, d$grp), stats::median)
 
   for (lab in c("label_value", "label_both")) {
     for (as.factor.x in c(FALSE, TRUE)) {
@@ -49,10 +52,92 @@ test_that("ggsummarystats(free.panels) titles each panel with its own group", {
         built <- suppressWarnings(ggplot2::ggplot_build(p[[nm]]$main.plot))
         # the strip actually drawn over the panel carries this group's name
         expect_equal(as.character(built$layout$layout$panel), nm)
-        # and the boxes sit at this group's level, not another's
-        expect_equal(mean(built$data[[1]]$middle), unname(truth[[grp]]),
-          tolerance = 1)
+        # and every box in it draws THIS group's median, not a neighbour's
+        drawn <- built$data[[1]]
+        expect_equal(
+          as.numeric(drawn$middle[order(as.numeric(drawn$x))]),
+          as.numeric(truth[grp, ]),
+          tolerance = 1e-8
+        )
       }
     }
+  }
+})
+
+test_that("ggsummarystats(free.panels) survives a facet column named 'panel'", {
+  # The panel label is written into the column named by label_col, which is
+  # "panel". A facet variable of that name therefore has its key overwritten by
+  # the label, and rebuilding the label from the overwritten key formatted it a
+  # second time: "panel:panel:Alpha", or "Alpha, p, p" with two facet variables.
+  # The keys are now read before the split, while they are still the keys.
+  set.seed(7)
+  d <- data.frame(
+    panel = rep(c("Alpha", "Beta"), each = 8),
+    grp = rep(c("a", "b"), 8),
+    val = c(stats::rnorm(8, 10), stats::rnorm(8, 20)),
+    stringsAsFactors = FALSE
+  )
+  p <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val",
+    facet.by = "panel", free.panels = TRUE, labeller = "label_both"))
+  expect_equal(names(p), c("panel:Alpha", "panel:Beta"))
+  expect_equal(
+    as.character(
+      suppressWarnings(ggplot2::ggplot_build(p[["panel:Alpha"]]$main.plot)
+      )$layout$layout$panel
+    ),
+    "panel:Alpha"
+  )
+
+  # two facet variables, one of them named "panel", with label_value
+  d2 <- data.frame(
+    panel = rep(c("Alpha", "Beta"), each = 8),
+    q = rep(c("p", "q"), each = 4, length.out = 16),
+    grp = rep(c("a", "b"), 8),
+    val = c(stats::rnorm(8, 10), stats::rnorm(8, 20)),
+    stringsAsFactors = FALSE
+  )
+  p2 <- suppressWarnings(ggsummarystats(d2, x = "grp", y = "val",
+    facet.by = c("panel", "q"), free.panels = TRUE, labeller = "label_value"))
+  expect_equal(names(p2), c("Alpha, p", "Alpha, q", "Beta, p", "Beta, q"))
+
+  # and each panel still draws its own cell's values: every box is the median of
+  # a (panel, q, grp) sub-cell, so compare the whole set for that panel
+  for (nm in names(p2)) {
+    parts <- strsplit(nm, ", ", fixed = TRUE)[[1]]
+    cell <- d2[d2$panel == parts[1] & d2$q == parts[2], ]
+    expected <- sort(as.numeric(tapply(cell$val, cell$grp, stats::median)))
+    built <- suppressWarnings(ggplot2::ggplot_build(p2[[nm]]$main.plot))
+    expect_equal(as.character(built$layout$layout$panel), nm)
+    expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
+      tolerance = 1e-8)
+  }
+})
+
+test_that("the faceted ?ggsummarystats example labels all four panels correctly", {
+  # The two-variable example on the help page had ALL FOUR panels transposed:
+  # the panel headed "supp:OJ, qc:fail" drew VC/pass's boxes and its n/median/iqr.
+  # Expected medians below are recomputed from ToothGrowth with base R.
+  df <- ToothGrowth
+  df$dose <- as.factor(df$dose)
+  set.seed(123)
+  qc <- rep(c("pass", "fail"), 30)
+  df$qc <- as.factor(sample(qc, 60))
+
+  p <- suppressWarnings(ggsummarystats(df, x = "dose", y = "len",
+    ggfunc = ggboxplot, add = "jitter", color = "dose", palette = "npg",
+    facet.by = c("supp", "qc"), labeller = "label_both", free.panels = TRUE))
+  expect_equal(length(p), 4L)
+
+  for (nm in names(p)) {
+    parts <- strsplit(nm, ", ", fixed = TRUE)[[1]]
+    cell <- df[df$supp == sub("supp:", "", parts[1]) &
+                 df$qc == sub("qc:", "", parts[2]), ]
+    expected <- sort(as.numeric(
+      tapply(cell$len, droplevels(cell$dose), stats::median)
+    ))
+    built <- suppressWarnings(ggplot2::ggplot_build(p[[nm]]$main.plot))
+    expect_equal(as.character(built$layout$layout$panel), nm)
+    expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
+      tolerance = 1e-8)
   }
 })

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -113,10 +113,11 @@ test_that("ggsummarystats(free.panels) survives a facet column named 'panel'", {
   }
 })
 
-test_that("the faceted ?ggsummarystats example labels all four panels correctly", {
-  # The two-variable example on the help page had ALL FOUR panels transposed:
-  # the panel headed "supp:OJ, qc:fail" drew VC/pass's boxes and its n/median/iqr.
-  # Expected medians below are recomputed from ToothGrowth with base R.
+test_that("a two-variable free.panels facet labels all four panels correctly", {
+  # The help page's faceted example plus free.panels = TRUE: ALL FOUR panels were
+  # transposed, the panel headed "supp:OJ, qc:fail" drawing VC/pass's boxes and
+  # its n/median/iqr. (The shipped example itself does not set free.panels, so it
+  # was never affected.) Expected medians recomputed from ToothGrowth in base R.
   df <- ToothGrowth
   df$dose <- as.factor(df$dose)
   set.seed(123)
@@ -241,10 +242,10 @@ test_that("ggsummarystats(free.panels) panel titles follow the data, not the alp
 })
 
 test_that("ggsummarystats(free.panels) survives facet columns named like paste()'s formals", {
-  # The label is assembled with do.call(paste, ...). Map() names its result after
-  # the facet variables, so without unname() those names reach paste() as
-  # arguments: a column called `sep` or `recycle0` errored, and `collapse`
-  # silently produced a blank title for every panel.
+  # The label used to be assembled with do.call(paste, values). Map() names its
+  # result after the facet variables, so those names reached paste() as arguments:
+  # a column called `sep` or `recycle0` errored, and `collapse` silently produced a
+  # blank title for every panel. The join is a fold now, which cannot pass a name.
   set.seed(1)
   for (nm in c("sep", "collapse", "recycle0")) {
     d <- data.frame(

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -143,12 +143,13 @@ test_that("the faceted ?ggsummarystats example labels all four panels correctly"
 })
 
 test_that("ggsummarystats(free.panels) survives facet columns named like internals", {
-  # These configurations are wrong on the old code path regardless of which
-  # rstatix is installed, because the label is written into a column named
-  # "panel" and rstatix's labeller has a local variable named `label`. With
-  # facet.by = c("panel", "label") the "panel" variable used to vanish from every
-  # title and the returned names came out DUPLICATED ("q", "p", "q", "p"), so
-  # p[["q"]] could only ever reach the first of the two.
+  # facet.by = c("panel", "label") is wrong on the old code path regardless of
+  # which rstatix is installed: rstatix's labeller has a local variable named
+  # `label`, which a data column of that name shadows, so the "panel" variable
+  # vanished from every title and the returned names came out DUPLICATED ("q",
+  # "p", "q", "p") - p[["q"]] could only ever reach the first of the two. The
+  # "panel" name is covered here because the label is written into a column of
+  # that name, which the key read must not be confused by.
   set.seed(4)
   d <- data.frame(
     panel = rep(c("Z", "Y"), each = 12),
@@ -236,5 +237,35 @@ test_that("ggsummarystats(free.panels) panel titles follow the data, not the alp
     expect_equal(as.character(built$layout$layout$panel), nm)
     expect_equal(sort(as.numeric(built$data[[1]]$middle)), expected,
       tolerance = 1e-8)
+  }
+})
+
+test_that("ggsummarystats(free.panels) survives facet columns named like paste()'s formals", {
+  # The label is assembled with do.call(paste, ...). Map() names its result after
+  # the facet variables, so without unname() those names reach paste() as
+  # arguments: a column called `sep` or `recycle0` errored, and `collapse`
+  # silently produced a blank title for every panel.
+  set.seed(1)
+  for (nm in c("sep", "collapse", "recycle0")) {
+    d <- data.frame(
+      grp = rep(c("a", "b"), 12),
+      val = c(stats::rnorm(12, 10), stats::rnorm(12, 20)),
+      stringsAsFactors = FALSE
+    )
+    d[[nm]] <- rep(c("North", "East"), each = 12)
+    p <- suppressWarnings(ggsummarystats(d, x = "grp", y = "val", facet.by = nm,
+      free.panels = TRUE, labeller = "label_both"))
+    expect_equal(names(p), paste0(nm, c(":North", ":East")))
+    expect_false(any(names(p) == ""))
+  }
+
+  # a facet.by that resolves to no grouping column still yields one labelled panel
+  d2 <- ToothGrowth
+  d2$dose <- factor(d2$dose)
+  for (fb in list(character(0), "")) {
+    p2 <- suppressWarnings(ggsummarystats(d2, x = "dose", y = "len",
+      facet.by = fb, free.panels = TRUE))
+    expect_equal(length(p2), 1L)
+    expect_equal(names(p2), "")
   }
 })


### PR DESCRIPTION
`ggsummarystats(free.panels = TRUE)` could title each panel with **another
group's name**, while the boxes and the summary table underneath showed this
group's data. A reader has no way to notice: every panel looks internally
consistent.

## Reproduce

```r
library(ggpubr)

set.seed(1)
d <- data.frame(
  region = rep(c("North", "East", "South"), each = 12),   # not alphabetical
  grp    = rep(c("a", "b"), 18),
  val    = c(rnorm(12, 100), rnorm(12, 10), rnorm(12, 50)),
  stringsAsFactors = FALSE
)
tapply(d$val, d$region, mean)
#>   East   North   South
#>  10.03  100.27   49.89

ggsummarystats(d, x = "grp", y = "val", facet.by = "region", free.panels = TRUE)
```

**Before** — the panel headed `East` draws boxes at 100 with median 100, but
East's mean is 10.03. `East` and `North` are swapped:

![before](https://i.imgur.com/KeqQQsY.png)

**After** — each panel is headed with the group it draws:

![after](https://i.imgur.com/lbOGGQJ.png)

## Cause

The panel label came from `rstatix::df_split_by()`, which builds it through
`df_unite_factors()`. That helper sorts the rows with `arrange()` before uniting,
and the label is then assigned back onto the *unsorted* nested frame — so as soon
as the sort reorders the groups, each row is labelled with a neighbour's name.
The label also travels into each nested data frame, which is where the panel
strip gets it.

The grouping key that `df_split_by()` returns beside each nested frame **is**
aligned with it, so the label is now rebuilt from that key and cannot drift.

## Scope

Affected any `facet.by` column whose groups do not already appear in sorted order:
a character column that is not alphabetical, a factor whose levels are ordered
differently from its rows, numeric, integer, logical and `Date` columns, and a
frame whose `NA` group is not last. A column whose groups already appear in sorted
order was unaffected. `labeller = "label_both"` was hit more often, because it
sorts the formatted `variable:value` strings rather than the underlying values.

The root cause was reported upstream (rstatix issue 324) and is fixed in
rstatix's development version. ggpubr requires `rstatix (>= 1.1.0)` — the
released version that still carries it — and the cases below involving a facet
column named `panel` or `label` are wrong on **any** rstatix version, so the fix
is applied here regardless:

- `facet.by = c("panel", "label")` dropped the `panel` variable from every title
  and returned **duplicated names** (`q`, `p`, `q`, `p`), so `p[["q"]]` could
  only reach the first of the two;
- a facet column named `label` lost the `label:` prefix `label_both` asks for.

A duplicated (`c("region","region")`) or named (`c(a = "region")`) `facet.by`
keeps working, and panel order is now pinned by a test: panels are returned in
the order the groups appear in the data — the order they have always been drawn
in — and each title names the panel it sits on.

The faceted example on `?ggsummarystats` (`facet.by = c("supp", "qc")`,
`labeller = "label_both"`) had **all four** of its panels transposed; it is now a
regression test with medians recomputed from `ToothGrowth` in base R.

Each panel keeps its position and its data — only the name written on it changes,
so titles now read in data order rather than sorted order. Label formatting is
unchanged, with one exception: a facet column named `label` with
`labeller = "label_both"` now gets the `label:` prefix it asks for, which upstream
variable shadowing had been dropping.

A facet column literally named `panel` is handled too: the label is written into
the column of that name, so the keys are read before the split rather than after.

Reported upstream as kassambara/rstatix#324; the helper is still affected for its
other callers, so this fix does not depend on that being released.

## Checks

Test suite FAIL 0, PASS 1624. Output for every other builder is byte-identical to
`master` (50-combination harness). Spelling clean.
