### PR TITLE
Draw the summary table on the categories the plot was drawn on

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,19 @@
 
 ## Bug fixes
 
+- `ggsummarystats()` now draws its summary table on the categories the plot
+  was drawn on, so each column sits under the box it describes. The table
+  trained its own x scale, so when the two orders differed the columns were
+  shuffled relative to the boxes: with `time = Pre/Post/Mid` the column under
+  `Pre` printed `Mid`'s median. The columns were shuffled by `order = ` in the
+  same way, and `select = ` / `remove = ` left behind a column for a group the
+  plot no longer drew. A `POSIXct` x, which could not be printed at all, now
+  draws. `$summary.plot$data` holds only the groups drawn, with its x column a
+  factor over those categories. Plots whose x axis is continuous — `ggline()`
+  or `ggbarplot()` with an integer or `Date` x, or any builder called with
+  `numeric.x.axis = TRUE` — and facets with `scales = "free_x"` are not
+  affected by this change. See `?ggsummarystats`.
+
 - `ggsummarystats(free.panels = TRUE)` now titles every panel with the group
   whose data it draws. The panel label was taken from a split that sorts its rows
   before building the label but attaches it to the unsorted data, so panels were

--- a/R/ggsummarystats.R
+++ b/R/ggsummarystats.R
@@ -18,6 +18,20 @@ NULL
 #'   table = )} adds ggplot components to the main plot and/or the summary table
 #'   and returns the updated object.
 #'   }
+#'
+#'   The summary table is drawn on the categories the plot itself was drawn on,
+#'   so its columns sit under the boxes they describe. It therefore reports the
+#'   groups the plot draws, and only those: a group excluded by \code{select = },
+#'   \code{remove = } or \code{order = } gets no column, and
+#'   \code{$summary.plot$data} holds only
+#'   the groups drawn, with its x column a factor over those categories. A group
+#'   the plot draws but has no summary row - for example all its \code{y} values
+#'   missing - keeps its slot with the column left blank, rather than shifting
+#'   every later column along. This does not apply to a plot whose x axis is
+#'   continuous - an integer or \code{Date} x under \code{\link{ggline}()} or
+#'   \code{\link{ggbarplot}()}, or any builder called with
+#'   \code{numeric.x.axis = TRUE} - nor to facets with \code{scales = "free_x"}, where
+#'   one set of categories cannot describe every panel.
 #' @inheritParams ggboxplot
 #' @param digits integer indicating the number of decimal places (round) to be
 #'   used.
@@ -249,6 +263,37 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
     ggtheme = ggtheme,
     facet.by = facet.by, labeller = labeller, ...
   )
+  # The table is built from its own frame, so it trains its own x scale. Whenever
+  # that scale orders the categories differently from the plot's - dplyr returns
+  # group keys sorted, while the builders factor x in the order the groups appear
+  # - every column sits under the wrong box, silently. Move the table's x onto the
+  # categories the plot ACTUALLY drew, so the two cannot disagree.
+  cats <- .plot_x_categories(main.plot)
+  keep.empty <- FALSE
+  if (!is.null(cats) && x %in% colnames(summary.stats)) {
+    keep <- !is.na(match(as.character(summary.stats[[x]]), cats))
+    # If nothing matches, the two key spaces are not what we think they are:
+    # leave the table exactly as released rather than blank it.
+    if (any(keep)) {
+      summary.stats <- summary.stats[keep, , drop = FALSE]
+      # as.character() states the coercion factor() would do anyway, and matches
+      # how ggplot2's discrete scale maps values: match(as.character(x), limits).
+      # exclude = NULL is load-bearing: get_limits() keeps an NA category, and
+      # without it factor() drops NA from the levels, so every column from the NA
+      # group onward rotates onto the wrong box - the very bug being fixed.
+      # ordered = is.ordered(.) because the class picks the default discrete
+      # scale: ggplot2 gives an ordered factor scale_*_ordinal (viridis) and an
+      # unordered one scale_*_hue. Dropping it recoloured the table's numbers
+      # away from the boxes they sit under, so the composite's own colour key
+      # disagreed with itself.
+      summary.stats[[x]] <- factor(
+        as.character(summary.stats[[x]]), levels = cats, exclude = NULL,
+        ordered = is.ordered(summary.stats[[x]])
+      )
+      keep.empty <- !all(cats %in% as.character(summary.stats[[x]]))
+    }
+  }
+
   summary.plot <- ggsummarytable(
     summary.stats,
     x = x, y = summaries,
@@ -258,6 +303,14 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
     digits = digits, size = table.font.size
   ) +
     clean_table_theme()
+  # Only when a category the plot drew has no summarised row - a group whose y is
+  # entirely missing - does the table need telling to keep the empty slot. Adding
+  # a scale is avoided otherwise: a user's own scale_x_discrete() would replace it
+  # and silently restore the misalignment, and $summary.plot is documented as
+  # editable. The factor levels above carry the order, where nothing can undo it.
+  if (keep.empty) {
+    summary.plot <- summary.plot + ggplot2::scale_x_discrete(drop = FALSE)
+  }
 
   plots <- list(
     main.plot = main.plot,
@@ -267,6 +320,38 @@ ggsummarystats_core <- function(data, x, y, summaries = c("n", "median", "iqr"),
   plots
 }
 
+
+# The categories the main plot's x scale actually trained on, or NULL when the
+# table cannot follow it. Reading the BUILT scale is the whole point: it reports
+# what was drawn, so it distinguishes a dropped level from a kept one - which
+# levels() of the input frame cannot - and it answers "discrete or continuous?"
+# per builder without this function having to know anything about the builders.
+#
+# NULL (leave the table exactly as released) when: the plot will not build; the
+# x scale is continuous (numeric.x.axis, and integer/Date under the builders that
+# do not factor them - the table cannot express a continuous axis); or the facets
+# use free x scales, where one set of categories cannot describe every panel.
+#
+# ggplot2::layer_scales() is the exported equivalent of this lookup, but it builds
+# the plot a second time and cannot report how many x scales there are, which is
+# half the test below.
+.plot_x_categories <- function(p) {
+  built <- tryCatch(
+    suppressMessages(suppressWarnings(ggplot2::ggplot_build(p))),
+    error = function(e) NULL
+  )
+  if (is.null(built)) {
+    return(NULL)
+  }
+  scales.x <- built$layout$panel_scales_x
+  if (length(scales.x) != 1) {
+    return(NULL)
+  }
+  if (!isTRUE(scales.x[[1]]$is_discrete())) {
+    return(NULL)
+  }
+  as.character(scales.x[[1]]$get_limits())
+}
 
 # Build one panel label per row of a df_split_by() result, from that row's own
 # grouping key, so the label cannot drift away from the data beside it. Mirrors

--- a/man/ggsummarystats.Rd
+++ b/man/ggsummarystats.Rd
@@ -130,6 +130,20 @@ Create a ggplot with summary stats (n, median, mean, iqr) table
   table = )} adds ggplot components to the main plot and/or the summary table
   and returns the updated object.
   }
+
+  The summary table is drawn on the categories the plot itself was drawn on,
+  so its columns sit under the boxes they describe. It therefore reports the
+  groups the plot draws, and only those: a group excluded by \code{select = },
+  \code{remove = } or \code{order = } gets no column, and
+  \code{$summary.plot$data} holds only
+  the groups drawn, with its x column a factor over those categories. A group
+  the plot draws but has no summary row - for example all its \code{y} values
+  missing - keeps its slot with the column left blank, rather than shifting
+  every later column along. This does not apply to a plot whose x axis is
+  continuous - an integer or \code{Date} x under \code{\link{ggline}()} or
+  \code{\link{ggbarplot}()}, or any builder called with
+  \code{numeric.x.axis = TRUE} - nor to facets with \code{scales = "free_x"}, where
+  one set of categories cannot describe every panel.
 }
 \section{Functions}{
 \itemize{

--- a/tests/testthat/test-ggsummarystats.R
+++ b/tests/testthat/test-ggsummarystats.R
@@ -300,3 +300,235 @@ test_that("ggsummarystats(free.panels) titles a missing group 'NA' and draws its
       tolerance = 1e-8)
   }
 })
+
+# Each summary-table column must sit under the box it describes. Returns the
+# number of drawn columns whose numbers are not that box's own, recomputed here
+# in base R rather than through ggpubr or rstatix.
+.miscounted_columns <- function(p, d, x, y) {
+  bm <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$main.plot)))
+  bt <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$summary.plot)))
+  cats <- as.character(bm$layout$panel_scales_x[[1]]$get_limits())
+  lab <- bt$data[[1]]
+  xs <- as.numeric(lab$x)
+  wrong <- 0
+  for (i in seq_along(cats)) {
+    drawn <- gsub("\n", "|", lab$label[abs(xs - i) < 1e-9])
+    v <- d[[y]][if (is.na(cats[i])) is.na(d[[x]]) else
+      (!is.na(d[[x]]) & as.character(d[[x]]) == cats[i])]
+    v <- v[!is.na(v)]
+    if (!length(v)) next
+    expected <- paste(length(v), round(stats::median(v)), round(stats::IQR(v)), sep = "|")
+    if (length(drawn) != 1 || !identical(drawn, expected)) wrong <- wrong + 1
+  }
+  wrong
+}
+
+test_that("ggsummarystats() table columns sit under the boxes they describe", {
+  # The table is built from its own frame and trained its own x scale: dplyr
+  # returns group keys sorted while the builders factor x in the order the groups
+  # appear, so with a non-alphabetical character x every column sat under the
+  # wrong box. Measured before the fix: the column under "Pre" (median 11.5)
+  # printed 22, which is "Mid"'s.
+  d <- data.frame(
+    time = rep(c("Pre", "Post", "Mid"), each = 4),
+    val = c(10:13, 30:33, 20:23), stringsAsFactors = FALSE
+  )
+  for (f in list(ggboxplot, ggviolin, ggdotplot, ggstripchart, ggbarplot,
+                 ggline, ggerrorplot)) {
+    p <- suppressWarnings(suppressMessages(
+      ggsummarystats(d, x = "time", y = "val", ggfunc = f)
+    ))
+    expect_equal(.miscounted_columns(p, d, "time", "val"), 0)
+    # the table now trains the same categories, in the same order, as the plot
+    expect_equal(
+      as.character(suppressWarnings(suppressMessages(
+        ggplot2::ggplot_build(p$summary.plot)))$layout$panel_scales_x[[1]]$get_limits()),
+      c("Pre", "Post", "Mid")
+    )
+  }
+})
+
+test_that("ggsummarystats() follows the plot for numeric, integer and Date x", {
+  # These reach the gate because five of the seven builders factor such a column.
+  # Moving the table's data onto the plot's categories is what keeps it on the
+  # axis it is drawn against; pinning only the axis, and leaving the data
+  # numeric, would shift every column one slot.
+  set.seed(1)
+  frames <- list(
+    numeric = data.frame(k = rep(c(0.5, 1, 2), each = 6), v = rep(c(10, 20, 30), each = 6) + stats::rnorm(18)),
+    integer = data.frame(k = rep(c(0L, 3L, 24L), each = 6), v = rep(c(10, 20, 30), each = 6) + stats::rnorm(18)),
+    date = data.frame(k = rep(as.Date("2020-01-01") + c(0, 10, 40), each = 6),
+                      v = rep(c(10, 20, 30), each = 6) + stats::rnorm(18))
+  )
+  for (nm in names(frames)) {
+    d <- frames[[nm]]
+    p <- suppressWarnings(suppressMessages(ggsummarystats(d, x = "k", y = "v")))
+    expect_equal(.miscounted_columns(p, d, "k", "v"), 0)
+  }
+})
+
+test_that("ggsummarystats() leaves a continuous or free-scaled plot alone", {
+  # The table cannot express a continuous axis, and one set of categories cannot
+  # describe free per-panel scales, so the gate must not fire for either.
+  skip_if_not_installed("ggplot2")
+  disc <- function(p) {
+    suppressWarnings(suppressMessages(
+      ggplot2::ggplot_build(p)))$layout$panel_scales_x[[1]]$is_discrete()
+  }
+  p1 <- suppressWarnings(suppressMessages(ggsummarystats(
+    ToothGrowth, x = "dose", y = "len", ggfunc = ggline, numeric.x.axis = TRUE
+  )))
+  expect_false(disc(p1$main.plot))
+  expect_false(disc(p1$summary.plot)) # untouched: still its own continuous scale
+
+  # free_x with DISJOINT categories per panel: one set of categories cannot
+  # describe both, so the gate must stay off. If it fired, panel 1's categories
+  # would be applied to the whole table and panel 2's groups would be filtered
+  # away - 2 rows instead of 4.
+  set.seed(2)
+  d2 <- data.frame(
+    g = c(rep(c("a", "b"), each = 6), rep(c("c", "d"), each = 6)),
+    p = rep(c("P1", "P2"), each = 12),
+    v = c(stats::rnorm(12, 10), stats::rnorm(12, 50)), stringsAsFactors = FALSE
+  )
+  p2 <- suppressWarnings(suppressMessages(ggsummarystats(
+    d2, x = "g", y = "v", facet.by = "p", scales = "free_x"
+  )))
+  b2 <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p2$summary.plot)))
+  expect_equal(nrow(b2$data[[1]]), 4L)
+  expect_s3_class(ggplot2::ggplotGrob(b2), "gtable")
+})
+
+test_that("ggsummarystats() summarises exactly the groups the plot draws", {
+  # The case that made an earlier attempt print a fabricated statistic: a removed
+  # group plus genuine NAs. Released draws FOUR columns for THREE categories, so
+  # the removed dose 1's median lands under the box labelled 2.
+  skip_if_not_installed("emmeans")
+  d <- ToothGrowth
+  d$dose <- as.character(d$dose)
+  d$dose[c(3, 17)] <- NA
+  p <- suppressWarnings(suppressMessages(ggsummarystats(
+    d, x = "dose", y = "len", comparisons = list(c("0.5", "2")), remove = "1"
+  )))
+  bt <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$summary.plot)))
+  expect_equal(nrow(bt$data[[1]]), 3L) # not 4
+  expect_equal(.miscounted_columns(p, d, "dose", "len"), 0)
+
+  # a group the plot draws but cannot summarise keeps its slot, and prints nothing
+  d2 <- data.frame(g = rep(c("A", "B", "C"), each = 4),
+                   v = c(1:4, rep(NA_real_, 4), 9:12), stringsAsFactors = FALSE)
+  p2 <- suppressWarnings(suppressMessages(ggsummarystats(d2, x = "g", y = "v")))
+  bt2 <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p2$summary.plot)))
+  expect_equal(
+    as.character(bt2$layout$panel_scales_x[[1]]$get_limits()), c("A", "B", "C")
+  )
+  expect_equal(.miscounted_columns(p2, d2, "g", "v"), 0)
+})
+
+test_that("ggsummarystats() adds no construction-time message and no scale of its own", {
+  # The probe build must stay silent (ggdotplot otherwise reports its bin width at
+  # call time, where released reports nothing), and no scale is added on the
+  # common path - a user's own scale_x_discrete() would replace it and silently
+  # restore the misalignment, and $summary.plot is documented as editable.
+  for (f in list(ggboxplot, ggviolin, ggdotplot, ggstripchart, ggbarplot,
+                 ggline, ggerrorplot)) {
+    expect_message(
+      suppressWarnings(invisible(
+        ggsummarystats(ToothGrowth, x = "dose", y = "len", ggfunc = f)
+      )),
+      NA
+    )
+  }
+  d <- data.frame(time = rep(c("Pre", "Post", "Mid"), each = 4),
+                  val = c(10:13, 30:33, 20:23), stringsAsFactors = FALSE)
+  p <- suppressWarnings(suppressMessages(ggsummarystats(d, x = "time", y = "val")))
+  styled <- style_summarystats(p, table = ggplot2::scale_x_discrete(labels = toupper))
+  b <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(styled$summary.plot)))
+  # the user's own scale must not be able to undo the alignment
+  expect_equal(as.character(b$layout$panel_scales_x[[1]]$get_limits()),
+               c("Pre", "Post", "Mid"))
+})
+
+test_that("ggsummarystats() keeps an ordered x ordered, so the table's colours match", {
+  # The class of the x column picks ggplot2's default discrete scale: an ordered
+  # factor gets scale_*_ordinal (viridis), an unordered one scale_*_hue. Coercing
+  # x without carrying `ordered` through recoloured the table's numbers away from
+  # the boxes they sit under, so the composite's own colour key disagreed with
+  # itself - on a call that was already correct.
+  ord <- data.frame(
+    g = factor(rep(c("lo", "mid", "hi"), each = 5),
+               levels = c("lo", "mid", "hi"), ordered = TRUE),
+    v = c(1:5, 11:15, 21:25)
+  )
+  p <- suppressWarnings(suppressMessages(
+    ggsummarystats(ord, x = "g", y = "v", color = "g")
+  ))
+  expect_true(is.ordered(p$summary.plot$data$g))
+  bm <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$main.plot)))
+  bt <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$summary.plot)))
+  bx <- as.numeric(bm$data[[1]]$x)
+  tx <- as.numeric(bt$data[[1]]$x)
+  for (i in 1:3) {
+    expect_equal(
+      unique(bt$data[[1]]$colour[abs(tx - i) < 1e-9]),
+      unique(bm$data[[1]]$colour[abs(bx - i) < 1e-9])
+    )
+  }
+
+  # and with order= the labels follow the re-ordered plot, colours still matching
+  p2 <- suppressWarnings(suppressMessages(ggsummarystats(
+    ord, x = "g", y = "v", color = "g", order = c("hi", "lo", "mid")
+  )))
+  expect_equal(.miscounted_columns(p2, ord, "g", "v"), 0)
+})
+
+test_that("ggsummarystats() keeps an NA category in its slot (exclude = NULL)", {
+  # get_limits() reports NA as a real category. factor() drops NA from its levels
+  # by default, so without exclude = NULL every column from the NA group onward
+  # rotates onto the wrong box - the same defect this fix exists to remove.
+  # Measured with the guard removed: NA's 52 lands on b's box, a's 12 on NA's.
+  k <- factor(c(rep(NA, 4), rep("a", 4), rep("b", 4)),
+              levels = c(NA, "a", "b"), exclude = NULL)
+  d <- data.frame(v = c(50:53, 10:13, 30:33))
+  d$k <- k
+  p <- suppressWarnings(suppressMessages(ggsummarystats(d, x = "k", y = "v")))
+  bt <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$summary.plot)))
+  lab <- bt$data[[1]]
+  ord <- order(as.numeric(lab$x))
+  expect_equal(as.numeric(lab$x)[ord], c(1, 2, 3))
+  # slot 1 is the NA group (median 51.5 -> 52), then a (11.5 -> 12), then b (32)
+  expect_equal(gsub("\n", "|", lab$label[ord]), c("4|52|2", "4|12|2", "4|32|2"))
+  expect_equal(.miscounted_columns(p, d, "k", "v"), 0)
+})
+
+test_that("ggsummarystats() falls back to released behaviour when it cannot follow the plot", {
+  # Two guards, both load-bearing, neither previously covered.
+  #
+  # 1. If no summarised row matches the plot's categories the two key spaces are
+  #    not what we think they are. Keeping the released table is better than a
+  #    blank one: without the any(keep) guard this draws ZERO columns.
+  d <- data.frame(
+    time = rep(c("Pre", "Post", "Mid"), each = 4),
+    val = c(10:13, 30:33, 20:23), stringsAsFactors = FALSE
+  )
+  p <- suppressWarnings(suppressMessages(
+    ggsummarystats(d, x = "time", y = "val", order = c("zz1", "zz2"))
+  ))
+  bt <- suppressWarnings(suppressMessages(ggplot2::ggplot_build(p$summary.plot)))
+  expect_equal(nrow(bt$data[[1]]), 3L)
+
+  # 2. If the main plot cannot be built, ggsummarystats() must still return its
+  #    object and let the error surface at print, as it always has - not raise it
+  #    at the call. Without the tryCatch the probe build throws here.
+  bad <- function(data, x, y, ...) {
+    ggboxplot(data, x, y, ...) + ggplot2::scale_x_continuous()
+  }
+  d2 <- data.frame(g = rep(c("a", "b"), each = 4), v = c(1:4, 9:12),
+                   stringsAsFactors = FALSE)
+  expect_s3_class(
+    suppressWarnings(suppressMessages(
+      ggsummarystats(d2, x = "g", y = "v", ggfunc = bad)
+    )),
+    "ggsummarystats"
+  )
+})


### PR DESCRIPTION
`ggsummarystats()` drew its summary table from its own frame, so the table
trained its own x scale. When the two scales ordered the categories differently,
every column sat under the wrong box — silently, with a figure that looked
entirely plausible.

## Reproduce

```r
library(ggpubr)

d <- data.frame(time = rep(c("Pre", "Post", "Mid"), each = 4),
                val  = c(10:13, 30:33, 20:23), stringsAsFactors = FALSE)
tapply(d$val, d$time, median)
#>  Mid  Post   Pre
#> 21.5  31.5  11.5

ggsummarystats(d, x = "time", y = "val")
```

**Before** — the `Pre` box sits at 11.5 but its column reads **22**, and `Mid`
(21.5) reads **12**. The two are swapped:

![before](https://i.imgur.com/QHvY9wW.png)

**After** — 12 / 32 / 22, each under its own box:

![after](https://i.imgur.com/W71QzOm.png)

## Why it happened, and what changed

The summary is grouped with `dplyr`, which sorts the group keys, while a
character x is factored in the order the groups appear. Nothing reconciled the
two.

The table's x is now moved onto the categories the plot **actually drew**, read
from the built plot rather than inferred from the input. Reading the built scale
is what makes this reliable: it distinguishes a level the plot dropped from one
it drew, and it answers "discrete or continuous?" for each builder without the
code having to know anything about the builders.

The gate is deliberately narrow — it applies only when the plot builds, has
exactly one x scale, that scale is discrete, and the summary's keys land on its
categories. Anything else keeps the previous behaviour unchanged.

Also fixed, as consequences of the same alignment: columns shuffled by `order =`;
a stale column left behind by `select =` / `remove =`; a group the plot draws but
has no summary row shifting every later column along; and a `POSIXct` x that
could not be printed at all under the builders that factor it.

## What moves, and what does not

Figures move only where the table was not already sitting on the plot's discrete
positions. A numeric x changes under all seven builders, since `ggline()` and
`ggbarplot()` factor a numeric x too unless `numeric.x.axis` is set; an integer
or `Date` x changes under the five that factor it — `ggboxplot()`, `ggviolin()`,
`ggdotplot()`, `ggstripchart()`, `ggerrorplot()`.

Unchanged: calls whose table already trained the plot's categories in the same
order; plots whose x axis is continuous (`ggline()`/`ggbarplot()` with an integer
or `Date` x, or any builder with `numeric.x.axis = TRUE`); and facets with
`scales = "free_x"`, where one set of categories cannot describe every panel.

`$summary.plot$data` now holds only the groups drawn, with its x column a factor
over those categories. `?ggsummarystats` documents the behaviour.

## Checks

Test suite passes; output is unchanged for every call where the two scales
already agreed, compared figure-by-figure; every drawn `n`, `median` and `iqr`
was checked against the same statistic recomputed with base R.
