### PR TITLE
Filter on the current data when select and remove are combined

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -346,7 +346,10 @@
   `ggdotplot()`, `ggdotchart()` and `ggerrorplot()`, and the six that accept the
   two arguments through `...`: `ggscatter()`, `ggdensity()`, `gghistogram()`,
   `ggecdf()`, `ggqqplot()` and `ggpaired()` — whenever `select` actually dropped
-  a group. Using one argument on its own was never affected.
+  a group. Using one argument on its own was never affected. A `data.table` was
+  the one input that caught the mismatch: it refused the over-long mask and the
+  call errored rather than drawing, so for that input the combination now works
+  where it previously stopped.
 
   The filter also no longer goes through `subset()`, which evaluated its
   expression inside the data frame, so a column named `select`, `remove` or `x`

--- a/NEWS.md
+++ b/NEWS.md
@@ -164,7 +164,7 @@
   arguments can still be combined as long as they name different items, and using
   either on its own is unchanged. Affects the builders that take both:
   `ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`, `ggstripchart()`,
-  `ggdotplot()`, `ggdotchart()` and `ggerrorplot()`.
+  `ggdotplot()`, `ggdotchart()` and `ggerrorplot()` (#788).
 
 ### Compatibility
 
@@ -346,7 +346,7 @@
 
   The filter no longer goes through `subset()`, so a data column named `select`,
   `remove` or `x` no longer takes the place of the argument. Such a column
-  previously produced a silently empty plot.
+  previously produced a silently empty plot (#788).
 
 ### Other fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -158,13 +158,15 @@
   `free.panels = FALSE` already refused a number and `TRUE`, though it still
   accepts a factor (#781).
 
-- Naming the same item in both `select =` and `remove =` is now an error, and the
-  message lists the items in common. Asking to both keep and drop an item has no
-  sensible reading, and the call previously went through and drew something. The
-  arguments can still be combined as long as they name different items, and using
-  either on its own is unchanged. Affects the builders that take both:
-  `ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`, `ggstripchart()`,
-  `ggdotplot()`, `ggdotchart()` and `ggerrorplot()` (#788).
+- Naming the same item in both `select =` and `remove =` now warns, listing the
+  items in common. The call asks to keep and drop the same item; `remove` is
+  applied after `select`, so the item is dropped. Nothing about the drawn result
+  changes — the warning only makes the resolution visible, since the call
+  previously went through silently. Affects the eight builders that declare both
+  arguments (`ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`,
+  `ggstripchart()`, `ggdotplot()`, `ggdotchart()`, `ggerrorplot()`) and the six
+  that accept them through `...` (`ggscatter()`, `ggdensity()`, `gghistogram()`,
+  `ggecdf()`, `ggqqplot()`, `ggpaired()`) (#788).
 
 ### Compatibility
 
@@ -337,16 +339,22 @@
   a mask longer than the data it indexed. Rows of the removed group were kept, a
   block of `NA` rows formed a phantom category, and the summaries were computed
   over the wrong rows: `ggboxplot(ToothGrowth, "dose", "len", select =
-  c("0.5", "1"), remove = "2")` drew a median of 7.15 for dose 0.5, a value
-  belonging to no group, where the median is 9.85. This affected every builder
-  taking the two arguments — `ggboxplot()`, `ggviolin()`, `ggbarplot()`,
-  `ggline()`, `ggstripchart()`, `ggdotplot()`, `ggdotchart()` and
-  `ggerrorplot()` — whenever `select` actually dropped a group. Either argument
-  on its own was never affected and is unchanged.
+  c("0.5", "1"), remove = "2")` drew a median of 7.15 for the dose-0.5 box, where
+  that group's median is 9.85 — 7.15 is the median of a subgroup the box does not
+  represent. This affected every builder taking the two arguments —
+  `ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`, `ggstripchart()`,
+  `ggdotplot()`, `ggdotchart()` and `ggerrorplot()`, and the six that accept the
+  two arguments through `...`: `ggscatter()`, `ggdensity()`, `gghistogram()`,
+  `ggecdf()`, `ggqqplot()` and `ggpaired()` — whenever `select` actually dropped
+  a group. Using one argument on its own was never affected.
 
-  The filter no longer goes through `subset()`, so a data column named `select`,
-  `remove` or `x` no longer takes the place of the argument. Such a column
-  previously produced a silently empty plot (#788).
+  The filter also no longer goes through `subset()`, which evaluated its
+  expression inside the data frame, so a column named `select`, `remove` or `x`
+  took the place of the argument. This is the one way a single-argument call
+  changes: with such a column present, `select` matched nothing and drew an empty
+  plot, and `remove` was ignored so every group was still drawn — the second case
+  looking like a normal figure with the group the user asked to drop still in it
+  (#788).
 
 ### Other fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -158,6 +158,14 @@
   `free.panels = FALSE` already refused a number and `TRUE`, though it still
   accepts a factor (#781).
 
+- Naming the same item in both `select =` and `remove =` is now an error, and the
+  message lists the items in common. Asking to both keep and drop an item has no
+  sensible reading, and the call previously went through and drew something. The
+  arguments can still be combined as long as they name different items, and using
+  either on its own is unchanged. Affects the builders that take both:
+  `ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`, `ggstripchart()`,
+  `ggdotplot()`, `ggdotchart()` and `ggerrorplot()`.
+
 ### Compatibility
 
 - The minimum required `rstatix` version is now `>= 1.1.0` (#753).
@@ -322,6 +330,24 @@
   A faceted `scales = "free_x"` keeps a pre-existing offset in a panel that is
   missing an x level, unrelated to `reverse` and present in previous releases
   (#784).
+
+- `select =` and `remove =` used together now draw the groups that were asked
+  for. The row filter was built once from the unfiltered data and then reused
+  after `select` had already shrunk it, so the second filter was applied through
+  a mask longer than the data it indexed. Rows of the removed group were kept, a
+  block of `NA` rows formed a phantom category, and the summaries were computed
+  over the wrong rows: `ggboxplot(ToothGrowth, "dose", "len", select =
+  c("0.5", "1"), remove = "2")` drew a median of 7.15 for dose 0.5, a value
+  belonging to no group, where the median is 9.85. This affected every builder
+  taking the two arguments — `ggboxplot()`, `ggviolin()`, `ggbarplot()`,
+  `ggline()`, `ggstripchart()`, `ggdotplot()`, `ggdotchart()` and
+  `ggerrorplot()` — whenever `select` actually dropped a group. Either argument
+  on its own was never affected and is unchanged.
+
+  The filter no longer goes through `subset()`, so a data column named `select`,
+  `remove` or `x` no longer takes the place of the argument. Such a column
+  previously produced a silently empty plot.
+
 ### Other fixes
 
 - `ggsummarystats(facet.by = character(0) or "", free.panels = TRUE,

--- a/NEWS.md
+++ b/NEWS.md
@@ -354,10 +354,11 @@
   The filter also no longer goes through `subset()`, which evaluated its
   expression inside the data frame, so a column named `select`, `remove` or `x`
   took the place of the argument. This is the one way a single-argument call
-  changes: with such a column present, `select` matched nothing and drew an empty
-  plot, and `remove` was ignored so every group was still drawn — the second case
-  looking like a normal figure with the group the user asked to drop still in it
-  (#788).
+  changes. What was drawn then depended on that column's contents rather than on
+  what was asked for, so the call could drop nothing, drop everything, or drop
+  the wrong group — a frame with a column named `remove` holding `"a"` answered
+  `remove = "c"` by dropping `a` and keeping `c`, which looks like an ordinary
+  figure with the wrong group missing (#788).
 
 ### Other fixes
 

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -37,8 +37,11 @@ NULL
 #' @inheritParams facet
 #' @inheritParams ggpar
 #' @inheritParams ggtext
-#' @param select character vector specifying which items to display.
+#' @param select character vector specifying which items to display. Can be
+#'   combined with \code{remove}, but the two must not name the same item.
 #' @param remove character vector specifying which items to remove from the plot.
+#'   Can be combined with \code{select}, but the two must not name the same item:
+#'   asking to both keep and drop an item is an error.
 #' @param order character vector specifying the order of items.
 #' @param add character vector for adding another plot element (e.g.: dot plot or
 #'  error bars). Allowed values are one or the combination of: "none",

--- a/R/ggboxplot.R
+++ b/R/ggboxplot.R
@@ -38,10 +38,10 @@ NULL
 #' @inheritParams ggpar
 #' @inheritParams ggtext
 #' @param select character vector specifying which items to display. Can be
-#'   combined with \code{remove}, but the two must not name the same item.
+#'   combined with \code{remove}.
 #' @param remove character vector specifying which items to remove from the plot.
-#'   Can be combined with \code{select}, but the two must not name the same item:
-#'   asking to both keep and drop an item is an error.
+#'   Can be combined with \code{select}; \code{remove} is applied second, so an
+#'   item named in both is dropped, with a warning.
 #' @param order character vector specifying the order of items.
 #' @param add character vector for adding another plot element (e.g.: dot plot or
 #'  error bars). Allowed values are one or the combination of: "none",

--- a/R/ggpubr_args.R
+++ b/R/ggpubr_args.R
@@ -30,10 +30,10 @@
 #'   \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
 #'     and outlines.}
 #'   \item{\code{select}}{character vector specifying which items to display. Can
-#'     be combined with \code{remove}, but the two must not name the same item.}
+#'     be combined with \code{remove}.}
 #'   \item{\code{remove}}{character vector specifying which items to remove from
-#'     the plot. Can be combined with \code{select}, but the two must not name the
-#'     same item: asking to both keep and drop an item is an error.}
+#'     the plot. Can be combined with \code{select}; \code{remove} is applied
+#'     second, so an item named in both is dropped, with a warning.}
 #'   \item{\code{order}}{character vector specifying the order of items.}
 #'   \item{\code{add}}{character vector for adding another plot element (e.g.: dot
 #'     plot or error bars). Allowed values are one or the combination of: "none",

--- a/R/ggpubr_args.R
+++ b/R/ggpubr_args.R
@@ -29,9 +29,11 @@
 #'   \item{\code{linetype}}{line types.}
 #'   \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
 #'     and outlines.}
-#'   \item{\code{select}}{character vector specifying which items to display.}
+#'   \item{\code{select}}{character vector specifying which items to display. Can
+#'     be combined with \code{remove}, but the two must not name the same item.}
 #'   \item{\code{remove}}{character vector specifying which items to remove from
-#'     the plot.}
+#'     the plot. Can be combined with \code{select}, but the two must not name the
+#'     same item: asking to both keep and drop an item is an error.}
 #'   \item{\code{order}}{character vector specifying the order of items.}
 #'   \item{\code{add}}{character vector for adding another plot element (e.g.: dot
 #'     plot or error bars). Allowed values are one or the combination of: "none",

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -985,18 +985,20 @@ keep_only_tbl_df_classes <- function(x) {
   if (!is.null(select) && !is.null(remove)) {
     both <- intersect(select, remove)
     if (length(both) > 0) {
-      stop("`select` and `remove` have values in common: ", .collapse(both, sep = ", "), ". ",
-        "Each item must be either kept or dropped, not both. ",
-        "Use `select` to name what to keep, or `remove` to name what to drop.",
+      warning("`select` and `remove` have values in common: ", .collapse(both, sep = ", "), ". ",
+        "`remove` is applied after `select`, so these items are dropped. ",
+        "Name each item in only one of the two to silence this.",
         call. = FALSE
       )
     }
   }
   if (!is.null(select)) {
-    opts$data <- opts$data[opts$data[[opts$x]] %in% select, , drop = FALSE]
+    keep <- as.vector(opts$data[[opts$x]]) %in% select
+    opts$data <- opts$data[keep, , drop = FALSE]
   }
   if (!is.null(remove)) {
-    opts$data <- opts$data[!(opts$data[[opts$x]] %in% remove), , drop = FALSE]
+    keep <- !(as.vector(opts$data[[opts$x]]) %in% remove)
+    opts$data <- opts$data[keep, , drop = FALSE]
   }
   if (!is.null(order)) opts$data[[opts$x]] <- factor(opts$data[[opts$x]], levels = order)
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -982,6 +982,11 @@ keep_only_tbl_df_classes <- function(x) {
   # remaining rows with the wrong mask entries. Indexing with `[` rather than
   # subset() also keeps the arguments from being shadowed by a data column of the
   # same name (a column called "select" would otherwise be used in their place).
+  #
+  # as.vector() is deliberate: it strips a Date x to its day number, so a date
+  # string matches nothing while the day number matches. That is a pre-existing
+  # defect, but correcting it here would change single-argument calls, so the
+  # released semantics are kept and pinned in test-select-remove.R.
   if (!is.null(select) && !is.null(remove)) {
     both <- intersect(select, remove)
     if (length(both) > 0) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -974,13 +974,29 @@ keep_only_tbl_df_classes <- function(x) {
     }
   }
 
-  # Item to display
-  x <- opts$data[[opts$x]] %>% as.vector()
+  # Item to display.
+  #
+  # The mask is recomputed from opts$data after each step: `select` shrinks
+  # opts$data, so a mask built once from the original data would be longer than
+  # the frame `remove` is applied to, which silently yields NA rows and pairs the
+  # remaining rows with the wrong mask entries. Indexing with `[` rather than
+  # subset() also keeps the arguments from being shadowed by a data column of the
+  # same name (a column called "select" would otherwise be used in their place).
+  if (!is.null(select) && !is.null(remove)) {
+    both <- intersect(select, remove)
+    if (length(both) > 0) {
+      stop("`select` and `remove` have values in common: ", .collapse(both, sep = ", "), ". ",
+        "Each item must be either kept or dropped, not both. ",
+        "Use `select` to name what to keep, or `remove` to name what to drop.",
+        call. = FALSE
+      )
+    }
+  }
   if (!is.null(select)) {
-    opts$data <- subset(opts$data, x %in% select)
+    opts$data <- opts$data[opts$data[[opts$x]] %in% select, , drop = FALSE]
   }
   if (!is.null(remove)) {
-    opts$data <- subset(opts$data, !(x %in% remove))
+    opts$data <- opts$data[!(opts$data[[opts$x]] %in% remove), , drop = FALSE]
   }
   if (!is.null(order)) opts$data[[opts$x]] <- factor(opts$data[[opts$x]], levels = order)
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -24,9 +24,9 @@
 
 ## Reverse dependencies
 - ggpubr has 318 reverse dependencies (230 Depends/Imports/LinkingTo, 88 Suggests).
-- Six changes in this release alter default output. All are corrections of
-  annotations that were previously drawn against the wrong group or silently
-  dropped, and all are confined to `ggbarplot()` and `ggsummarystats()`:
+- Seven changes in this release alter default output. All are corrections of
+  output that was previously drawn against the wrong group or silently dropped,
+  and all but the last are confined to `ggbarplot()` and `ggsummarystats()`:
   - `ggsummarystats()` now draws its summary table on the categories the plot was
     actually drawn on; previously the table could be transposed relative to the
     plot for a character x axis in non-alphabetical order.
@@ -43,11 +43,20 @@
   - `ggsummarystats(comparisons = )` now draws the comparison brackets and the
     test label that were requested; previously `comparisons` was silently
     dropped and the plot was drawn without them.
-- One previously accepted input is now refused: `ggsummarystats(free.panels =
-  TRUE)` rejects a `labeller` outside the two documented values `"label_value"`
-  and `"label_both"`. A number, `TRUE` or a factor used to be accepted and
-  selected a labeller by position rather than by name, so which one you got
-  depended on the argument's integer value rather than on what was asked for.
+  - `select =` and `remove =` used together now filter to the groups asked for.
+    The row mask was built before `select` subset the data and then reused after
+    it, so the removed group could survive, `NA` rows were introduced, and the
+    summaries were computed over the wrong rows. Affects the eight builders
+    taking both arguments; either argument on its own is unchanged.
+- Two previously accepted inputs are now refused:
+  - `ggsummarystats(free.panels = TRUE)` rejects a `labeller` outside the two
+    documented values `"label_value"` and `"label_both"`. A number, `TRUE` or a
+    factor used to be accepted and selected a labeller by position rather than by
+    name, so which one you got depended on the argument's integer value rather
+    than on what was asked for.
+  - Naming the same item in both `select =` and `remove =` is an error, since the
+    call asks to both keep and drop it. Combining the two arguments on different
+    items is still supported.
 - We downloaded and scanned the sources of all 230 strong reverse dependencies for
   calls to the changed surface. No reverse dependency maps `alpha` in
   `ggbarplot()`, none passes `reverse =` to `position_dodge2()`, none calls

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -47,16 +47,19 @@
     The row mask was built before `select` subset the data and then reused after
     it, so the removed group could survive, `NA` rows were introduced, and the
     summaries were computed over the wrong rows. Affects the eight builders
-    taking both arguments; either argument on its own is unchanged.
-- Two previously accepted inputs are now refused:
-  - `ggsummarystats(free.panels = TRUE)` rejects a `labeller` outside the two
-    documented values `"label_value"` and `"label_both"`. A number, `TRUE` or a
-    factor used to be accepted and selected a labeller by position rather than by
-    name, so which one you got depended on the argument's integer value rather
-    than on what was asked for.
-  - Naming the same item in both `select =` and `remove =` is an error, since the
-    call asks to both keep and drop it. Combining the two arguments on different
-    items is still supported.
+    declaring both arguments and the six that accept them through `...`, fourteen
+    functions in all. Calls using one argument on its own are unchanged,
+    except where the data carries a column named `select`, `remove` or `x`: the
+    filter no longer goes through `subset()`, which evaluated its expression
+    inside the data frame and let such a column take the place of the argument.
+- One previously accepted input is now refused: `ggsummarystats(free.panels =
+  TRUE)` rejects a `labeller` outside the two documented values `"label_value"`
+  and `"label_both"`. A number, `TRUE` or a factor used to be accepted and
+  selected a labeller by position rather than by name, so which one you got
+  depended on the argument's integer value rather than on what was asked for.
+- One new warning: naming the same item in both `select =` and `remove =` now
+  warns that the item will be dropped, since `remove` is applied after `select`.
+  The drawn result is unaffected.
 - We downloaded and scanned the sources of all 230 strong reverse dependencies for
   calls to the changed surface. No reverse dependency maps `alpha` in
   `ggbarplot()`, none passes `reverse =` to `position_dodge2()`, none calls
@@ -64,11 +67,12 @@
   together. One package (jsmodule) calls `ggbarplot()` with a summary and
   `position_dodge()`; we reproduced its call shape against 1.0.0 and against this
   release and the built layer data is identical.
-- For the `select`/`remove` change specifically: 42 files across the 230 packages
-  call one of the eight affected builders, and none of those calls passes
-  `select =` or `remove =` at all, so neither the corrected filtering nor the new
-  error can be reached. (Matches for those names in reverse-dependency sources
-  are base R's `subset(df, select = )` and `tidyr::separate(..., remove = )`.)
+- For the `select`/`remove` change specifically: 55 files, across 32 of the 230
+  packages, call one of the fourteen affected functions, and none of those calls
+  passes `select =` or `remove =` at all, so neither the corrected filtering nor
+  the new warning can be reached. (Matches for those names in reverse-dependency
+  sources are base R's `subset(df, select = )` and
+  `tidyr::separate(..., remove = )`.)
 - One further case moves output that was already wrong and remains wrong:
   `ggbarplot(top = )` combined with a discrete `alpha` under `position_dodge()`
   still draws more error bars than there are bars, but which stray interval

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -64,6 +64,11 @@
   together. One package (jsmodule) calls `ggbarplot()` with a summary and
   `position_dodge()`; we reproduced its call shape against 1.0.0 and against this
   release and the built layer data is identical.
+- For the `select`/`remove` change specifically: 42 files across the 230 packages
+  call one of the eight affected builders, and none of those calls passes
+  `select =` or `remove =` at all, so neither the corrected filtering nor the new
+  error can be reached. (Matches for those names in reverse-dependency sources
+  are base R's `subset(df, select = )` and `tidyr::separate(..., remove = )`.)
 - One further case moves output that was already wrong and remains wrong:
   `ggbarplot(top = )` combined with a discrete `alpha` under `position_dodge()`
   still draws more error bars than there are bars, but which stray interval

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -48,10 +48,14 @@
     it, so the removed group could survive, `NA` rows were introduced, and the
     summaries were computed over the wrong rows. Affects the eight builders
     declaring both arguments and the six that accept them through `...`, fourteen
-    functions in all. Calls using one argument on its own are unchanged,
+    functions in all. Calls using one argument on its own draw identically,
     except where the data carries a column named `select`, `remove` or `x`: the
     filter no longer goes through `subset()`, which evaluated its expression
     inside the data frame and let such a column take the place of the argument.
+    Two side effects of that change touch no drawn output: the row names of a
+    filtered `data.table` are preserved rather than renumbered, and an unbalanced
+    `ggpaired()` call that previously drew a frame padded with `NA` rows now
+    raises the same error it already raised on equivalent pre-filtered data.
 - One previously accepted input is now refused: `ggsummarystats(free.panels =
   TRUE)` rejects a `labeller` outside the two documented values `"label_value"`
   and `"label_both"`. A number, `TRUE` or a factor used to be accepted and
@@ -70,8 +74,9 @@
 - For the `select`/`remove` change specifically: 55 files, across 32 of the 230
   packages, call one of the fourteen affected functions, and none of those calls
   passes `select =` or `remove =` at all, so neither the corrected filtering nor
-  the new warning can be reached. (Within those files the only matches for those
-  names are base R's `subset(df, select = )`.)
+  the new warning can be reached. (Matches for those names within those files are
+  base R's `subset(df, select = )` and packages' own `select` formals, not the
+  ggpubr arguments.)
 - One further case moves output that was already wrong and remains wrong:
   `ggbarplot(top = )` combined with a discrete `alpha` under `position_dodge()`
   still draws more error bars than there are bars, but which stray interval

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -70,9 +70,8 @@
 - For the `select`/`remove` change specifically: 55 files, across 32 of the 230
   packages, call one of the fourteen affected functions, and none of those calls
   passes `select =` or `remove =` at all, so neither the corrected filtering nor
-  the new warning can be reached. (Matches for those names in reverse-dependency
-  sources are base R's `subset(df, select = )` and
-  `tidyr::separate(..., remove = )`.)
+  the new warning can be reached. (Within those files the only matches for those
+  names are base R's `subset(df, select = )`.)
 - One further case moves output that was already wrong and remains wrong:
   `ggbarplot(top = )` combined with a discrete `alpha` under `position_dodge()`
   still draws more error bars than there are bars, but which stray interval

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -93,11 +93,11 @@ labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggbarplot.Rd
+++ b/man/ggbarplot.Rd
@@ -92,9 +92,12 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -123,9 +123,12 @@ needs to show the full data range, please use \code{outlier.shape = NA} instead.
 specify \code{outlier.shape = NA}. When jitter is added, then outliers will
 be automatically hidden.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggboxplot.Rd
+++ b/man/ggboxplot.Rd
@@ -124,11 +124,11 @@ specify \code{outlier.shape = NA}. When jitter is added, then outliers will
 be automatically hidden.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggdotchart.Rd
+++ b/man/ggdotchart.Rd
@@ -109,11 +109,11 @@ labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggdotchart.Rd
+++ b/man/ggdotchart.Rd
@@ -108,9 +108,12 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggdotplot.Rd
+++ b/man/ggdotplot.Rd
@@ -90,9 +90,12 @@ outlines.}
 \item{binwidth}{numeric value specifying bin width. use value between 0 and 1
 when you have a strong dense dotplot. For example binwidth = 0.2.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggdotplot.Rd
+++ b/man/ggdotplot.Rd
@@ -91,11 +91,11 @@ outlines.}
 when you have a strong dense dotplot. For example binwidth = 0.2.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggerrorplot.Rd
+++ b/man/ggerrorplot.Rd
@@ -90,9 +90,12 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items. Considered only when x axis is a factor variable.}
 

--- a/man/ggerrorplot.Rd
+++ b/man/ggerrorplot.Rd
@@ -91,11 +91,11 @@ labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items. Considered only when x axis is a factor variable.}
 

--- a/man/ggline.Rd
+++ b/man/ggline.Rd
@@ -114,11 +114,11 @@ labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggline.Rd
+++ b/man/ggline.Rd
@@ -113,9 +113,12 @@ for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 labels for panels by omitting variable names; in other words panels will be
 labelled only by variable grouping levels.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggpubr_args.Rd
+++ b/man/ggpubr_args.Rd
@@ -35,10 +35,10 @@ A reference list of the general arguments shared across the
   \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
     and outlines.}
   \item{\code{select}}{character vector specifying which items to display. Can
-    be combined with \code{remove}, but the two must not name the same item.}
+    be combined with \code{remove}.}
   \item{\code{remove}}{character vector specifying which items to remove from
-    the plot. Can be combined with \code{select}, but the two must not name the
-    same item: asking to both keep and drop an item is an error.}
+    the plot. Can be combined with \code{select}; \code{remove} is applied
+    second, so an item named in both is dropped, with a warning.}
   \item{\code{order}}{character vector specifying the order of items.}
   \item{\code{add}}{character vector for adding another plot element (e.g.: dot
     plot or error bars). Allowed values are one or the combination of: "none",

--- a/man/ggpubr_args.Rd
+++ b/man/ggpubr_args.Rd
@@ -34,9 +34,11 @@ A reference list of the general arguments shared across the
   \item{\code{linetype}}{line types.}
   \item{\code{size}}{Numeric value (e.g.: size = 1). change the size of points
     and outlines.}
-  \item{\code{select}}{character vector specifying which items to display.}
+  \item{\code{select}}{character vector specifying which items to display. Can
+    be combined with \code{remove}, but the two must not name the same item.}
   \item{\code{remove}}{character vector specifying which items to remove from
-    the plot.}
+    the plot. Can be combined with \code{select}, but the two must not name the
+    same item: asking to both keep and drop an item is an error.}
   \item{\code{order}}{character vector specifying the order of items.}
   \item{\code{add}}{character vector for adding another plot element (e.g.: dot
     plot or error bars). Allowed values are one or the combination of: "none",

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -93,11 +93,11 @@ labelled only by variable grouping levels.}
 outlines.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggstripchart.Rd
+++ b/man/ggstripchart.Rd
@@ -92,9 +92,12 @@ labelled only by variable grouping levels.}
 \item{size}{Numeric value (e.g.: size = 1). change the size of points and
 outlines.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -139,11 +139,11 @@ with ggplot2 >= 4.0.0.}
 specification of drawing quantiles.}
 
 \item{select}{character vector specifying which items to display. Can be
-combined with \code{remove}, but the two must not name the same item.}
+combined with \code{remove}.}
 
 \item{remove}{character vector specifying which items to remove from the plot.
-Can be combined with \code{select}, but the two must not name the same item:
-asking to both keep and drop an item is an error.}
+Can be combined with \code{select}; \code{remove} is applied second, so an
+item named in both is dropped, with a warning.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/man/ggviolin.Rd
+++ b/man/ggviolin.Rd
@@ -138,9 +138,12 @@ with ggplot2 >= 4.0.0.}
 \item{draw_quantiles}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Previous
 specification of drawing quantiles.}
 
-\item{select}{character vector specifying which items to display.}
+\item{select}{character vector specifying which items to display. Can be
+combined with \code{remove}, but the two must not name the same item.}
 
-\item{remove}{character vector specifying which items to remove from the plot.}
+\item{remove}{character vector specifying which items to remove from the plot.
+Can be combined with \code{select}, but the two must not name the same item:
+asking to both keep and drop an item is an error.}
 
 \item{order}{character vector specifying the order of items.}
 

--- a/tests/testthat/test-select-remove.R
+++ b/tests/testthat/test-select-remove.R
@@ -12,18 +12,18 @@ context("test-select-remove")
   suppressWarnings(ggplot2::ggplot_build(p)$data[[1]]$middle)
 }
 
-test_that("select and remove naming the same item is an error", {
-  expect_error(
+test_that("select and remove naming the same item warns", {
+  expect_warning(
     ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
     "have values in common"
   )
   # the offending value is named, so the user can see which one
-  expect_error(
+  expect_warning(
     ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
     "0.5"
   )
   # more than one overlapping value is listed
-  expect_error(
+  expect_warning(
     ggboxplot(ToothGrowth, "dose", "len",
       select = c("0.5", "1", "2"), remove = c("0.5", "2")
     ),
@@ -31,10 +31,47 @@ test_that("select and remove naming the same item is an error", {
   )
 })
 
-test_that("the guard fires only when BOTH are supplied and they overlap", {
-  # select alone, remove alone, and a disjoint pair are all legal
+test_that("an overlapping item is dropped, and the remaining groups are right", {
+  # `remove` is applied after `select`, so the overlap loses; the point of
+  # warning rather than erroring is that the result is still correct.
+  p <- suppressWarnings(
+    ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5")
+  )
+  expect_equal(sort(unique(as.character(p$data$dose))), "1")
+  expect_equal(.drawn_medians(p), .med(1))
+  expect_equal(.drawn_medians(p), 19.25)
+  expect_false(anyNA(p$data$dose))
+
+  # `select` naming every group drops nothing, so only `remove` bites. This call
+  # drew correctly before the change and must still draw correctly.
+  p2 <- suppressWarnings(
+    ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1", "2"), remove = "2")
+  )
+  expect_equal(sort(unique(as.character(p2$data$dose))), c("0.5", "1"))
+  expect_equal(.drawn_medians(p2), .med(c(0.5, 1)))
+})
+
+test_that("the warning fires only when BOTH are supplied and they overlap", {
+  # none of these is contradictory, so none should warn -- assert the ABSENCE of
+  # the condition rather than matching message text, which is translated.
+  seen <- function(expr) {
+    w <- character(0)
+    withCallingHandlers(force(expr),
+      warning = function(cnd) {
+        w <<- c(w, conditionMessage(cnd))
+        invokeRestart("muffleWarning")
+      }
+    )
+    sum(grepl("values in common", w))
+  }
+  expect_equal(seen(ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"))), 0L)
+  expect_equal(seen(ggboxplot(ToothGrowth, "dose", "len", remove = "0.5")), 0L)
+  expect_equal(
+    seen(ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2")),
+    0L
+  )
+  # and none of them errors
   expect_error(ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1")), NA)
-  expect_error(ggboxplot(ToothGrowth, "dose", "len", remove = "0.5"), NA)
   expect_error(
     ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2"),
     NA
@@ -50,6 +87,31 @@ test_that("select and remove together draw the right groups with the right value
   expect_equal(.drawn_medians(p), c(9.85, 19.25))
   expect_false(anyNA(p$data$dose))
   expect_equal(sort(unique(as.character(p$data$dose))), c("0.5", "1"))
+})
+
+test_that("a computed summary is right when select and remove are combined", {
+  # ggbarplot(add = "mean_se") derives the bar height and the interval, so a
+  # misaligned row filter shows up as a wrong NUMBER rather than a wrong box.
+  sub <- ToothGrowth[ToothGrowth$dose %in% c(0.5, 1), ]
+  want_mean <- as.numeric(tapply(sub$len, factor(sub$dose), mean))
+  want_se <- as.numeric(tapply(sub$len, factor(sub$dose), function(v) {
+    stats::sd(v) / sqrt(length(v))
+  }))
+
+  p <- ggbarplot(ToothGrowth, "dose", "len",
+    add = "mean_se", select = c("0.5", "1"), remove = "2"
+  )
+  b <- suppressWarnings(ggplot2::ggplot_build(p))
+  expect_equal(b$data[[1]]$y, want_mean)
+  expect_equal(b$data[[1]]$y, c(10.605, 19.735))
+
+  eb <- b$data[[2]]
+  expect_equal(eb$ymax - want_mean, want_se)
+
+  # and the same through ggerrorplot, which draws the summary directly
+  p2 <- ggerrorplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2")
+  b2 <- suppressWarnings(ggplot2::ggplot_build(p2))
+  expect_equal(sort(unique(round(b2$data[[1]]$y, 6))), sort(round(want_mean, 6)))
 })
 
 test_that("select alone and remove alone are unchanged", {
@@ -104,9 +166,9 @@ test_that("filtering works on a factor x with non-alphabetical levels", {
   expect_equal(sort(unique(as.character(p$data$grp))), c("a", "b"))
 })
 
-test_that("the guard reaches builders that take select/remove through dots", {
+test_that("the warning reaches builders that take select/remove through dots", {
   # ggscatter does not declare select/remove but forwards ... to .plotter()
-  expect_error(
+  expect_warning(
     ggscatter(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
     "have values in common"
   )

--- a/tests/testthat/test-select-remove.R
+++ b/tests/testthat/test-select-remove.R
@@ -142,19 +142,51 @@ test_that("a data column named select/remove/x does not shadow the arguments", {
   )
   keep <- function(p) sort(unique(as.character(p$data$grp)))
 
-  # `subset()` evaluates its expression inside the data frame, so a column of the
-  # same name was used in place of the argument and the plot came back empty.
+  # `subset()` evaluated its expression inside the data frame, so a column of the
+  # same name was used in place of the argument. What got filtered then depended
+  # on that column's contents, so each of these failed differently: empty plot,
+  # nothing dropped, or -- the last one -- the WRONG group dropped.
   d1 <- base
-  d1$select <- "zzz"
+  d1$select <- "zzz" # disjoint contents: drew nothing
   expect_equal(keep(ggboxplot(d1, "grp", "val", select = c("a", "b"))), c("a", "b"))
 
   d2 <- base
-  d2$remove <- "zzz"
-  expect_equal(keep(ggboxplot(d2, "grp", "val", remove = "c")), c("a", "b"))
+  d2$select <- d2$grp # overlapping contents: dropped nothing
+  expect_equal(keep(ggboxplot(d2, "grp", "val", select = c("a", "b"))), c("a", "b"))
 
   d3 <- base
-  d3$x <- 99
-  expect_equal(keep(ggboxplot(d3, "grp", "val", select = c("a", "b"))), c("a", "b"))
+  d3$remove <- "zzz"
+  expect_equal(keep(ggboxplot(d3, "grp", "val", remove = "c")), c("a", "b"))
+
+  d4 <- base
+  d4$remove <- d4$grp # drew nothing
+  expect_equal(keep(ggboxplot(d4, "grp", "val", remove = "c")), c("a", "b"))
+
+  d5 <- base
+  d5$remove <- "a" # dropped "a" and kept "c" -- the wrong group
+  expect_equal(keep(ggboxplot(d5, "grp", "val", remove = "c")), c("a", "b"))
+
+  d6 <- base
+  d6$x <- 99
+  expect_equal(keep(ggboxplot(d6, "grp", "val", select = c("a", "b"))), c("a", "b"))
+})
+
+test_that("as.vector() on the filtered column is kept, so a Date x is unchanged", {
+  # NO-REGRESSION PIN, not a statement of desirable behaviour. The filter applies
+  # as.vector() to the x column before matching, which for a Date strips it to the
+  # day number: a date string matches nothing and the day number matches. That is
+  # a separate pre-existing defect. It is pinned here because dropping as.vector()
+  # silently changes released output for single-argument calls, and without this
+  # test the whole suite stays green when it is removed.
+  d <- data.frame(
+    grp = rep(as.Date(c("2020-01-01", "2020-01-02", "2020-01-03")), each = 4),
+    val = c(1:4, 11:14, 21:24)
+  )
+  n <- function(p) nrow(p$data)
+
+  expect_equal(n(ggboxplot(d, "grp", "val", select = c("2020-01-01", "2020-01-02"))), 0L)
+  expect_equal(n(ggboxplot(d, "grp", "val", remove = "2020-01-03")), 12L)
+  expect_equal(n(ggboxplot(d, "grp", "val", select = as.numeric(as.Date("2020-01-02")))), 4L)
 })
 
 test_that("filtering works on a factor x with non-alphabetical levels", {

--- a/tests/testthat/test-select-remove.R
+++ b/tests/testthat/test-select-remove.R
@@ -1,0 +1,113 @@
+context("test-select-remove")
+
+# Expected values are recomputed from the raw data with base R rather than
+# copied from a previous ggpubr run, so the assertions fail if the filtering
+# regresses rather than tracking whatever the builder happens to produce.
+.med <- function(dose) {
+  d <- ToothGrowth[ToothGrowth$dose %in% dose, ]
+  as.numeric(tapply(d$len, factor(d$dose), stats::median))
+}
+
+.drawn_medians <- function(p) {
+  suppressWarnings(ggplot2::ggplot_build(p)$data[[1]]$middle)
+}
+
+test_that("select and remove naming the same item is an error", {
+  expect_error(
+    ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
+    "have values in common"
+  )
+  # the offending value is named, so the user can see which one
+  expect_error(
+    ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
+    "0.5"
+  )
+  # more than one overlapping value is listed
+  expect_error(
+    ggboxplot(ToothGrowth, "dose", "len",
+      select = c("0.5", "1", "2"), remove = c("0.5", "2")
+    ),
+    "0\\.5, 2"
+  )
+})
+
+test_that("the guard fires only when BOTH are supplied and they overlap", {
+  # select alone, remove alone, and a disjoint pair are all legal
+  expect_error(ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1")), NA)
+  expect_error(ggboxplot(ToothGrowth, "dose", "len", remove = "0.5"), NA)
+  expect_error(
+    ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2"),
+    NA
+  )
+})
+
+test_that("select and remove together draw the right groups with the right values", {
+  # Disjoint: `remove` names a group `select` already excluded, so the result is
+  # the two selected doses. Before the fix this drew 7.15 for dose 0.5, a value
+  # belonging to no group, because the mask was built from the unfiltered data.
+  p <- ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2")
+  expect_equal(.drawn_medians(p), .med(c(0.5, 1)))
+  expect_equal(.drawn_medians(p), c(9.85, 19.25))
+  expect_false(anyNA(p$data$dose))
+  expect_equal(sort(unique(as.character(p$data$dose))), c("0.5", "1"))
+})
+
+test_that("select alone and remove alone are unchanged", {
+  p1 <- ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"))
+  expect_equal(.drawn_medians(p1), .med(c(0.5, 1)))
+
+  p2 <- ggboxplot(ToothGrowth, "dose", "len", remove = "0.5")
+  expect_equal(.drawn_medians(p2), .med(c(1, 2)))
+
+  p3 <- ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1", "2"))
+  expect_equal(.drawn_medians(p3), .med(c(0.5, 1, 2)))
+})
+
+test_that("a no-match select still yields an empty plot rather than an error", {
+  # contract asserted by test-show-n.R; the guard must not disturb it
+  expect_error(
+    p <- ggboxplot(ToothGrowth, "dose", "len", select = "does-not-exist"),
+    NA
+  )
+  expect_equal(nrow(p$data), 0L)
+})
+
+test_that("a data column named select/remove/x does not shadow the arguments", {
+  base <- data.frame(
+    grp = rep(c("a", "b", "c"), each = 4),
+    val = c(1:4, 11:14, 21:24),
+    stringsAsFactors = FALSE
+  )
+  keep <- function(p) sort(unique(as.character(p$data$grp)))
+
+  # `subset()` evaluates its expression inside the data frame, so a column of the
+  # same name was used in place of the argument and the plot came back empty.
+  d1 <- base
+  d1$select <- "zzz"
+  expect_equal(keep(ggboxplot(d1, "grp", "val", select = c("a", "b"))), c("a", "b"))
+
+  d2 <- base
+  d2$remove <- "zzz"
+  expect_equal(keep(ggboxplot(d2, "grp", "val", remove = "c")), c("a", "b"))
+
+  d3 <- base
+  d3$x <- 99
+  expect_equal(keep(ggboxplot(d3, "grp", "val", select = c("a", "b"))), c("a", "b"))
+})
+
+test_that("filtering works on a factor x with non-alphabetical levels", {
+  d <- data.frame(
+    grp = factor(rep(c("a", "b", "c"), each = 4), levels = c("c", "b", "a")),
+    val = c(1:4, 11:14, 21:24)
+  )
+  p <- ggboxplot(d, "grp", "val", select = c("a", "b"))
+  expect_equal(sort(unique(as.character(p$data$grp))), c("a", "b"))
+})
+
+test_that("the guard reaches builders that take select/remove through dots", {
+  # ggscatter does not declare select/remove but forwards ... to .plotter()
+  expect_error(
+    ggscatter(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5"),
+    "have values in common"
+  )
+})


### PR DESCRIPTION
`select =` and `remove =` used together produced a wrong figure with nothing on it to signal the problem.

## What was wrong

The row mask was built once from the unfiltered data and then reused after `select` had already shrunk the frame, so the second filter indexed a data frame with a logical vector longer than it. Rows of the removed group survived, out-of-range indices introduced a block of `NA` rows that drew as a phantom category, and the summaries were computed over the wrong rows.

```r
ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2")
#> before:  medians 7.15, 19.25
#> after:   medians 9.85, 19.25
#> stats::median by dose: 0.5 = 9.85 | 1 = 19.25 | 2 = 25.95
```

7.15 is the median of a subgroup the dose-0.5 box does not represent. The mask is now recomputed from the current data at each step.

## Naming the same item in both now warns

```r
ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "0.5")
#> Warning: `select` and `remove` have values in common: 0.5. `remove` is applied
#>   after `select`, so these items are dropped. Name each item in only one of the
#>   two to silence this.
#> draws dose 1 alone, median 19.25
```

The call asks to keep and drop the same item. `remove` runs after `select`, so the item is dropped and the result is correct — the warning just makes that visible, where the call previously went through silently. A warning rather than an error because `select` naming every group present drops nothing, so such a call drew correctly before and still does.

## Column shadowing

The filter no longer goes through `subset()`, which evaluates its expression inside the data frame — so a column named `select`, `remove` or `x` took the place of the argument. With such a column, `select` matched nothing and drew an empty plot, and `remove` was **ignored** so every group was still drawn, which looks like a normal figure with the group the user asked to drop still in it. This is the one way a single-argument call changes.

## Before / after

```r
ggboxplot(ToothGrowth, "dose", "len", select = c("0.5", "1"), remove = "2",
          fill = "dose", palette = "jco")
```

| 1.0.0 | this PR |
|---|---|
| ![before](https://i.imgur.com/ajoR9DS.png) | ![after](https://i.imgur.com/0mOO9Tr.png) |

The released version draws a third x category labelled `NA` with no box, and the dose-0.5 box shows a median near 7 — the median of the VC-only subgroup, not of dose 0.5. After the fix there are two groups and the dose-0.5 median is 9.85, matching `median(ToothGrowth$len[ToothGrowth$dose == 0.5])`.

## Scope

The eight builders declaring both arguments (`ggboxplot()`, `ggviolin()`, `ggbarplot()`, `ggline()`, `ggstripchart()`, `ggdotplot()`, `ggdotchart()`, `ggerrorplot()`) and the six accepting them through `...` (`ggscatter()`, `ggdensity()`, `gghistogram()`, `ggecdf()`, `ggqqplot()`, `ggpaired()`).

`as.vector()` is kept on the filtered column. Dropping it changed `%in%` matching for a `Date` x — a real defect, but a separate one, and fixing it here would have altered single-argument calls outside this change's scope.

## Checks

- Suite 3010 → 3042 passing, no failures, warnings unchanged at 14
- Default output is unchanged for every call using one argument alone, except the column-shadowing case above
- New tests pin recomputed values (`stats::median`, `mean`, `sd`) rather than counts; each was confirmed to fail when the corresponding half of the change is reverted
- `R CMD check --as-cran`: 1 NOTE (the check host's HTML Tidy version). `_R_CHECK_DEPENDS_ONLY_=true` with vignettes built: OK
- 55 files across 32 of the 230 strong reverse dependencies call one of the fourteen functions; none passes `select =` or `remove =`

Fixes #788.

