### PR TITLE
Keep each dodge2 error bar on its own bar with a discrete alpha (#404)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -270,7 +270,13 @@
   `color`/`fill`/`alpha` column that is not discrete (ggplot2 does not group the
   bars by such a column, so the layer draws more bars than there are dodge
   positions and no error bar can be matched to one bar), and a column named
-  after one of the statistics `desc_statby()` computes. Calls without a discrete
+  after one of the statistics `desc_statby()` computes. `label = TRUE` (or a
+  character label vector) is a third: the value labels are placed by their own
+  layer, which dodges on the legend key alone, so with the `alpha` subgroup
+  carried they land between the bars — four of eight over the bar whose value
+  they show. Aligning the error bars while half the numbers float would make the
+  figure look trustworthy and read wrong, so a labelled call keeps the released
+  behaviour until the label layer is keyed too. Calls without a discrete
   `alpha` column are unchanged, including a faceted `position_dodge2()` with
   `scales = "free_x"`, whose error bars keep the positions they have always had.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -289,12 +289,27 @@
   `position_dodge2()` with `scales = "free_x"`, whose error bars keep the
   positions they have always had.
 
-  One case does change for a call that already drew: an `alpha` mapped to a
-  column that is **already** a grouping variable (for example `fill = "supp",
-  alpha = "supp"`) worked before, because the summary already carried that
-  column. With `error.plot = "crossbar"` its crossbars were drawn off-centre and
-  wider than their bars; they are now centred on the bar at the bar's own width.
-  Their fill is unchanged — it still follows the mapped `fill`.
+  **Two** cases change for calls that already drew. Both need an `alpha` mapped
+  to a column that is **already** a grouping variable (for example
+  `fill = "supp", alpha = "supp"`), which worked before because the summary
+  already carried that column, and in both the annotation was previously drawn
+  on the wrong bar:
+
+  - with `error.plot = "crossbar"`, the crossbars were drawn off-centre and
+    wider than their bars (`x = 0.75` and width `0.45`, against a bar at
+    `x = 0.825` and width `0.315`); they are now centred on the bar at the bar's
+    own width. Their fill is unchanged — it still follows the mapped `fill`;
+  - with `position_dodge2(reverse = TRUE)`, every error bar carried the *other*
+    bar's mean and error, because `position_dodge2()` lays each x out in
+    descending group order there while the summary was ordered ascending. They
+    are now paired correctly.
+
+  The `reverse = TRUE` correction applies only where a discrete `alpha` column
+  is carried. **Without one it is unchanged, and still wrong**:
+  `ggbarplot(ToothGrowth, "dose", "len", fill = "supp", add = "mean_se",
+  position = position_dodge2(reverse = TRUE))` draws each error bar on the
+  neighbouring bar, exactly as it does in previous releases. Fixing that changes
+  released output for every such call and is left for its own change.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -299,7 +299,8 @@
     wider than their bars (`x = 0.75` and width `0.45`, against a bar at
     `x = 0.825` and width `0.315`); they are now centred on the bar at the bar's
     own width. Their fill is unchanged — it still follows the mapped `fill`;
-  - with `position_dodge2(reverse = TRUE)`, every error bar carried the *other*
+  - with `position_dodge2(reverse = TRUE)` — or any value `position_dodge2()`
+    itself treats as true, such as `1` — every error bar carried the *other*
     bar's mean and error, because `position_dodge2()` lays each x out in
     descending group order there while the summary was ordered ascending. They
     are now paired correctly.

--- a/NEWS.md
+++ b/NEWS.md
@@ -249,13 +249,14 @@
   column splits the summary into one row per (x, legend, alpha) cell;
   `position_dodge2()` places its error layer by re-centring it on the bars, and
   that step now orders the summary on every discrete aesthetic ggplot2 groups
-  the bars by, then checks the pairing it produced against the bars it is about
-  to draw on. Verified against `stats::aggregate` for `sort.val =`,
-  `sort.by.groups = FALSE`, `top =`, shuffled input rows, an `add.params$color`
-  naming the `alpha` column, `facet.by =` of one or two variables with fixed or
-  free scales, an `alpha` column that is ordered, logical, reversed or contains
-  `NA`, unbalanced, singleton and zero-variance cells, and tibble or grouped
-  input.
+  the bars by — in the direction `position_dodge2()` lays them out, so
+  `reverse = TRUE` is included — and then checks the pairing it produced against
+  the bars it is about to draw on. Verified against `stats::aggregate` for
+  `sort.val =`, `sort.by.groups = FALSE`, `top =`, shuffled input rows, an
+  `add.params$color` naming the `alpha` column, `facet.by =` of one or two
+  variables with fixed or free scales, an `alpha` column that is ordered,
+  logical or reversed, cells that share a mean, unbalanced, singleton and
+  zero-variance cells, and tibble or grouped input.
 
   `error.plot = "crossbar"` is included. A crossbar is wide, so it normally
   dodges itself — but `position_dodge2()` packs elements by their own width and
@@ -265,26 +266,35 @@
   it is re-centred like the other error plots and drawn as a crossbar rather
   than falling back to an error bar.
 
-  Two configurations keep the released behaviour of refusing to draw, rather
-  than placing an interval beside a bar it was not computed from: a
-  `color`/`fill`/`alpha` column that is not discrete (ggplot2 does not group the
-  bars by such a column, so the layer draws more bars than there are dodge
-  positions and no error bar can be matched to one bar), and a column named
-  after one of the statistics `desc_statby()` computes. `label = TRUE` (or a
-  character label vector) is a third: the value labels are placed by their own
-  layer, which dodges on the legend key alone, so with the `alpha` subgroup
-  carried they land between the bars — four of eight over the bar whose value
-  they show. Aligning the error bars while half the numbers float would make the
-  figure look trustworthy and read wrong, so a labelled call keeps the released
-  behaviour until the label layer is keyed too. A raw-data layer
-  (`add = c("mean_se", "jitter")` and likewise `point`, `dotplot`, `boxplot`,
-  `violin`) is the fourth, for the same reason: those layers are placed under
-  the same position, and `position_dodge2()` packs by each element's own width,
-  which a point does not have — they already sit off their own bar without any
-  `alpha` (unchanged by this fix), and the extra subgroup would double it.
-  Calls without a discrete
-  `alpha` column are unchanged, including a faceted `position_dodge2()` with
-  `scales = "free_x"`, whose error bars keep the positions they have always had.
+  Four configurations keep the released behaviour of refusing to draw, rather
+  than placing an interval beside a bar it was not computed from:
+
+  - a `color`/`fill`/`alpha` column that is **not discrete** — ggplot2 does not
+    group the bars by such a column, so the layer draws more bars than there are
+    dodge positions and no error bar can be matched to one bar;
+  - **`label = TRUE`** (or a character label vector) — the value labels are
+    placed by their own layer, which dodges on the legend key alone, so with the
+    `alpha` subgroup carried they land between the bars, four of eight over the
+    bar whose value they show;
+  - **a raw-data layer** (`add = c("mean_se", "jitter")`, and likewise `point`,
+    `dotplot`, `boxplot`, `violin`) — placed under the same position, and
+    `position_dodge2()` packs by each element's own width, which a point does
+    not have. They already sit off their own bar without any `alpha` (unchanged
+    by this fix), and the extra subgroup would double it;
+  - **an asymmetric summary** (`median_q1q3`, `median_hilow`) — a quantile pair
+    rather than centre ± error, so the summary has no half-width column for the
+    layer to be rebuilt from.
+
+  Calls without a discrete `alpha` column are unchanged, including a faceted
+  `position_dodge2()` with `scales = "free_x"`, whose error bars keep the
+  positions they have always had.
+
+  One case does change for a call that already drew: an `alpha` mapped to a
+  column that is **already** a grouping variable (for example `fill = "supp",
+  alpha = "supp"`) worked before, because the summary already carried that
+  column. With `error.plot = "crossbar"` its crossbars were drawn off-centre and
+  wider than their bars; they are now centred on the bar at the bar's own width.
+  Their fill is unchanged — it still follows the mapped `fill`.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -216,7 +216,7 @@
   appearance of such a plot, which was previously drawn with the error bars
   permuted.
 
-  Still unchanged from previous releases: `position_dodge2()` and the stacked
+  Still unchanged from previous releases: the stacked
   default, a numeric `alpha` column, and a grouping column named after one of the
   statistics `desc_statby()` computes (`length`, `min`, `max`, `median`, `mean`,
   `iqr`, `mad`, `sd`, `se`, `ci`, `range`, `cv`, `var`) — the summary's column of
@@ -231,12 +231,48 @@
   `fill` key alone, so with a discrete `alpha` they are drawn between the bars,
   two to a position.
 
-  `top =` remains unsupported alongside a discrete `alpha`, and is the one
+  Under plain `position_dodge()`, `top =` remains unsupported alongside a
+  discrete `alpha`, and is the one
   configuration whose broken output changed rather than staying as released: the
   error layer is still built for every summary group rather than for the bars
   actually kept, so it draws more error bars than there are bars, some over empty
   space and some overlapping a kept bar while carrying another group's statistic
   — but which stray interval lands where now differs from previous releases.
+  (Under `position_dodge2()` the error layer is built from the same truncated
+  summary as the bars, so `top =` is aligned there.)
+
+- `ggbarplot()` now draws a summary with a variable mapped to `alpha` under
+  `position_dodge2()`, with each error bar on its own bar (#404). The
+  combination previously failed at draw with `"alpha * 255": non-numeric
+  argument to binary operator`, because the summary dropped the `alpha` column
+  and its name reached the graphics engine as a static opacity. Carrying the
+  column splits the summary into one row per (x, legend, alpha) cell;
+  `position_dodge2()` places its error layer by re-centring it on the bars, and
+  that step now orders the summary on every discrete aesthetic ggplot2 groups
+  the bars by, then checks the pairing it produced against the bars it is about
+  to draw on. Verified against `stats::aggregate` for `sort.val =`,
+  `sort.by.groups = FALSE`, `top =`, shuffled input rows, an `add.params$color`
+  naming the `alpha` column, `facet.by =` of one or two variables with fixed or
+  free scales, an `alpha` column that is ordered, logical, reversed or contains
+  `NA`, unbalanced, singleton and zero-variance cells, and tibble or grouped
+  input.
+
+  `error.plot = "crossbar"` is included. A crossbar is wide, so it normally
+  dodges itself — but `position_dodge2()` packs elements by their own width and
+  a crossbar's is not the bar's, so the two only appear to agree while there are
+  few enough subgroups for the offset to stay inside the bar; the `alpha`
+  subgroup doubles them and the crossbar then lands on a neighbour. On this path
+  it is re-centred like the other error plots and drawn as a crossbar rather
+  than falling back to an error bar.
+
+  Two configurations keep the released behaviour of refusing to draw, rather
+  than placing an interval beside a bar it was not computed from: a
+  `color`/`fill`/`alpha` column that is not discrete (ggplot2 does not group the
+  bars by such a column, so the layer draws more bars than there are dodge
+  positions and no error bar can be matched to one bar), and a column named
+  after one of the statistics `desc_statby()` computes. Calls without a discrete
+  `alpha` column are unchanged, including a faceted `position_dodge2()` with
+  `scales = "free_x"`, whose error bars keep the positions they have always had.
 
 - `stat_compare_means(label = "p.format")` (and `label = "p"`) no longer fail
   with `could not find function "create_p_label"` when ggpubr is called via

--- a/NEWS.md
+++ b/NEWS.md
@@ -276,7 +276,13 @@
   carried they land between the bars — four of eight over the bar whose value
   they show. Aligning the error bars while half the numbers float would make the
   figure look trustworthy and read wrong, so a labelled call keeps the released
-  behaviour until the label layer is keyed too. Calls without a discrete
+  behaviour until the label layer is keyed too. A raw-data layer
+  (`add = c("mean_se", "jitter")` and likewise `point`, `dotplot`, `boxplot`,
+  `violin`) is the fourth, for the same reason: those layers are placed under
+  the same position, and `position_dodge2()` packs by each element's own width,
+  which a point does not have — they already sit off their own bar without any
+  `alpha` (unchanged by this fix), and the extra subgroup would double it.
+  Calls without a discrete
   `alpha` column are unchanged, including a faceted `position_dodge2()` with
   `scales = "free_x"`, whose error bars keep the positions they have always had.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -289,11 +289,11 @@
   `position_dodge2()` with `scales = "free_x"`, whose error bars keep the
   positions they have always had.
 
-  **Two** cases change for calls that already drew. Both need an `alpha` mapped
-  to a column that is **already** a grouping variable (for example
+  **Five** cases change for calls that already drew. All of them need an `alpha`
+  mapped to a column that is **already** a grouping variable (for example
   `fill = "supp", alpha = "supp"`), which worked before because the summary
-  already carried that column, and in both the annotation was previously drawn
-  on the wrong bar:
+  already carried that column. In the first four the annotation was previously
+  drawn on the wrong bar:
 
   - with `error.plot = "crossbar"`, the crossbars were drawn off-centre and
     wider than their bars (`x = 0.75` and width `0.45`, against a bar at
@@ -303,7 +303,21 @@
     itself treats as true, such as `1` — every error bar carried the *other*
     bar's mean and error, because `position_dodge2()` lays each x out in
     descending group order there while the summary was ordered ascending. They
-    are now paired correctly.
+    are now paired correctly;
+  - with `facet.by =` and `scales = "free_x"` (or `"free"`), a panel that is
+    missing an x level renumbers the levels it does draw, and the error bars
+    were placed at the positions of the un-renumbered panel — off their bars,
+    sometimes past the edge of the panel. They now follow the drawn panel.
+    `scales = "fixed"` and `"free_y"` are unaffected;
+  - with an `add.params$group` naming a column unrelated to the legend, the
+    error layer was summarised by that column instead and every interval
+    carried another cell's statistic (measured 0 of 6 on their own bar); they
+    are now paired with the bars;
+  - with `error.plot = "crossbar"` and an `add.params$color` naming a data
+    column whose name is also a colour (a column called `"red"`, say), the
+    argument used to be dropped and the outline drawn black; it is now used as
+    the colour. This matches what the other `error.plot` values already did with
+    the same input.
 
   The `reverse = TRUE` correction applies only where a discrete `alpha` column
   is carried. **Without one it is unchanged, and still wrong**:

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -334,6 +334,13 @@ ggbarplot_core <- function(data, x, y,
   # Mirrors how add.label is resolved further down: a non-logical `label` is a
   # column of user labels and is always drawn.
   draws.labels <- if (is.logical(label)) isTRUE(label[1]) else TRUE
+  # Anything in `add` that is not the summary itself draws the RAW observations
+  # (jitter, point, dotplot, boxplot, violin). Those layers are placed by ggadd()
+  # under the same position, and position_dodge2() packs by each element's own
+  # width - a point has none - so they do not take the bar's slot.
+  draws.raw.layers <- length(setdiff(
+    add, c(.summary_functions(), .errorbar_functions(), "none")
+  )) > 0
   alpha.order.vars <- NULL
   if (has.alpha.group) {
     base.group <- add.params$group %||% x
@@ -406,6 +413,16 @@ ggbarplot_core <- function(data, x, y,
     # would make the figure look trustworthy and read wrong, so a labelled call
     # keeps the released behaviour until the label layer is keyed too.
     if (inherits(position, "PositionDodge2") && draws.labels) has.alpha.group <- FALSE
+    # And for a raw-data layer. Under position_dodge2() those points already sit
+    # off their own bar without any alpha (8 of 12 - pre-existing, and unchanged
+    # here); splitting the bars finer makes it 12 of 24, i.e. half the
+    # observations drawn over a bar they are not from. That is the same
+    # misleading figure the labels would give, so the same disposition: this
+    # combination keeps the released path until dodge2's raw layers are placed
+    # on the bars the way its error layer now is.
+    if (inherits(position, "PositionDodge2") && draws.raw.layers) {
+      has.alpha.group <- FALSE
+    }
   }
   # Include the alpha subgroup in the summary grouping. Otherwise the summarized
   # data drops the alpha column, which (a) makes geom_exec pass alpha as a static

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -331,6 +331,9 @@ ggbarplot_core <- function(data, x, y,
   # groups the bars by. We materialise it as a real column with a safe name
   # (rather than an "interaction(a, b)" mapping string), so it survives special
   # characters in the variable names and options(ggpubr.parse_aes = FALSE).
+  # Mirrors how add.label is resolved further down: a non-logical `label` is a
+  # column of user labels and is always drawn.
+  draws.labels <- if (is.logical(label)) isTRUE(label[1]) else TRUE
   alpha.order.vars <- NULL
   if (has.alpha.group) {
     base.group <- add.params$group %||% x
@@ -396,6 +399,13 @@ ggbarplot_core <- function(data, x, y,
     # from. Released behaviour (which refuses to draw at all) is the honest
     # outcome there, so leave that path exactly as it was.
     if (inherits(position, "PositionDodge2") && !key.exact) has.alpha.group <- FALSE
+    # Same reasoning for `label`. The value labels are placed by their own layer,
+    # which dodges on the legend key alone, so with the alpha subgroup carried
+    # they land between the bars - measured 4 of 8 over the bar whose value they
+    # show. Aligning the error bars while half the numbers float between bars
+    # would make the figure look trustworthy and read wrong, so a labelled call
+    # keeps the released behaviour until the label layer is keyed too.
+    if (inherits(position, "PositionDodge2") && draws.labels) has.alpha.group <- FALSE
   }
   # Include the alpha subgroup in the summary grouping. Otherwise the summarized
   # data drops the alpha column, which (a) makes geom_exec pass alpha as a static

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -741,8 +741,18 @@ ggbarplot_core <- function(data, x, y,
   nms <- names(dots)
   if (is.null(nms) || !length(nms)) return("fixed")
   target <- names(formals(facet))
-  m <- pmatch(nms, target, duplicates.ok = TRUE)
-  hit <- which(!is.na(m) & target[m] == "scales")
+  # R matches an EXACT name first, and an abbreviation of a formal that is
+  # already matched exactly is then left over and swallowed by `...`. So with
+  # both `scales = "free_x"` and `scale = "fixed"`, facet() uses "free_x" and
+  # ignores the other - taking the last partial hit read "fixed" and probed a
+  # layout the plot never draws, putting the intervals on the wrong bars.
+  exact <- which(nms == "scales")
+  hit <- if (length(exact)) {
+    exact
+  } else {
+    m <- pmatch(nms, target, duplicates.ok = TRUE)
+    which(!is.na(m) & target[m] == "scales")
+  }
   if (!length(hit)) return("fixed")
   val <- dots[[hit[length(hit)]]]
   if (is.character(val) && length(val) == 1L &&

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -291,11 +291,8 @@ ggbarplot_core <- function(data, x, y,
   # #404: an `alpha` aesthetic mapped to a discrete data column defines an extra
   # dodge subgroup (e.g. fill = cut, alpha = clarity -> 2 bars per cut). Detect it
   # so the summary keeps that column and the error layer dodges by it too. Both
-  # the carrying and the dodge key are scoped to plain position_dodge():
-  # has.alpha.group gates grouping.vars as well, so under position_dodge2() the
-  # column is not carried at all and that path keeps its released behaviour,
-  # including the "alpha * 255" draw error - see the note below on why its
-  # rank-based re-centring (#363) cannot take the column safely.
+  # plain position_dodge() and position_dodge2() are covered; every other
+  # position keeps its released behaviour, including its draw errors.
   alpha.var <- list(...)[["alpha"]]   # [[ ]] avoids $ partial-matching a `...` arg
   alpha.is.col <- !is.null(alpha.var) && length(alpha.var) == 1 &&
     is.character(alpha.var) && alpha.var %in% names(data) &&
@@ -305,29 +302,21 @@ ggbarplot_core <- function(data, x, y,
   # longer map it, and the column NAME reaches grid as a static opacity - the
   # "alpha * 255" draw error of #404. But carrying it also SPLITS the summary into
   # one row per (x, legend, alpha) cell, and only the interaction dodge key built
-  # below can place that many rows on the right bars. It is specific to plain
-  # position_dodge(), so the column is carried only there.
+  # below can place that many rows on the right bars.
   #
-  # position_dodge2() is deliberately NOT included, even though its error layer is
-  # re-centred on the bars (#363): that re-centring matches summary rows to bars by
-  # SORT POSITION, and with the alpha column carried the sort key
-  # (PANEL, x, legend) is no longer total - the alpha subgroup is only a stable
-  # tie. Anything that reorders the summary (`sort.val`, `top`, `sort.by.groups`)
-  # or that resolves a different key (`add.params$color`/`$fill` naming another
-  # column) then silently permutes the match, so an error bar lands on a
-  # neighbouring bar carrying ITS mean and ITS error. Making dodge2 work needs the
-  # row-to-bar match keyed on the bars' own identity rather than on rank, which is
-  # a focused change of its own; until then position_dodge2() keeps the released
-  # behaviour exactly, rather than trading a draw error for a wrong number.
-  has.alpha.group <- alpha.is.col &&
-    inherits(position, "PositionDodge") && !inherits(position, "PositionDodge2")
+  # position_dodge2() re-centres its error layer on the bars itself (#363) by
+  # matching summary rows to bars by SORT POSITION. With the alpha column carried
+  # the released key (PANEL, x, legend) is no longer total - the alpha subgroup is
+  # only a stable tie - so anything that reorders the summary (`sort.val`, `top`,
+  # `sort.by.groups`) or that resolves a different key (`add.params$color` naming
+  # another column) permutes the match. It is handed the FULL discrete key below
+  # and then CHECKS the pairing it produced against the bars it is about to draw
+  # on, so a key that does not describe the layout falls back to the standard
+  # layer rather than drawing one cell's interval on another cell's bar.
+  # PositionDodge2 subclasses PositionDodge, so the one test covers both.
+  has.alpha.group <- alpha.is.col && inherits(position, "PositionDodge")
 
   grouping.vars <- intersect(c(x, color, fill, facet.by), names(data))
-  # Include the alpha subgroup in the summary grouping. Otherwise the summarized
-  # data drops the alpha column, which (a) makes geom_exec pass alpha as a static
-  # value -> the "alpha * 255" draw error (#404), and (b) collapses the mean/CI
-  # across the subgroups. Left unchanged when no discrete alpha var is mapped.
-  if (has.alpha.group) grouping.vars <- unique(c(grouping.vars, alpha.var))
 
   # static summaries for computing mean/median and adding errors
   if (is.null(add.params$fill)) add.params$fill <- "white"
@@ -342,6 +331,7 @@ ggbarplot_core <- function(data, x, y,
   # groups the bars by. We materialise it as a real column with a safe name
   # (rather than an "interaction(a, b)" mapping string), so it survives special
   # characters in the variable names and options(ggpubr.parse_aes = FALSE).
+  alpha.order.vars <- NULL
   if (has.alpha.group) {
     base.group <- add.params$group %||% x
     # Key on EVERY mapped discrete aesthetic, in the order ggplot2 lays them out
@@ -397,8 +387,23 @@ ggbarplot_core <- function(data, x, y,
       "length", "min", "max", "median", "mean", "iqr", "mad", "sd", "se",
       "ci", "range", "cv", "var"
     )
-    data[[".ggpubr.alpha.group."]] <- if (all(key.discrete) &&
-      !any(c(key.vars, grouping.vars) %in% stat.cols)) {
+    key.exact <- all(key.discrete) && !any(c(key.vars, grouping.vars) %in% stat.cols)
+    # Under position_dodge2() the alpha column is carried ONLY when that key is
+    # exact. In the degenerate cases the key describes a partition the bars are
+    # not drawn on, so no ordering can place one interval per bar - and unlike
+    # plain dodge, dodge2 has no correctly-valued layout to fall back to: it
+    # would draw an interval next to a bar that is not the one it was computed
+    # from. Released behaviour (which refuses to draw at all) is the honest
+    # outcome there, so leave that path exactly as it was.
+    if (inherits(position, "PositionDodge2") && !key.exact) has.alpha.group <- FALSE
+  }
+  # Include the alpha subgroup in the summary grouping. Otherwise the summarized
+  # data drops the alpha column, which (a) makes geom_exec pass alpha as a static
+  # value -> the "alpha * 255" draw error (#404), and (b) collapses the mean/CI
+  # across the subgroups. Left unchanged when no discrete alpha var is mapped.
+  if (has.alpha.group) {
+    grouping.vars <- unique(c(grouping.vars, alpha.var))
+    data[[".ggpubr.alpha.group."]] <- if (key.exact) {
       do.call(
         interaction,
         c(
@@ -414,6 +419,12 @@ ggbarplot_core <- function(data, x, y,
       )
     }
     add.params$group <- ".ggpubr.alpha.group."
+    # The same columns, in the same order, are what position_dodge2()'s error
+    # layer must sort on: collide2() lays each x's elements out by ascending
+    # group id, and that id is id() over exactly these columns. Only offered when
+    # the key is exact - in the degenerate cases above no key describes the
+    # layout, so the helper is left on its released rank match.
+    if (key.exact) alpha.order.vars <- key.vars
   }
   add.params <- .check_add.params(add, add.params, error.plot, data, color, fill, ...)
 
@@ -507,10 +518,19 @@ ggbarplot_core <- function(data, x, y,
   } else if (inherits(position, "PositionDodge2") &&
              nb.bars.by.xposition >= 2 &&
              any(.errorbar_functions() %in% add) &&
-             error.plot %in% .narrow_error_plots()) {
+             (error.plot %in% .narrow_error_plots() ||
+              (!is.null(alpha.order.vars) && error.plot == "crossbar"))) {
     # position_dodge2() misplaces thin error bars relative to the dodged bars
     # (#363). Draw any non-error add layers normally, then re-center the error
     # bars on the actual bar positions.
+    #
+    # A crossbar is wide, so it is normally left to dodge itself - but dodge2
+    # packs elements by their OWN width, and the crossbar's width is not the
+    # bar's, so the two only appear to agree while there are few enough
+    # subgroups for the offset to stay inside the bar. Carrying an `alpha`
+    # column doubles the subgroups and the offset then lands the crossbar on a
+    # neighbouring bar, correctly valued and wrongly placed. On that path it is
+    # re-centred like the others; without the alpha column nothing changes.
     p <- add.params %>%
       .add_item(add = .remove_errorbar_func(add), position = add.position) %>%
       do.call(ggadd, .)
@@ -520,7 +540,8 @@ ggbarplot_core <- function(data, x, y,
       color = add.params$color, fill = add.params$fill,
       group = add.params$group, facet.by = facet.by,
       func = .get_summary_func(add), error.plot = error.plot,
-      width = cap.width
+      width = cap.width, order.vars = alpha.order.vars,
+      facet.scales = .facet_scales_from_dots(list(...))
     )
     if (!is.null(eb)) {
       p <- p + eb
@@ -649,6 +670,30 @@ ggbarplot_core <- function(data, x, y,
   geom_func
 }
 
+# The `scales` a faceted plot will actually be drawn with. It reaches facet()
+# through `...`, so R matches it PARTIALLY against facet()'s formals: `scale =`
+# and `scal =` all arrive as `scales`, while `s =` is ambiguous with
+# `short.panel.labs`/`strip.position` and reaches nothing. Testing names with
+# `==` would miss every abbreviation - the class of bug that has bitten this
+# package repeatedly. pmatch(duplicates.ok = TRUE) resolves each name the way R
+# itself will; without it one exact name consumes the formal and every other
+# abbreviation of it returns NA.
+.facet_scales_from_dots <- function(dots) {
+  nms <- names(dots)
+  if (is.null(nms) || !length(nms)) return("fixed")
+  target <- names(formals(facet))
+  m <- pmatch(nms, target, duplicates.ok = TRUE)
+  hit <- which(!is.na(m) & target[m] == "scales")
+  if (!length(hit)) return("fixed")
+  val <- dots[[hit[length(hit)]]]
+  if (is.character(val) && length(val) == 1L &&
+      val %in% c("fixed", "free", "free_x", "free_y")) {
+    val
+  } else {
+    "fixed"
+  }
+}
+
 .is_stacked <- function(p) {
   inherits(p$layers[[1]]$position, "PositionStack")
 }
@@ -675,10 +720,16 @@ ggbarplot_core <- function(data, x, y,
 # centres cannot be matched.
 .geom_dodge2_errorbar <- function(p, data_sum, x, y, color = NULL, fill = NULL,
                                   group = NULL, facet.by = NULL, func = "mean_se",
-                                  error.plot = "errorbar", width = 0.1) {
+                                  error.plot = "errorbar", width = 0.1,
+                                  order.vars = NULL, facet.scales = "fixed") {
   legend.var <- intersect(unique(c(color, fill, group)), colnames(data_sum))
-  if (length(legend.var) == 0) return(NULL)
-  legend.var <- legend.var[1]
+  # order.vars is the full set of discrete columns ggplot2 groups the bars by
+  # (#404). It is supplied only when an `alpha` column has split the summary
+  # finer than the legend variable, and it then replaces the legend-only sort
+  # key; without it every step below is exactly the released path.
+  order.vars <- intersect(order.vars, colnames(data_sum))
+  if (length(legend.var) == 0 && length(order.vars) == 0) return(NULL)
+  legend.var <- if (length(legend.var)) legend.var[1] else NULL
 
   # Error limits (centre +/- error), honouring upper_/lower_/both, from data_sum.
   # Only symmetric summaries whose error half-width is a data_sum column are
@@ -700,8 +751,30 @@ ggbarplot_core <- function(data, x, y,
   # Actual dodged bar centres from the built plot. Faceting is applied later (by
   # .plotter), so build against a temporarily-faceted copy: dodge2 positions
   # depend on which groups are present *within each panel*.
+  #
+  # The probe must be faceted the way the FINAL plot will be. With a free x
+  # scale a panel that is missing an x level renumbers its remaining levels, so
+  # a fixed-scale probe reads centres the drawn panel never uses; with two
+  # facet variables facet() uses facet_grid(), not facet_wrap(). Released calls
+  # keep the original fixed facet_wrap() probe (its imperfection there is
+  # pre-existing behaviour, not something to change under this fix), so the
+  # accurate probe is used only on the alpha path.
   build.p <- p
-  if (!is.null(facet.by)) build.p <- p + ggplot2::facet_wrap(facet.by)
+  if (!is.null(facet.by)) {
+    build.p <- if (length(order.vars) && length(facet.by) == 2) {
+      p + ggplot2::facet_grid(
+        stats::as.formula(paste(glue::backtick(facet.by), collapse = " ~ ")),
+        scales = facet.scales
+      )
+    } else if (length(order.vars)) {
+      p + ggplot2::facet_wrap(
+        stats::as.formula(paste0("~", glue::backtick(facet.by))),
+        scales = facet.scales
+      )
+    } else {
+      p + ggplot2::facet_wrap(facet.by)
+    }
+  }
   built <- ggplot2::ggplot_build(build.p)
   bar.layer <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomBar"), logical(1)))
   if (length(bar.layer) == 0) return(NULL)
@@ -718,11 +791,49 @@ ggbarplot_core <- function(data, x, y,
     ds$PANEL <- factor(1L)
   }
   as.int <- function(v) if (is.factor(v)) as.integer(v) else as.integer(factor(v))
-  ds <- ds[order(as.int(ds$PANEL), as.int(ds[[x]]), as.int(ds[[legend.var]])), , drop = FALSE]
+  ord.keys <- if (length(order.vars)) {
+    c(list(as.int(ds$PANEL), as.int(ds[[x]])),
+      lapply(order.vars, function(k) as.int(ds[[k]])))
+  } else {
+    list(as.int(ds$PANEL), as.int(ds[[x]]), as.int(ds[[legend.var]]))
+  }
+  ds <- ds[do.call(order, ord.keys), , drop = FALSE]
   if (nrow(ds) != nrow(bd)) return(NULL)
-  ds$.ebx. <- bd$x
 
-  geom.error <- .get_geom_error_function(error.plot)
+  # Check the pairing instead of trusting the sort. geom_bar(stat = "identity")
+  # draws each summary row's own centre, so the bar a row has been matched to
+  # must carry that row's centre; if it does not, the two orders disagree and we
+  # are one line away from drawing one cell's interval on another cell's bar.
+  # Bail out and let the caller keep the standard layer, which is unaligned but
+  # never mislabelled. Only the alpha path is checked - the released key is left
+  # byte-identical, including in the degenerate cases where it is imperfect.
+  if (length(order.vars)) {
+    if (!isTRUE(all.equal(as.numeric(bd$y), as.numeric(ds$.yc.),
+                          tolerance = 1e-9, check.attributes = FALSE))) {
+      return(NULL)
+    }
+    # Two cells sharing a centre within one (panel, x) satisfy that check even
+    # when swapped, and the swap would move a DIFFERENT half-width onto each of
+    # their bars - which a centre cannot reveal. Refuse that case as well.
+    tie <- paste(ds$PANEL, as.character(ds[[x]]),
+                 signif(as.numeric(ds$.yc.), 12), sep = "\r")
+    half <- signif(as.numeric(ds$.ymax. - ds$.ymin.), 12)
+    if (any(vapply(split(half, tie), function(z) length(unique(z)) > 1L, logical(1)))) {
+      return(NULL)
+    }
+  }
+  ds$.ebx. <- bd$x
+  # Each bar's own drawn width, so a crossbar can be given the width of the bar
+  # it belongs to instead of dodging itself to a different one.
+  ds$.ebw. <- as.numeric(bd$xmax) - as.numeric(bd$xmin)
+
+  # .get_geom_error_function() has no "crossbar" case and falls back to
+  # geom_errorbar, which would silently draw the wrong geom. It is shared with
+  # the stacked path, so resolve crossbar here rather than there and leave every
+  # other caller on exactly the function it resolves today.
+  is.crossbar <- identical(error.plot, "crossbar")
+  geom.error <- if (is.crossbar) ggplot2::geom_crossbar else
+    .get_geom_error_function(error.plot)
   color.is.var <- !is.null(color) && length(color) == 1 && color %in% colnames(ds)
   if (color.is.var) {
     mapping <- ggplot2::aes(
@@ -732,9 +843,20 @@ ggbarplot_core <- function(data, x, y,
   } else {
     mapping <- ggplot2::aes(x = .data$.ebx., ymin = .data$.ymin., ymax = .data$.ymax.)
   }
-  if (identical(geom.error, ggplot2::geom_pointrange)) mapping$y <- ggplot2::aes(y = .data$.yc.)$y
+  if (identical(geom.error, ggplot2::geom_pointrange) || is.crossbar) {
+    mapping$y <- ggplot2::aes(y = .data$.yc.)$y
+  }
+  if (is.crossbar) mapping$width <- ggplot2::aes(width = .data$.ebw.)$width
   opts <- list(data = ds, mapping = mapping, inherit.aes = FALSE, position = "identity")
   if (!color.is.var && !is.null(color) && length(color) == 1) opts$colour <- color
+  if (is.crossbar && !is.null(fill) && length(fill) == 1) {
+    if (fill %in% colnames(ds)) {
+      mapping$fill <- ggplot2::aes(fill = .data[[fill]])$fill
+      opts$mapping <- mapping
+    } else {
+      opts$fill <- fill
+    }
+  }
   if (identical(geom.error, ggplot2::geom_errorbar)) opts$width <- width
   do.call(geom.error, opts)
 }

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -423,6 +423,18 @@ ggbarplot_core <- function(data, x, y,
     if (inherits(position, "PositionDodge2") && draws.raw.layers) {
       has.alpha.group <- FALSE
     }
+    # And for an ASYMMETRIC summary. The re-centred layer is built from the
+    # summary's own half-width column, so median_q1q3 / median_hilow - which are
+    # quantile pairs, not centre +/- error - have no such column and the helper
+    # cannot place them. Their intervals are correct but unpaired, and with the
+    # subgroup carried "unpaired" means drawn inside another cell's bar.
+    if (inherits(position, "PositionDodge2") && any(.errorbar_functions() %in% add)) {
+      err.col <- .get_errorbar_error_func(.get_summary_func(add))
+      if (is.null(err.col) ||
+          !err.col %in% c("se", "sd", "ci", "range", "iqr", "mad")) {
+        has.alpha.group <- FALSE
+      }
+    }
   }
   # Include the alpha subgroup in the summary grouping. Otherwise the summarized
   # data drops the alpha column, which (a) makes geom_exec pass alpha as a static
@@ -568,15 +580,32 @@ ggbarplot_core <- function(data, x, y,
       group = add.params$group, facet.by = facet.by,
       func = .get_summary_func(add), error.plot = error.plot,
       width = cap.width, order.vars = alpha.order.vars,
-      facet.scales = .facet_scales_from_dots(list(...))
+      facet.scales = .facet_scales_from_dots(list(...)),
+      reverse = isTRUE(position$reverse), bar.fill = fill
     )
     if (!is.null(eb)) {
       p <- p + eb
-    } else {
-      # Could not match centres -> keep the standard (unaligned) error layer
+    } else if (is.null(alpha.order.vars)) {
+      # Could not match centres -> keep the standard (unaligned) error layer.
+      # Released behaviour, and safe here: without the alpha subgroup there are
+      # two elements per x and each interval still lands on its own bar.
       p <- add.params %>%
         .add_item(add = .get_summary_func(add), position = add.position) %>%
         do.call(ggadd, .)
+    } else {
+      # On the alpha path that same fallback is NOT safe. position_dodge2()
+      # packs by each element's own width, so the thin intervals collapse into a
+      # cluster at the tick centre: with the subgroup carried they land INSIDE
+      # neighbouring bars, and an interval drawn inside a bar is read as that
+      # bar's. Master refuses to draw these calls at all, so there is no working
+      # output to preserve - draw the bars without an error layer and say so,
+      # rather than publish a figure whose intervals belong to other bars.
+      warning(
+        "Could not align the error bars with the dodged bars, so they were not ",
+        "drawn. This combination of `alpha`, `position_dodge2()` and the ",
+        "requested summary is not supported; use `position_dodge()` instead.",
+        call. = FALSE
+      )
     }
   } else {
     p <- add.params %>%
@@ -748,7 +777,8 @@ ggbarplot_core <- function(data, x, y,
 .geom_dodge2_errorbar <- function(p, data_sum, x, y, color = NULL, fill = NULL,
                                   group = NULL, facet.by = NULL, func = "mean_se",
                                   error.plot = "errorbar", width = 0.1,
-                                  order.vars = NULL, facet.scales = "fixed") {
+                                  order.vars = NULL, facet.scales = "fixed",
+                                  reverse = FALSE, bar.fill = NULL) {
   legend.var <- intersect(unique(c(color, fill, group)), colnames(data_sum))
   # order.vars is the full set of discrete columns ggplot2 groups the bars by
   # (#404). It is supplied only when an `alpha` column has split the summary
@@ -819,8 +849,20 @@ ggbarplot_core <- function(data, x, y,
   }
   as.int <- function(v) if (is.factor(v)) as.integer(v) else as.integer(factor(v))
   ord.keys <- if (length(order.vars)) {
-    c(list(as.int(ds$PANEL), as.int(ds[[x]])),
-      lapply(order.vars, function(k) as.int(ds[[k]])))
+    # collide2() lays each x's elements out by ASCENDING group id - or by
+    # DESCENDING group id under position_dodge2(reverse = TRUE), which sorts on
+    # -group. Negating the key here follows it; ordering ascending against
+    # reversed bars matched every row to the mirror bar, so the centre check
+    # below refused and the caller drew an unpaired layer instead.
+    keys <- lapply(order.vars, function(k) {
+      v <- as.int(ds[[k]])
+      # interaction(addNA(...)) keeps NA as a real TRAILING level, and order()
+      # would put it last in either direction. Give it that trailing rank
+      # explicitly so it mirrors with everything else.
+      if (anyNA(v)) v[is.na(v)] <- if (all(is.na(v))) 1L else max(v, na.rm = TRUE) + 1L
+      if (isTRUE(reverse)) -v else v
+    })
+    c(list(as.int(ds$PANEL), as.int(ds[[x]])), keys)
   } else {
     list(as.int(ds$PANEL), as.int(ds[[x]]), as.int(ds[[legend.var]]))
   }
@@ -831,23 +873,21 @@ ggbarplot_core <- function(data, x, y,
   # draws each summary row's own centre, so the bar a row has been matched to
   # must carry that row's centre; if it does not, the two orders disagree and we
   # are one line away from drawing one cell's interval on another cell's bar.
-  # Bail out and let the caller keep the standard layer, which is unaligned but
-  # never mislabelled. Only the alpha path is checked - the released key is left
-  # byte-identical, including in the degenerate cases where it is imperfect.
-  if (length(order.vars)) {
-    if (!isTRUE(all.equal(as.numeric(bd$y), as.numeric(ds$.yc.),
-                          tolerance = 1e-9, check.attributes = FALSE))) {
-      return(NULL)
-    }
-    # Two cells sharing a centre within one (panel, x) satisfy that check even
-    # when swapped, and the swap would move a DIFFERENT half-width onto each of
-    # their bars - which a centre cannot reveal. Refuse that case as well.
-    tie <- paste(ds$PANEL, as.character(ds[[x]]),
-                 signif(as.numeric(ds$.yc.), 12), sep = "\r")
-    half <- signif(as.numeric(ds$.ymax. - ds$.ymin.), 12)
-    if (any(vapply(split(half, tie), function(z) length(unique(z)) > 1L, logical(1)))) {
-      return(NULL)
-    }
+  # Only the alpha path is checked - the released key is left byte-identical,
+  # including in the degenerate cases where it is imperfect.
+  #
+  # There is deliberately NO extra guard for two cells that share a centre within
+  # one (panel, x). An earlier revision refused those, reasoning that a swap
+  # between them would move a different half-width onto each bar and the centre
+  # could not reveal it. That was backwards: the order above is built from the
+  # same discrete key ggplot2 groups the bars by, so it is correct whether or not
+  # the centres happen to tie - a tie defeats the VERIFICATION, never the
+  # ordering. Refusing on it only sent ordinary rounded or count data down the
+  # unpaired path, which is the one outcome worth avoiding.
+  if (length(order.vars) &&
+      !isTRUE(all.equal(as.numeric(bd$y), as.numeric(ds$.yc.),
+                        tolerance = 1e-9, check.attributes = FALSE))) {
+    return(NULL)
   }
   ds$.ebx. <- bd$x
   # Each bar's own drawn width, so a crossbar can be given the width of the bar
@@ -876,12 +916,30 @@ ggbarplot_core <- function(data, x, y,
   if (is.crossbar) mapping$width <- ggplot2::aes(width = .data$.ebw.)$width
   opts <- list(data = ds, mapping = mapping, inherit.aes = FALSE, position = "identity")
   if (!color.is.var && !is.null(color) && length(color) == 1) opts$colour <- color
-  if (is.crossbar && !is.null(fill) && length(fill) == 1) {
-    if (fill %in% colnames(ds)) {
-      mapping$fill <- ggplot2::aes(fill = .data[[fill]])$fill
-      opts$mapping <- mapping
+  if (is.crossbar) {
+    # A crossbar is filled, and every other ggpubr crossbar takes its fill from
+    # the MAPPED fill aesthetic (ggadd() never forwards add.params$fill to
+    # add_summary(), so the mapping wins). ggbarplot_core() defaults
+    # add.params$fill to "white" before .check_add.params() can set it, so
+    # reading that here silently turned a released, working call's crossbars
+    # from the group colours to white - and a white cap truncates the coloured
+    # bar at centre - error, which reads as a lower bar. Follow the bar's own
+    # fill, and only fall back to add.params$fill when it is not a column.
+    crossbar.fill <- if (!is.null(bar.fill) && length(bar.fill) == 1 &&
+                         bar.fill %in% colnames(ds)) {
+      bar.fill
+    } else if (!is.null(fill) && length(fill) == 1) {
+      fill
     } else {
-      opts$fill <- fill
+      NULL
+    }
+    if (!is.null(crossbar.fill)) {
+      if (crossbar.fill %in% colnames(ds)) {
+        mapping$fill <- ggplot2::aes(fill = .data[[crossbar.fill]])$fill
+        opts$mapping <- mapping
+      } else {
+        opts$fill <- crossbar.fill
+      }
     }
   }
   if (identical(geom.error, ggplot2::geom_errorbar)) opts$width <- width

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -943,7 +943,23 @@ ggbarplot_core <- function(data, x, y,
     }
   }
   if (identical(geom.error, ggplot2::geom_errorbar)) opts$width <- width
-  do.call(geom.error, opts)
+  if (!is.crossbar) return(do.call(geom.error, opts))
+  # `width` is not in GeomCrossbar$aesthetics(), so layer() warns "Ignoring
+  # unknown aesthetics: width" - but GeomErrorbar$setup_data(), which
+  # GeomCrossbar delegates to, reads `data$width` before falling back to
+  # resolution(x) * 0.9, so the mapping IS honoured and the warning is simply
+  # wrong. It has to be a mapping rather than a parameter, because each crossbar
+  # takes the width of its own bar and those differ across x groups. Muffle that
+  # one message only - every other condition, including ggplot2's own advice
+  # about a discrete alpha, still reaches the user.
+  withCallingHandlers(
+    do.call(geom.error, opts),
+    warning = function(w) {
+      if (grepl("unknown aesthetics.*width", conditionMessage(w))) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
 }
 
 # remove "mean_se", "mean_sd", etc

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -918,7 +918,18 @@ ggbarplot_core <- function(data, x, y,
   }
   if (is.crossbar) mapping$width <- ggplot2::aes(width = .data$.ebw.)$width
   opts <- list(data = ds, mapping = mapping, inherit.aes = FALSE, position = "identity")
-  if (!color.is.var && !is.null(color) && length(color) == 1) opts$colour <- color
+  # color.is.var tests membership in the SUMMARY, so a real data column that is
+  # not one of the grouping variables falls through here and is handed to the
+  # geom as a literal colour ("Unknown colour name: z"). That is released
+  # behaviour for the thin error plots, which have always reached this helper,
+  # so it is left alone. The CROSSBAR had not: it dodged itself, and such a call
+  # drew (silently ignoring the argument). Routing it through here would have
+  # turned that into a crash, so on that path the static colour is set only when
+  # it really is one.
+  if (!color.is.var && !is.null(color) && length(color) == 1 &&
+      (!is.crossbar || .is_color(color))) {
+    opts$colour <- color
+  }
   if (is.crossbar) {
     # A crossbar is filled, and every other ggpubr crossbar takes its fill from
     # the MAPPED fill aesthetic (ggadd() never forwards add.params$fill to

--- a/R/ggbarplot.R
+++ b/R/ggbarplot.R
@@ -581,7 +581,10 @@ ggbarplot_core <- function(data, x, y,
       func = .get_summary_func(add), error.plot = error.plot,
       width = cap.width, order.vars = alpha.order.vars,
       facet.scales = .facet_scales_from_dots(list(...)),
-      reverse = isTRUE(position$reverse), bar.fill = fill
+      # ggplot2's collide2() branches on `if (reverse)`, which is TRUE for 1 or
+      # "TRUE" as well; isTRUE() alone would read those as FALSE and sort the
+      # summary against mirrored bars.
+      reverse = isTRUE(as.logical(position$reverse)[1]), bar.fill = fill
     )
     if (!is.null(eb)) {
       p <- p + eb

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -418,6 +418,47 @@ test_that("the re-centred crossbar does not emit a spurious aesthetics warning (
   expect_true(any(grepl("alpha for a discrete variable", seen)))
 })
 
+test_that("reverse is read the way collide2() reads it, not just isTRUE (#404)", {
+  # ggplot2 branches on `if (reverse)`, which is TRUE for 1 and "TRUE" as well.
+  # isTRUE() alone saw those as FALSE, so the summary was ordered ascending
+  # against bars laid out descending: the pairing check then refused and the
+  # error layer was dropped entirely. Only `reverse = TRUE` was covered before,
+  # so the coercion could have been reverted with the suite still green.
+  d <- .mk()
+  for (rv in list(TRUE, 1, "TRUE")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(reverse = rv)))
+    info <- paste("reverse =", format(rv))
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    # the error layer must still be there - dropping it is the failure mode
+    expect_equal(nrow(.layer(p, b, "GeomErrorbar")), 12L, info = info)
+    .expect_on_own_bar(p, d, info = info)
+  }
+})
+
+test_that("a re-centred crossbar tolerates add.params$color naming a column (#404)", {
+  # `color.is.var` tests membership in the SUMMARY, so a data column that is not
+  # a grouping variable falls through and would be passed to the geom as a
+  # literal colour ("Unknown colour name: z"). The released crossbar dodged
+  # itself and never reached that code, so such a call DREW, ignoring the
+  # argument; routing the crossbar through the re-centring turned it into a
+  # crash. It draws again.
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  tg$z <- rep(c("z1", "z2"), length.out = nrow(tg))
+  expect_no_error(suppressWarnings(ggplot2::ggplotGrob(
+    ggbarplot(tg, "dose", "len", fill = "supp", alpha = "supp", add = "mean_se",
+              position = position_dodge2(), error.plot = "crossbar",
+              add.params = list(color = "z"))
+  )))
+  # a real colour is still honoured
+  p <- suppressWarnings(ggbarplot(tg, "dose", "len", fill = "supp", alpha = "supp",
+    add = "mean_se", position = position_dodge2(), error.plot = "crossbar",
+    add.params = list(color = "red")))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_true(all(as.character(.layer(p, b, "GeomCrossbar")$colour) == "red"))
+})
+
 test_that("a key that cannot describe the bars keeps the released refusal (#404)", {
   # When a keyed column is not discrete, or is named after a desc_statby()
   # statistic, no ordering maps one error bar to one bar. Drawing anyway would

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -291,6 +291,30 @@ test_that("a key that cannot describe the bars keeps the released refusal (#404)
   expect_error(ggplot2::ggplotGrob(p2))
 })
 
+test_that("label = TRUE keeps the released behaviour rather than floating labels (#404)", {
+  # The value labels are drawn by their own layer, which dodges on the legend key
+  # alone. With the alpha subgroup carried they land BETWEEN the bars - measured
+  # 4 of 8 over the bar whose value they show. Aligning the error bars while half
+  # the numbers float would make the figure look trustworthy and read wrong, so a
+  # labelled call is left exactly as released (it does not draw) until the label
+  # layer is keyed too. Same reasoning the plain-dodge fix recorded for `label`.
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2(), label = TRUE))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  # the alpha column is NOT carried: one bar per (x, fill), as before
+  expect_equal(nrow(.layer(p, b, "GeomBar")), 6L)
+  expect_error(ggplot2::ggplotGrob(p))
+  # a character label vector is a label too, and is gated the same way
+  p2 <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2(),
+    label = as.character(seq_len(6))))
+  expect_equal(nrow(.layer(p2, suppressWarnings(ggplot2::ggplot_build(p2)), "GeomBar")), 6L)
+  # and label = FALSE is unaffected: the subgroup is carried and aligned
+  .expect_on_own_bar(suppressWarnings(ggbarplot(d, "g", "v", fill = "f",
+    alpha = "a", add = "mean_se", position = position_dodge2(), label = FALSE)), d)
+})
+
 test_that("no-regression: dodge2 WITHOUT alpha is untouched by the alpha path (#404)", {
   # Pinned absolute positions, not a sorted set: a permutation of the same values
   # would satisfy a set comparison. Values measured on the released path.

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -533,6 +533,55 @@ test_that("the key orders colour before fill, as ggplot2 lays the bars out (#404
   }
 })
 
+test_that("an NA key level keeps its trailing rank, in both directions (#404)", {
+  # interaction(addNA(...)) keeps NA as a real TRAILING level and ggplot2's
+  # id_var(drop = TRUE) sorts na.last, so the ordering gives NA that same
+  # trailing rank explicitly instead of letting order() place it. Removing that
+  # one line leaves the whole suite green while the pairing goes wrong - here
+  # the error layer is dropped entirely, and on other arrangements two
+  # intervals simply swap. Under `reverse` the rank has to mirror with
+  # everything else, which is why both directions are driven.
+  cells <- expand.grid(xg = c("X1", "X2"), fi = c("f1", "f2"),
+                       al = c("a1", NA), stringsAsFactors = FALSE)
+  cells$m <- seq(20, by = 10, length.out = nrow(cells))
+  cells$s <- seq(1, by = 1, length.out = nrow(cells))
+  d <- do.call(rbind, lapply(seq_len(nrow(cells)), function(i) {
+    data.frame(
+      xg = cells$xg[i], fi = cells$fi[i], al = cells$al[i],
+      v = c(cells$m[i] - cells$s[i], cells$m[i], cells$m[i] + cells$s[i]),
+      stringsAsFactors = FALSE
+    )
+  }))
+  k <- interaction(
+    addNA(factor(d$xg), ifany = TRUE), addNA(factor(d$fi), ifany = TRUE),
+    addNA(factor(d$al), ifany = TRUE), drop = TRUE
+  )
+  ref <- do.call(rbind, lapply(split(d$v, k), function(z) {
+    data.frame(m = mean(z), s = stats::sd(z))
+  }))
+
+  for (rv in c(FALSE, TRUE)) {
+    p <- suppressWarnings(ggbarplot(d, "xg", "v", fill = "fi", alpha = "al",
+      add = "mean_sd", position = position_dodge2(reverse = rv)))
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    bd <- .layer(p, b, "GeomBar")
+    ed <- .layer(p, b, "GeomErrorbar")
+    info <- paste("reverse =", rv)
+    # the layer must exist at all - dropping it is one of the failure modes
+    expect_false(is.null(ed), info = info)
+    expect_equal(nrow(ed), nrow(bd), info = info)
+    for (i in seq_len(nrow(ed))) {
+      j <- which(as.numeric(ed$x[i]) >= as.numeric(bd$xmin) - 1e-9 &
+                   as.numeric(ed$x[i]) <= as.numeric(bd$xmax) + 1e-9)
+      expect_equal(length(j), 1L, info = info)
+      q <- which(abs(ref$m - as.numeric(bd$y[j])) < 1e-9)
+      expect_equal(length(q), 1L, info = info)
+      expect_equal(ed$ymin[i], ref$m[q] - ref$s[q], tolerance = 1e-9, info = info)
+      expect_equal(ed$ymax[i], ref$m[q] + ref$s[q], tolerance = 1e-9, info = info)
+    }
+  }
+})
+
 test_that("a key that cannot describe the bars keeps the released refusal (#404)", {
   # When a keyed column is not discrete, or is named after a desc_statby()
   # statistic, no ordering maps one error bar to one bar. Drawing anyway would

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -315,6 +315,26 @@ test_that("label = TRUE keeps the released behaviour rather than floating labels
     alpha = "a", add = "mean_se", position = position_dodge2(), label = FALSE)), d)
 })
 
+test_that("a raw-data layer keeps the released behaviour rather than stray points (#404)", {
+  # jitter/point/dotplot/boxplot/violin draw the OBSERVATIONS, placed by ggadd()
+  # under the same position - and position_dodge2() packs by each element's own
+  # width, which a point does not have. They already sit off their own bar with
+  # no alpha at all (8 of 12, pre-existing and unchanged); splitting the bars
+  # finer takes it to 12 of 24, half the observations over a bar they are not
+  # from. So this combination is left exactly as released.
+  d <- .mk()
+  for (extra in c("jitter", "point", "dotplot", "boxplot", "violin")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = c("mean_se", extra), position = position_dodge2()))
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    # the alpha column is NOT carried: one bar per (x, fill)
+    expect_equal(nrow(.layer(p, b, "GeomBar")), 6L, info = extra)
+  }
+  # the summary alone is unaffected, with or without an explicit "none"
+  .expect_on_own_bar(suppressWarnings(ggbarplot(d, "g", "v", fill = "f",
+    alpha = "a", add = "mean_se", position = position_dodge2())), d)
+})
+
 test_that("no-regression: dodge2 WITHOUT alpha is untouched by the alpha path (#404)", {
   # Pinned absolute positions, not a sorted set: a permutation of the same values
   # would satisfy a set comparison. Values measured on the released path.

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -273,6 +273,111 @@ test_that("no-regression: a faceted dodge2 WITHOUT alpha keeps its released layo
   }
 })
 
+test_that("dodge2(reverse = TRUE) pairs each interval with its own bar (#404)", {
+  # collide2() sorts each x by -group when reverse = TRUE, so ordering the
+  # summary ascending matched every row to the MIRROR bar. The centre check
+  # caught it and refused, and the caller then drew an unpaired layer - four
+  # intervals clustered at the tick centre, two bars carrying two each and two
+  # none. The sort follows `reverse` now, so it aligns instead of bailing.
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2(reverse = TRUE)))
+  .expect_on_own_bar(p, d)
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_equal(as.numeric(.layer(p, b, "GeomErrorbar")$x),
+               as.numeric(.layer(p, b, "GeomBar")$x), tolerance = 1e-9)
+})
+
+test_that("cells that share a mean still pair with their own bar (#404)", {
+  # An earlier revision refused a centre tied within one (panel, x), reasoning
+  # that a swap could move a different half-width onto each bar. That was
+  # backwards - the order comes from the discrete key ggplot2 groups the bars
+  # by, so it is right whether or not the centres tie; refusing only sent
+  # ordinary rounded/count data down the unpaired path. Two cells here share a
+  # mean of 10 while their standard errors differ.
+  d <- data.frame(
+    g = rep(c("A", "B"), each = 12),
+    f = rep(rep(c("f1", "f2"), each = 6), 2),
+    a = rep(rep(c("a1", "a2"), each = 3), 4),
+    v = c(9, 10, 11,  38, 40, 42,  19, 20, 21,  58, 60, 62,
+          29, 30, 31, 68, 70, 72,  49, 50, 51,  88, 90, 92),
+    stringsAsFactors = FALSE
+  )
+  d$v[d$g == "A" & d$f == "f1" & d$a == "a2"] <- c(5, 10, 15)
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2()))
+  pr <- .pairing(p)
+  expect_false(any(is.na(pr$bar)))
+  expect_equal(sort(pr$bar), seq_len(pr$n.bars))
+  ref <- merge(
+    stats::aggregate(v ~ g + f + a, d, mean),
+    stats::aggregate(v ~ g + f + a, d, function(z) stats::sd(z) / sqrt(length(z))),
+    by = c("g", "f", "a")
+  )
+  names(ref)[4:5] <- c("mean", "se")
+  for (i in seq_along(pr$bar)) {
+    cell <- ref[abs(ref$mean - pr$bar.y[i]) < 1e-9, , drop = FALSE]
+    # both tied cells are acceptable only if the half-width also matches
+    expect_true(any(abs(pr$ymin[i] - (cell$mean - cell$se)) < 1e-9 &
+                      abs(pr$ymax[i] - (cell$mean + cell$se)) < 1e-9))
+  }
+})
+
+test_that("an asymmetric summary keeps the released refusal under dodge2 (#404)", {
+  # median_q1q3 / median_hilow are quantile PAIRS, not centre +/- error, so the
+  # summary has no half-width column and the re-centring helper cannot place
+  # them. Their intervals are correct but unpaired, and with the subgroup
+  # carried "unpaired" means drawn inside another cell's bar - 4 of 8 measured.
+  d <- .mk()
+  for (f in c("median_q1q3", "median_hilow")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = f, position = position_dodge2()))
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    expect_equal(nrow(.layer(p, b, "GeomBar")), 6L, info = f)
+    expect_error(ggplot2::ggplotGrob(p), info = f)
+  }
+  # a symmetric one on the same data is unaffected: it draws, and every interval
+  # is its own cell's median +/- IQR (the ggpubr convention is the FULL IQR on
+  # each side, not Q1-Q3), checked against base R
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "median_iqr", position = position_dodge2()))
+  pr <- .pairing(p)
+  expect_false(any(is.na(pr$bar)))
+  expect_equal(sort(pr$bar), seq_len(pr$n.bars))
+  ref <- merge(
+    stats::aggregate(v ~ g + f + a, d, stats::median),
+    stats::aggregate(v ~ g + f + a, d, stats::IQR),
+    by = c("g", "f", "a")
+  )
+  names(ref)[4:5] <- c("mid", "iqr")
+  for (i in seq_along(pr$bar)) {
+    cell <- ref[abs(ref$mid - pr$bar.y[i]) < 1e-9, , drop = FALSE]
+    expect_equal(nrow(cell), 1L)
+    expect_equal(pr$ymin[i], cell$mid - cell$iqr, tolerance = 1e-9)
+    expect_equal(pr$ymax[i], cell$mid + cell$iqr, tolerance = 1e-9)
+  }
+})
+
+test_that("a re-centred crossbar keeps the mapped fill, not add.params$fill (#404)", {
+  # Every other ggpubr crossbar takes its fill from the mapped fill aesthetic.
+  # ggbarplot_core() defaults add.params$fill to "white" before
+  # .check_add.params() can set it, so reading that turned a released, working
+  # call's crossbars from the group colours to white - and a white cap truncates
+  # the coloured bar at centre - error, so the bar reads lower than it is.
+  tg <- ToothGrowth
+  tg$dose <- factor(tg$dose)
+  p <- suppressWarnings(ggbarplot(tg, "dose", "len", fill = "supp", alpha = "supp",
+    add = "mean_se", position = position_dodge2(), error.plot = "crossbar"))
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bd <- .layer(p, b, "GeomBar"); ed <- .layer(p, b, "GeomCrossbar")
+  expect_equal(sort(unique(as.character(ed$fill))), sort(unique(as.character(bd$fill))))
+  expect_false(any(as.character(ed$fill) == "white"))
+  # and it is centred on its bar, at the bar's width
+  expect_equal(as.numeric(ed$x), as.numeric(bd$x), tolerance = 1e-9)
+  expect_equal(as.numeric(ed$xmax - ed$xmin), as.numeric(bd$xmax - bd$xmin),
+               tolerance = 1e-9)
+})
+
 test_that("a key that cannot describe the bars keeps the released refusal (#404)", {
   # When a keyed column is not discrete, or is named after a desc_statby()
   # statistic, no ordering maps one error bar to one bar. Drawing anyway would

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -309,17 +309,36 @@ test_that("cells that share a mean still pair with their own bar (#404)", {
   pr <- .pairing(p)
   expect_false(any(is.na(pr$bar)))
   expect_equal(sort(pr$bar), seq_len(pr$n.bars))
+
   ref <- merge(
     stats::aggregate(v ~ g + f + a, d, mean),
     stats::aggregate(v ~ g + f + a, d, function(z) stats::sd(z) / sqrt(length(z))),
     by = c("g", "f", "a")
   )
   names(ref)[4:5] <- c("mean", "se")
+
+  # Identify each bar by the aesthetics IT was drawn with, decoded through
+  # ggplot2's own scales - NOT by its height. Looking the cell up by height
+  # returns BOTH tied cells, and accepting either makes the assertion pass just
+  # as happily when the two tied intervals are swapped, which is the one failure
+  # this test exists to catch.
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bd <- .layer(p, b, "GeomBar")
+  f.lv <- levels(factor(d$f)); a.lv <- levels(factor(d$a))
+  f.map <- stats::setNames(b$plot$scales$get_scales("fill")$map(f.lv), f.lv)
+  a.map <- stats::setNames(b$plot$scales$get_scales("alpha")$map(a.lv), a.lv)
+  x.lab <- as.character(b$layout$panel_params[[1]]$x$get_labels())
+
   for (i in seq_along(pr$bar)) {
-    cell <- ref[abs(ref$mean - pr$bar.y[i]) < 1e-9, , drop = FALSE]
-    # both tied cells are acceptable only if the half-width also matches
-    expect_true(any(abs(pr$ymin[i] - (cell$mean - cell$se)) < 1e-9 &
-                      abs(pr$ymax[i] - (cell$mean + cell$se)) < 1e-9))
+    j <- pr$bar[i]
+    cell.g <- x.lab[round(as.numeric(bd$x[j]))]
+    cell.f <- names(f.map)[match(as.character(bd$fill[j]), as.character(f.map))]
+    cell.a <- names(a.map)[which.min(abs(a.map - as.numeric(bd$alpha[j])))]
+    expect_false(is.na(cell.g) || is.na(cell.f) || length(cell.a) != 1L)
+    cell <- ref[ref$g == cell.g & ref$f == cell.f & ref$a == cell.a, , drop = FALSE]
+    expect_equal(nrow(cell), 1L)
+    expect_equal(pr$ymin[i], cell$mean - cell$se, tolerance = 1e-9)
+    expect_equal(pr$ymax[i], cell$mean + cell$se, tolerance = 1e-9)
   }
 })
 

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -1,0 +1,308 @@
+context("test-ggbarplot-alpha-dodge2")
+
+# #404 under position_dodge2(). Mapping `alpha` to a discrete column used to fail
+# at draw with "alpha * 255": the summary dropped the column, so its NAME reached
+# grid as a static opacity. Carrying the column splits the summary into one row
+# per (x, legend, alpha) cell, which dodge2's re-centring (#363) could not place,
+# because it matched summary rows to bars by SORT POSITION and the released key
+# (PANEL, x, legend) is not total once the alpha subgroup exists. It is now given
+# the full discrete key and CHECKS the pairing it produced against the bars.
+#
+# The fixture makes every cell mean AND every cell standard error distinct, so an
+# error bar drawn on a neighbouring bar cannot pass by carrying a value that
+# happens to match: both endpoints move. Each cell is c(m - s, m, m + s), whose
+# mean is exactly m and whose se is exactly s/sqrt(3).
+
+.mk <- function() {
+  cells <- expand.grid(
+    g = c("x1", "x2", "x3"), f = c("f1", "f2"), a = c("a1", "a2"),
+    stringsAsFactors = FALSE
+  )
+  cells$m <- seq(10, by = 9, length.out = nrow(cells))   # 12 distinct means
+  cells$s <- seq(1.5, by = 0.7, length.out = nrow(cells)) # 12 distinct spreads
+  do.call(rbind, lapply(seq_len(nrow(cells)), function(i) {
+    data.frame(
+      g = cells$g[i], f = cells$f[i], a = cells$a[i],
+      v = c(cells$m[i] - cells$s[i], cells$m[i], cells$m[i] + cells$s[i]),
+      stringsAsFactors = FALSE
+    )
+  }))
+}
+
+# Independent reference: mean and se per cell from base R, never desc_statby().
+.ref <- function(d) {
+  m <- stats::aggregate(v ~ g + f + a, d, mean)
+  s <- stats::aggregate(v ~ g + f + a, d, function(z) stats::sd(z) / sqrt(length(z)))
+  names(m)[4] <- "mean"; names(s)[4] <- "se"
+  merge(m, s, by = c("g", "f", "a"))
+}
+
+.layer <- function(p, b, classes) {
+  i <- which(vapply(p$layers, function(l) class(l$geom)[1] %in% classes, logical(1)))
+  b$data[[i[1]]]
+}
+
+# For every error bar: the single bar whose rect contains it, that bar's drawn
+# value, and the interval the error bar draws. Returns NA for a bar index when
+# the error bar sits between bars, so "off its bar" cannot silently pass.
+.pairing <- function(p) {
+  # ggplot2 warns "Using alpha for a discrete variable is not advised" on every
+  # build here. These assertions are about geometry, never about that condition,
+  # so silencing it does not weaken them.
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bd <- .layer(p, b, "GeomBar")
+  ed <- .layer(p, b, c("GeomErrorbar", "GeomPointrange", "GeomLinerange", "GeomCrossbar"))
+  idx <- vapply(seq_len(nrow(ed)), function(i) {
+    hit <- which(as.character(bd$PANEL) == as.character(ed$PANEL[i]) &
+                   as.numeric(ed$x[i]) >= as.numeric(bd$xmin) - 1e-9 &
+                   as.numeric(ed$x[i]) <= as.numeric(bd$xmax) + 1e-9)
+    if (length(hit) == 1L) hit else NA_integer_
+  }, integer(1))
+  list(
+    n.bars = nrow(bd), bar = idx, bar.y = as.numeric(bd$y)[idx],
+    ymin = as.numeric(ed$ymin), ymax = as.numeric(ed$ymax)
+  )
+}
+
+# Assert each error bar sits on its own bar and carries THAT bar's own mean+se.
+.expect_on_own_bar <- function(p, d, info = NULL) {
+  pr <- .pairing(p)
+  ref <- .ref(d)
+  expect_false(any(is.na(pr$bar)), info = info)          # none between bars
+  expect_equal(sort(pr$bar), seq_len(pr$n.bars), info = info)  # a bijection
+  for (i in seq_along(pr$bar)) {
+    cell <- ref[abs(ref$mean - pr$bar.y[i]) < 1e-9, , drop = FALSE]
+    expect_equal(nrow(cell), 1L, info = info)
+    expect_equal(pr$ymin[i], cell$mean - cell$se, tolerance = 1e-9, info = info)
+    expect_equal(pr$ymax[i], cell$mean + cell$se, tolerance = 1e-9, info = info)
+  }
+}
+
+test_that("alpha + position_dodge2() renders instead of failing on alpha * 255 (#404)", {
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2()))
+  # The claim is that it no longer ERRORS at draw. ggplot2 separately warns that
+  # a discrete alpha is not advised - that warning is released behaviour and is
+  # not what is under test, so asserting silence would pin the wrong condition.
+  expect_no_error(suppressWarnings(ggplot2::ggplotGrob(p)))
+})
+
+test_that("every dodge2 error bar sits on its own bar carrying its own mean and se (#404)", {
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2()))
+  .expect_on_own_bar(p, d)
+})
+
+test_that("the dodge2 pairing survives every reordering of the summary (#404)", {
+  d <- .mk()
+  calls <- list(
+    `sort.val=desc` = function() ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), sort.val = "desc"),
+    `sort.by.groups=FALSE` = function() ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), sort.val = "desc",
+      sort.by.groups = FALSE),
+    `shuffled rows` = function() ggbarplot(d[sample.int(nrow(d)), ], "g", "v",
+      fill = "f", alpha = "a", add = "mean_se", position = position_dodge2()),
+    # add.params$color naming the alpha column re-resolves the legend variable,
+    # which used to decide the sort key on its own
+    `add.params$color` = function() ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), add.params = list(color = "a"))
+  )
+  set.seed(1)
+  for (nm in names(calls)) {
+    .expect_on_own_bar(suppressWarnings(calls[[nm]]()), d, info = nm)
+  }
+})
+
+test_that("top = truncates bars and error bars together under dodge2 (#404)", {
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2(), top = 8))
+  pr <- .pairing(p)
+  expect_equal(pr$n.bars, 8L)
+  expect_equal(length(pr$ymin), 8L)
+  .expect_on_own_bar(p, d)
+})
+
+test_that("error.plot = 'crossbar' draws a crossbar, not an errorbar, and aligns (#404)", {
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge2(), error.plot = "crossbar"))
+  geoms <- vapply(p$layers, function(l) class(l$geom)[1], character(1))
+  # .get_geom_error_function() has no "crossbar" case and would fall back to
+  # geom_errorbar; the wrong geom must not be what gets drawn.
+  expect_true("GeomCrossbar" %in% geoms)
+  expect_false("GeomErrorbar" %in% geoms)
+  .expect_on_own_bar(p, d)
+})
+
+test_that("one-sided and point/line error plots also align under dodge2 with alpha (#404)", {
+  d <- .mk()
+  ref <- .ref(d)
+  for (ep in c("pointrange", "linerange", "upper_errorbar", "lower_errorbar")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), error.plot = ep))
+    pr <- .pairing(p)
+    expect_false(any(is.na(pr$bar)), info = ep)
+    expect_equal(sort(pr$bar), seq_len(pr$n.bars), info = ep)
+    for (i in seq_along(pr$bar)) {
+      cell <- ref[abs(ref$mean - pr$bar.y[i]) < 1e-9, , drop = FALSE]
+      lo <- if (ep == "upper_errorbar") cell$mean else cell$mean - cell$se
+      hi <- if (ep == "lower_errorbar") cell$mean else cell$mean + cell$se
+      expect_equal(pr$ymin[i], lo, tolerance = 1e-9, info = ep)
+      expect_equal(pr$ymax[i], hi, tolerance = 1e-9, info = ep)
+    }
+  }
+})
+
+.mk_facet <- function() {
+  # x1 is ABSENT from panel q, so with a free x scale panel q renumbers its
+  # remaining levels and a fixed-scale probe would read centres the drawn panel
+  # never uses. With the last level missing instead, the two coincide and the
+  # bug hides - the dropped level has to be the first one.
+  cells <- expand.grid(
+    g = c("x1", "x2", "x3"), f = c("f1", "f2"), a = c("a1", "a2"),
+    blk = c("p", "q"), stringsAsFactors = FALSE
+  )
+  cells <- cells[!(cells$blk == "q" & cells$g == "x1"), ]
+  cells$m <- seq(10, by = 7, length.out = nrow(cells))
+  cells$s <- seq(1.5, by = 0.4, length.out = nrow(cells))
+  do.call(rbind, lapply(seq_len(nrow(cells)), function(i) {
+    data.frame(
+      g = cells$g[i], f = cells$f[i], a = cells$a[i], blk = cells$blk[i],
+      v = c(cells$m[i] - cells$s[i], cells$m[i], cells$m[i] + cells$s[i]),
+      stringsAsFactors = FALSE
+    )
+  }))
+}
+
+.expect_faceted_on_own_bar <- function(p, d, info = NULL) {
+  pr <- .pairing(p)
+  m <- stats::aggregate(v ~ g + f + a + blk, d, mean)
+  s <- stats::aggregate(v ~ g + f + a + blk, d, function(z) stats::sd(z) / sqrt(length(z)))
+  names(m)[5] <- "mean"; names(s)[5] <- "se"
+  ref <- merge(m, s, by = c("g", "f", "a", "blk"))
+  expect_false(any(is.na(pr$bar)), info = info)
+  expect_equal(sort(pr$bar), seq_len(pr$n.bars), info = info)
+  for (i in seq_along(pr$bar)) {
+    cell <- ref[abs(ref$mean - pr$bar.y[i]) < 1e-9, , drop = FALSE]
+    expect_equal(nrow(cell), 1L, info = info)
+    expect_equal(pr$ymin[i], cell$mean - cell$se, tolerance = 1e-9, info = info)
+    expect_equal(pr$ymax[i], cell$mean + cell$se, tolerance = 1e-9, info = info)
+  }
+}
+
+test_that("dodge2 with alpha aligns under a FREE x scale, where a panel renumbers (#404)", {
+  d <- .mk_facet()
+  for (sc in c("fixed", "free_x", "free")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), facet.by = "blk", scales = sc))
+    .expect_faceted_on_own_bar(p, d, info = sc)
+  }
+})
+
+test_that("`scales` is read through partial matching, as facet() receives it (#404)", {
+  # scales reaches facet() through `...`, so `scale =` and `scal =` arrive as
+  # `scales`. An exact-name lookup would silently probe fixed scales and put the
+  # error bars on the wrong bars in exactly the free-scale case above.
+  d <- .mk_facet()
+  for (nm in c("scales", "scale", "scal")) {
+    args <- list(d, "g", "v", fill = "f", alpha = "a", add = "mean_se",
+                 position = position_dodge2(), facet.by = "blk")
+    args[[nm]] <- "free_x"
+    .expect_faceted_on_own_bar(suppressWarnings(do.call(ggbarplot, args)), d, info = nm)
+  }
+  # `s =` is ambiguous with short.panel.labs/strip.position, so it reaches
+  # facet() no better than it reaches us: the default stands.
+  expect_equal(ggpubr:::.facet_scales_from_dots(list(s = "free_x")), "fixed")
+  expect_equal(ggpubr:::.facet_scales_from_dots(list(scal = "free_x")), "free_x")
+  expect_equal(ggpubr:::.facet_scales_from_dots(list()), "fixed")
+})
+
+test_that("dodge2 with alpha aligns with two facet variables, which use facet_grid (#404)", {
+  d <- .mk_facet()
+  d$blk2 <- rep(c("u", "w"), length.out = nrow(d))
+  pr <- NULL
+  for (sc in c("fixed", "free_x")) {
+    p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+      add = "mean_se", position = position_dodge2(), facet.by = c("blk", "blk2"),
+      scales = sc))
+    pr <- .pairing(p)
+    expect_false(any(is.na(pr$bar)), info = sc)
+    expect_equal(sort(pr$bar), seq_len(pr$n.bars), info = sc)
+  }
+})
+
+test_that("no-regression: a faceted dodge2 WITHOUT alpha keeps its released layout (#404)", {
+  # The probe is only made facet-accurate on the alpha path. Without alpha this
+  # call keeps exactly the positions it has always had, including under a free
+  # x scale where the released probe is known to be imperfect - changing that is
+  # a separate, pre-existing issue and not this fix's to make.
+  d <- .mk_facet()
+  # Measured on master (857f0b0) and pinned, so a future change is noticed.
+  # Under a free x scale panel q renumbers its bars to 0.825..2.175 while the
+  # released probe still reads the fixed-scale centres 1.825..3.175 - all four
+  # of that panel's error bars are off their bars. That is a PRE-EXISTING defect
+  # of the no-alpha path, unchanged here and deliberately left for its own fix.
+  expected <- list(
+    fixed = list(
+      bar = c(0.825, 1.175, 1.825, 2.175, 2.825, 3.175, 1.825, 2.175, 2.825, 3.175),
+      err = c(0.825, 1.175, 1.825, 2.175, 2.825, 3.175, 1.825, 2.175, 2.825, 3.175)
+    ),
+    free_x = list(
+      bar = c(0.825, 1.175, 1.825, 2.175, 2.825, 3.175, 0.825, 1.175, 1.825, 2.175),
+      err = c(0.825, 1.175, 1.825, 2.175, 2.825, 3.175, 1.825, 2.175, 2.825, 3.175)
+    )
+  )
+  for (sc in names(expected)) {
+    p <- ggbarplot(d, "g", "v", fill = "f", add = "mean_se",
+                   position = position_dodge2(), facet.by = "blk", scales = sc)
+    b <- suppressWarnings(ggplot2::ggplot_build(p))
+    bd <- .layer(p, b, "GeomBar"); ed <- .layer(p, b, "GeomErrorbar")
+    expect_equal(round(as.numeric(bd$x), 4), expected[[sc]]$bar, info = sc)
+    expect_equal(round(as.numeric(ed$x), 4), expected[[sc]]$err, info = sc)
+  }
+})
+
+test_that("a key that cannot describe the bars keeps the released refusal (#404)", {
+  # When a keyed column is not discrete, or is named after a desc_statby()
+  # statistic, no ordering maps one error bar to one bar. Drawing anyway would
+  # put an interval beside a bar it was not computed from, so these keep the
+  # released behaviour of not drawing at all. Text is not pinned - it comes from
+  # ggplot2 and is translated.
+  d <- .mk()
+  dnum <- d; dnum$fnum <- as.numeric(factor(dnum$f))
+  p1 <- suppressWarnings(ggbarplot(dnum, "g", "v", fill = "fnum", alpha = "a",
+    add = "mean_se", position = position_dodge2()))
+  expect_error(ggplot2::ggplotGrob(p1))
+
+  dnum2 <- d; dnum2$anum <- as.integer(factor(dnum2$a))
+  p2 <- suppressWarnings(ggbarplot(dnum2, "g", "v", fill = "f", alpha = "anum",
+    add = "mean_se", position = position_dodge2()))
+  expect_error(ggplot2::ggplotGrob(p2))
+})
+
+test_that("no-regression: dodge2 WITHOUT alpha is untouched by the alpha path (#404)", {
+  # Pinned absolute positions, not a sorted set: a permutation of the same values
+  # would satisfy a set comparison. Values measured on the released path.
+  d <- .mk()
+  p <- ggbarplot(d, "g", "v", fill = "f", add = "mean_se",
+                 position = position_dodge2())
+  b <- ggplot2::ggplot_build(p)
+  bd <- .layer(p, b, "GeomBar")
+  ed <- .layer(p, b, "GeomErrorbar")
+  expect_equal(as.numeric(ed$x), as.numeric(bd$x), tolerance = 1e-9)
+  expect_equal(round(as.numeric(bd$x), 4),
+               c(0.8250, 1.1750, 1.8250, 2.1750, 2.8250, 3.1750))
+  # and the summary is NOT split by anything else
+  expect_equal(nrow(bd), 6L)
+})
+
+test_that("no-regression: plain position_dodge() with alpha keeps its own key (#404)", {
+  d <- .mk()
+  p <- suppressWarnings(ggbarplot(d, "g", "v", fill = "f", alpha = "a",
+    add = "mean_se", position = position_dodge(0.9)))
+  .expect_on_own_bar(p, d)
+})

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -52,6 +52,9 @@ context("test-ggbarplot-alpha-dodge2")
   b <- suppressWarnings(ggplot2::ggplot_build(p))
   bd <- .layer(p, b, "GeomBar")
   ed <- .layer(p, b, c("GeomErrorbar", "GeomPointrange", "GeomLinerange", "GeomCrossbar"))
+  # A broken pairing makes the caller drop the error layer entirely. Say so,
+  # instead of crashing in seq_len(nrow(NULL)) and reporting an unrelated error.
+  if (is.null(ed) || !nrow(ed)) stop("no error layer was drawn")
   idx <- vapply(seq_len(nrow(ed)), function(i) {
     hit <- which(as.character(bd$PANEL) == as.character(ed$PANEL[i]) &
                    as.numeric(ed$x[i]) >= as.numeric(bd$xmin) - 1e-9 &
@@ -226,6 +229,17 @@ test_that("`scales` is read through partial matching, as facet() receives it (#4
   expect_equal(ggpubr:::.facet_scales_from_dots(list(s = "free_x")), "fixed")
   expect_equal(ggpubr:::.facet_scales_from_dots(list(scal = "free_x")), "free_x")
   expect_equal(ggpubr:::.facet_scales_from_dots(list()), "fixed")
+  # An EXACT name wins, and an abbreviation of an already-matched formal is left
+  # over for `...` and ignored - so facet() here uses "free_x". Reading the last
+  # partial hit instead gave "fixed" and probed a layout the plot never draws.
+  expect_equal(
+    ggpubr:::.facet_scales_from_dots(list(scales = "free_x", scale = "fixed")),
+    "free_x"
+  )
+  expect_equal(
+    ggpubr:::.facet_scales_from_dots(list(scale = "fixed", scales = "free_x")),
+    "free_x"
+  )
 })
 
 test_that("dodge2 with alpha aligns with two facet variables, which use facet_grid (#404)", {
@@ -457,6 +471,66 @@ test_that("a re-centred crossbar tolerates add.params$color naming a column (#40
     add.params = list(color = "red")))
   b <- suppressWarnings(ggplot2::ggplot_build(p))
   expect_true(all(as.character(.layer(p, b, "GeomCrossbar")$colour) == "red"))
+})
+
+test_that("the key orders colour before fill, as ggplot2 lays the bars out (#404)", {
+  # ggplot2's add_group() ids the bars over the layer's discrete columns in the
+  # order they appear in the layer data - `colour` before `fill`. Keying on the
+  # other order transposes the pairing as soon as `color` and `fill` name
+  # DIFFERENT columns, which is the failure mode released ggpubr got right. No
+  # other test in this file sets colour and fill to different columns alongside
+  # alpha, so transposing the key left the whole suite green.
+  #
+  # Tied cell means make it bite hardest: the centre self-check cannot see a
+  # swap between them, so only a correct key order gets the half-widths right.
+  cells <- expand.grid(
+    g = c("A", "B"), cc = c("c1", "c2"), f = c("f1", "f2"), a = c("a1", "a2"),
+    stringsAsFactors = FALSE
+  )
+  cells$mid <- 50                                  # every cell shares a mean
+  cells$s <- seq(1, by = 1.5, length.out = nrow(cells))  # every spread differs
+  d <- do.call(rbind, lapply(seq_len(nrow(cells)), function(i) {
+    data.frame(
+      g = cells$g[i], cc = cells$cc[i], f = cells$f[i], a = cells$a[i],
+      v = c(cells$mid[i] - cells$s[i], cells$mid[i], cells$mid[i] + cells$s[i]),
+      stringsAsFactors = FALSE
+    )
+  }))
+  p <- suppressWarnings(ggbarplot(d, "g", "v", color = "cc", fill = "f",
+    alpha = "a", add = "mean_se", position = position_dodge2()))
+  pr <- .pairing(p)
+  expect_false(any(is.na(pr$bar)))
+  expect_equal(sort(pr$bar), seq_len(pr$n.bars))
+
+  ref <- merge(
+    stats::aggregate(v ~ g + cc + f + a, d, mean),
+    stats::aggregate(v ~ g + cc + f + a, d, function(z) stats::sd(z) / sqrt(length(z))),
+    by = c("g", "cc", "f", "a")
+  )
+  names(ref)[5:6] <- c("mean", "se")
+
+  # decode each bar from ITS OWN aesthetics, through ggplot2's scales
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bd <- .layer(p, b, "GeomBar")
+  lv <- function(v) levels(factor(d[[v]]))
+  c.map <- stats::setNames(b$plot$scales$get_scales("colour")$map(lv("cc")), lv("cc"))
+  f.map <- stats::setNames(b$plot$scales$get_scales("fill")$map(lv("f")), lv("f"))
+  a.map <- stats::setNames(b$plot$scales$get_scales("alpha")$map(lv("a")), lv("a"))
+  x.lab <- as.character(b$layout$panel_params[[1]]$x$get_labels())
+
+  for (i in seq_along(pr$bar)) {
+    j <- pr$bar[i]
+    cell <- ref[
+      ref$g == x.lab[round(as.numeric(bd$x[j]))] &
+        ref$cc == names(c.map)[match(as.character(bd$colour[j]), as.character(c.map))] &
+        ref$f == names(f.map)[match(as.character(bd$fill[j]), as.character(f.map))] &
+        ref$a == names(a.map)[which.min(abs(a.map - as.numeric(bd$alpha[j])))], ,
+      drop = FALSE
+    ]
+    expect_equal(nrow(cell), 1L)
+    expect_equal(pr$ymin[i], cell$mean - cell$se, tolerance = 1e-9)
+    expect_equal(pr$ymax[i], cell$mean + cell$se, tolerance = 1e-9)
+  }
 })
 
 test_that("a key that cannot describe the bars keeps the released refusal (#404)", {

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -378,6 +378,27 @@ test_that("a re-centred crossbar keeps the mapped fill, not add.params$fill (#40
                tolerance = 1e-9)
 })
 
+test_that("the re-centred crossbar does not emit a spurious aesthetics warning (#404)", {
+  # `width` is not in GeomCrossbar$aesthetics(), so layer() warns "Ignoring
+  # unknown aesthetics: width" - but GeomErrorbar$setup_data(), which
+  # GeomCrossbar delegates to, reads data$width first, so the mapping IS
+  # honoured and the warning is wrong. Master never emitted it.
+  d <- .mk()
+  seen <- character(0)
+  withCallingHandlers(
+    invisible(ggbarplot(d, "g", "v", fill = "f", alpha = "a", add = "mean_se",
+      position = position_dodge2(), error.plot = "crossbar")),
+    warning = function(w) {
+      seen <<- c(seen, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_false(any(grepl("unknown aesthetics", seen)))
+  # ...and warnings are NOT blanket-suppressed: ggplot2's own advice about a
+  # discrete alpha must still reach the user, or this test could not fail.
+  expect_true(any(grepl("alpha for a discrete variable", seen)))
+})
+
 test_that("a key that cannot describe the bars keeps the released refusal (#404)", {
   # When a keyed column is not discrete, or is named after a desc_statby()
   # statistic, no ordering maps one error bar to one bar. Drawing anyway would

--- a/tests/testthat/test-ggbarplot-alpha-dodge2.R
+++ b/tests/testthat/test-ggbarplot-alpha-dodge2.R
@@ -136,6 +136,13 @@ test_that("error.plot = 'crossbar' draws a crossbar, not an errorbar, and aligns
   expect_true("GeomCrossbar" %in% geoms)
   expect_false("GeomErrorbar" %in% geoms)
   .expect_on_own_bar(p, d)
+  # Re-centring fixes the crossbar's centre but not its width: left at the
+  # default it is drawn 0.9 wide over a 0.1575-wide bar, spanning the whole x
+  # group. It has to take the width of the bar it belongs to.
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  bd <- .layer(p, b, "GeomBar"); ed <- .layer(p, b, "GeomCrossbar")
+  expect_equal(as.numeric(ed$xmax - ed$xmin), as.numeric(bd$xmax - bd$xmin),
+               tolerance = 1e-9)
 })
 
 test_that("one-sided and point/line error plots also align under dodge2 with alpha (#404)", {


### PR DESCRIPTION
Mapping `alpha` to a discrete column under `position_dodge2()` failed at draw:

```r
ggbarplot(d, "dose", "len", fill = "supp", alpha = "batch",
          add = "mean_se", position = position_dodge2())
#> Error: Problem while converting geom to grob.
#> Caused by error in `alpha * 255`: non-numeric argument to binary operator
```

The summary dropped the `alpha` column, so its *name* reached the graphics
engine as a static opacity. Plain `position_dodge()` was fixed earlier in this
cycle; this does the same for `position_dodge2()`.

## After

```r
ggbarplot(d, "dose", "len", fill = "supp", alpha = "batch", add = "mean_se",
          position = position_dodge2(), palette = c("#0073C2", "#EFC000"))

ggbarplot(d, "dose", "len", fill = "supp", alpha = "batch", add = "mean_se",
          position = position_dodge2(), error.plot = "crossbar",
          palette = c("#0073C2", "#EFC000"))
```

![Twelve dodged bars in three dose groups; left panel draws an error bar centred on each bar, right panel a crossbar spanning each bar's own width](https://i.imgur.com/8gkt1Nr.png)

Each interval is centred on its own bar and carries that bar's own mean and
standard error (checked against `stats::aggregate`, 12/12; bar x and error-bar
x are equal to 1e-9).

## What changed

Carrying the `alpha` column splits the summary into one row per
(x, legend, alpha) cell. `position_dodge2()` places its error layer by
re-centring it on the bars, matching summary rows to bars by sort position —
and the previous key `(PANEL, x, legend)` is not a total order once that
subgroup exists, so `sort.val`, `top`, `sort.by.groups` or an
`add.params$color` naming another column permuted the match.

- The layer is now ordered on every discrete aesthetic ggplot2 groups the bars
  by, in the direction `collide2()` lays each x out in — ascending group id, or
  descending under `position_dodge2(reverse = TRUE)`, which is why `reverse`
  aligns here rather than being refused.
- It then **checks** the pairing against the bars it is about to draw on:
  `geom_bar(stat = "identity")` draws each row's own centre, so a bar not
  carrying its matched row's centre means the orders disagree.
- `error.plot = "crossbar"` is included. A crossbar is wide so it normally
  dodges itself, but `dodge2` packs by each element's own width and a
  crossbar's is not the bar's; the extra subgroup grew the offset enough to
  land it on a neighbour. It is re-centred at the bar's own width and resolved
  to `geom_crossbar` (the shared error-geom lookup has no crossbar case and
  would otherwise draw an error bar).
- The bar-centre probe always built `facet_wrap()` at fixed scales. With a free
  x scale, a panel missing an x level renumbers the rest, so the probe read
  centres the drawn panel never uses; with two facet variables `facet()` uses
  `facet_grid()`. The probe now matches, and `scales` is resolved from `...` by
  partial matching, since it reaches `facet()` that way and `scale =` / `scal =`
  arrive as `scales`.

## Scope: four combinations deliberately left on the released path

The fix covers the error layer, which is what it can show correct. Each case
below would turn a call that currently refuses to draw into a figure that looks
trustworthy and reads wrong, so each keeps exactly what it does today:

- a `color`/`fill`/`alpha` column that is **not discrete** — ggplot2 does not
  group the bars by it, so the layer draws more bars than there are dodge
  positions and no error bar can be matched to one bar;
- **`label = TRUE`** (or a character label vector) — the value labels are placed
  by their own layer, which dodges on the legend key alone, so with the subgroup
  carried they land between the bars (4 of 8 over the bar whose value they
  show). Same defect and same disposition as plain `position_dodge()`, where it
  is disclosed rather than fixed;
- **a raw-data layer** (`add = c("mean_se", "jitter")`, and likewise `point`,
  `dotplot`, `boxplot`, `violin`) — those are placed under the same position,
  and `dodge2` packs by each element's own width, which a point has none of.
  They already sit off their own bar with no `alpha` at all (8 of 12, measured
  identically on `master` and here, pre-existing and untouched);
- **an asymmetric summary** (`median_q1q3`, `median_hilow`) — a quantile pair
  rather than centre ± error, so the summary has no half-width column for the
  layer to be rebuilt from.

Where the pairing genuinely cannot be established, the alpha path no longer
falls back to the standard layer at all — under `dodge2` that layer *is* the
defect being fixed, so the intervals collapse to the tick centre and land inside
neighbouring bars. It draws the bars without an error layer and warns instead.
Without the subgroup the fallback is still taken, because there each interval
does land on its own bar.

## One released call does change

An `alpha` mapped to a column that is **already** a grouping variable
(`fill = "supp", alpha = "supp"`) worked before, because the summary already
carried that column. With `error.plot = "crossbar"` its crossbars were drawn
off-centre and wider than their bars (`x = 0.75`, width `0.45`, against a bar at
`x = 0.825`, width `0.315`); they are now centred at the bar's own width. Their
fill is unchanged — it still follows the mapped `fill`.

## Default output

Calls without a discrete `alpha` column are unchanged: the 50 byte-identity
fixtures pass, and 18 further layer-data + PNG md5 comparisons against `master`
are identical, including the faceted `scales = "free_x"` case whose error bars
keep exactly the positions they have today. `_R_CHECK_DEPENDS_ONLY_=true
R CMD check` is Status: OK.

Verified across missing values, unused and reversed factor levels, ordered and
logical columns, unbalanced/singleton/zero-variance cells, one x group, 3x3
designs, tibble and grouped input, one and two facet variables, `mean_sd`,
`median_iqr`, cells that share a mean, `reverse = TRUE`, and the asymmetric summaries. Full suite green
(`[ FAIL 0 | WARN 14 | SKIP 0 | PASS 2656 ]`).
